### PR TITLE
Read value key in tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "figma-tokens",
-	"version": "32",
+	"version": "33",
 	"description": "Figma Design Tokens",
 	"license": "ISC",
 	"scripts": {

--- a/src/app/components/EditTokenForm.tsx
+++ b/src/app/components/EditTokenForm.tsx
@@ -3,10 +3,28 @@ import {useTokenDispatch} from '../store/TokenContext';
 import Input from './Input';
 import Modal from './Modal';
 
-const EditTokenForm = ({submitTokenValue, explainer = '', property, isPristine, initialValue, initialName, path}) => {
+const EditTokenForm = ({
+    submitTokenValue,
+    explainer = '',
+    property,
+    isPristine,
+    initialValue,
+    initialName,
+    path,
+    schema,
+    optionsSchema,
+}) => {
     const title = isPristine ? `New Token in ${path}` : `${path}.${initialName}`;
+
+    React.useEffect(() => {
+        console.log('Initialvalue is', initialValue);
+    }, [initialValue]);
+
     const defaultValue = {
         value: initialValue.value ?? initialValue,
+        options: {
+            description: initialValue.description,
+        },
         name: initialName,
         path,
     };
@@ -23,8 +41,17 @@ const EditTokenForm = ({submitTokenValue, explainer = '', property, isPristine, 
         setTokenValue((prevState) => ({...prevState, value: {...prevState.value, [e.target.name]: e.target.value}}));
     };
 
+    const handleOptionsChange = (e) => {
+        e.persist();
+        setTokenValue((prevState) => ({
+            ...prevState,
+            options: {...prevState.options, [e.target.name]: e.target.value},
+        }));
+    };
+
     const handleSubmit = (e) => {
         e.preventDefault();
+        console.log('submitting', tokenValue);
         submitTokenValue(tokenValue);
         setShowEditForm(false);
     };
@@ -32,6 +59,10 @@ const EditTokenForm = ({submitTokenValue, explainer = '', property, isPristine, 
     const handleReset = () => {
         setShowEditForm(false);
     };
+
+    React.useEffect(() => {
+        console.log('token val in edit is', tokenValue, schema, optionsSchema);
+    }, [schema, tokenValue, optionsSchema]);
 
     return (
         <Modal isOpen close={handleReset} title={title}>
@@ -45,16 +76,17 @@ const EditTokenForm = ({submitTokenValue, explainer = '', property, isPristine, 
                     type="text"
                     name="name"
                 />
-                {typeof tokenValue.value === 'object' ? (
-                    Object.entries(tokenValue.value).map(([key, value]) => (
+                {schema ? (
+                    Object.entries(schema).map(([key, schemaValue]: [string, string]) => (
                         <Input
                             key={key}
                             full
                             label={key}
-                            value={value}
+                            value={tokenValue.value ? tokenValue.value[key] : tokenValue[key]}
                             onChange={handleObjectChange}
                             type="text"
                             name={key}
+                            custom={schemaValue}
                             required
                         />
                     ))
@@ -69,6 +101,21 @@ const EditTokenForm = ({submitTokenValue, explainer = '', property, isPristine, 
                         required
                     />
                 )}
+
+                {optionsSchema
+                    ? Object.entries(optionsSchema).map(([key, schemaValue]: [string, string]) => (
+                          <Input
+                              key={key}
+                              full
+                              label={key}
+                              value={tokenValue.options[key]}
+                              onChange={handleOptionsChange}
+                              type="text"
+                              name={key}
+                              custom={schemaValue}
+                          />
+                      ))
+                    : null}
 
                 {explainer && <div className="mt-1 text-xxs text-gray-600">{explainer}</div>}
                 <div className="flex space-x-2 justify-end">

--- a/src/app/components/EditTokenForm.tsx
+++ b/src/app/components/EditTokenForm.tsx
@@ -76,7 +76,7 @@ const EditTokenForm = ({
                     type="text"
                     name="name"
                 />
-                {schema ? (
+                {typeof schema === 'object' ? (
                     Object.entries(schema).map(([key, schemaValue]: [string, string]) => (
                         <Input
                             key={key}

--- a/src/app/components/EditTokenForm.tsx
+++ b/src/app/components/EditTokenForm.tsx
@@ -16,10 +16,6 @@ const EditTokenForm = ({
 }) => {
     const title = isPristine ? `New Token in ${path}` : `${path}.${initialName}`;
 
-    React.useEffect(() => {
-        console.log('Initialvalue is', initialValue);
-    }, [initialValue]);
-
     const defaultValue = {
         value: initialValue.value ?? initialValue,
         options: {
@@ -51,7 +47,6 @@ const EditTokenForm = ({
 
     const handleSubmit = (e) => {
         e.preventDefault();
-        console.log('submitting', tokenValue);
         submitTokenValue(tokenValue);
         setShowEditForm(false);
     };
@@ -59,10 +54,6 @@ const EditTokenForm = ({
     const handleReset = () => {
         setShowEditForm(false);
     };
-
-    React.useEffect(() => {
-        console.log('token val in edit is', tokenValue, schema, optionsSchema);
-    }, [schema, tokenValue, optionsSchema]);
 
     return (
         <Modal isOpen close={handleReset} title={title}>

--- a/src/app/components/EditTokenForm.tsx
+++ b/src/app/components/EditTokenForm.tsx
@@ -3,15 +3,19 @@ import {useTokenDispatch} from '../store/TokenContext';
 import Input from './Input';
 import Modal from './Modal';
 
-const EditTokenForm = ({submitTokenValue, explainer = '', property, isPristine, initialToken, initialName, path}) => {
+const EditTokenForm = ({submitTokenValue, explainer = '', property, isPristine, initialValue, initialName, path}) => {
     const title = isPristine ? `New Token in ${path}` : `${path}.${initialName}`;
     const defaultValue = {
-        token: initialToken,
+        value: initialValue.value ?? initialValue,
         name: initialName,
         path,
     };
     const [tokenValue, setTokenValue] = React.useState(defaultValue);
     const {setShowEditForm} = useTokenDispatch();
+
+    React.useEffect(() => {
+        console.log('showing edit form', tokenValue, initialValue);
+    });
 
     const handleChange = (e) => {
         e.persist();
@@ -20,7 +24,7 @@ const EditTokenForm = ({submitTokenValue, explainer = '', property, isPristine, 
 
     const handleObjectChange = (e) => {
         e.persist();
-        setTokenValue((prevState) => ({...prevState, token: {...prevState.token, [e.target.name]: e.target.value}}));
+        setTokenValue((prevState) => ({...prevState, value: {...prevState.value, [e.target.name]: e.target.value}}));
     };
 
     const handleSubmit = (e) => {
@@ -45,8 +49,8 @@ const EditTokenForm = ({submitTokenValue, explainer = '', property, isPristine, 
                     type="text"
                     name="name"
                 />
-                {typeof tokenValue.token === 'object' ? (
-                    Object.entries(tokenValue.token).map(([key, value]) => (
+                {typeof tokenValue.value === 'object' ? (
+                    Object.entries(tokenValue.value).map(([key, value]) => (
                         <Input
                             key={key}
                             full
@@ -62,10 +66,10 @@ const EditTokenForm = ({submitTokenValue, explainer = '', property, isPristine, 
                     <Input
                         full
                         label={property}
-                        value={tokenValue.token}
+                        value={tokenValue.value}
                         onChange={handleChange}
                         type="text"
-                        name="token"
+                        name="value"
                         required
                     />
                 )}

--- a/src/app/components/EditTokenForm.tsx
+++ b/src/app/components/EditTokenForm.tsx
@@ -13,10 +13,6 @@ const EditTokenForm = ({submitTokenValue, explainer = '', property, isPristine, 
     const [tokenValue, setTokenValue] = React.useState(defaultValue);
     const {setShowEditForm} = useTokenDispatch();
 
-    React.useEffect(() => {
-        console.log('showing edit form', tokenValue, initialValue);
-    });
-
     const handleChange = (e) => {
         e.persist();
         setTokenValue((prevState) => ({...prevState, [e.target.name]: e.target.value}));

--- a/src/app/components/EditTokenForm.tsx
+++ b/src/app/components/EditTokenForm.tsx
@@ -90,6 +90,7 @@ const EditTokenForm = ({
                         type="text"
                         name="value"
                         required
+                        custom={schema}
                     />
                 )}
 

--- a/src/app/components/Input.tsx
+++ b/src/app/components/Input.tsx
@@ -1,19 +1,21 @@
 import * as React from 'react';
 
-const Input = ({name, required = false, tabindex = null, label, full, onChange, value, type, custom = ''}) => (
-    <label htmlFor={name} className="text-xxs font-medium block">
-        <div>{label}</div>
-        <input
-            tabIndex={tabindex}
-            type={type}
-            value={value}
-            className={`input ${full && 'w-full'}`}
-            name={name}
-            onChange={onChange}
-            required={required}
-            data-custom={custom}
-        />
-    </label>
-);
+const Input = ({name, required = false, tabindex = null, label, full, onChange, value, type, custom = ''}) => {
+    return (
+        <label htmlFor={name} className="text-xxs font-medium block">
+            <div>{label}</div>
+            <input
+                tabIndex={tabindex}
+                type={type}
+                value={value}
+                className={`input ${full && 'w-full'}`}
+                name={name}
+                onChange={onChange}
+                required={required}
+                data-custom={custom}
+            />
+        </label>
+    );
+};
 
 export default Input;

--- a/src/app/components/Input.tsx
+++ b/src/app/components/Input.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-const Input = ({name, required = false, tabindex = null, label, full, onChange, value, type}) => (
+const Input = ({name, required = false, tabindex = null, label, full, onChange, value, type, custom = ''}) => (
     <label htmlFor={name} className="text-xxs font-medium block">
         <div>{label}</div>
         <input
@@ -11,6 +11,7 @@ const Input = ({name, required = false, tabindex = null, label, full, onChange, 
             name={name}
             onChange={onChange}
             required={required}
+            data-custom={custom}
         />
     </label>
 );

--- a/src/app/components/NewGroupForm.tsx
+++ b/src/app/components/NewGroupForm.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import {useTokenDispatch} from '../store/TokenContext';
+import Input from './Input';
+import Modal from './Modal';
+
+const NewGroupForm = ({path, setSingleTokenValue}) => {
+    const title = 'Create new group';
+    const [activeToken] = React.useState('options');
+    const [name, setName] = React.useState('');
+    const {setShowNewGroupForm, setLoading, updateTokens} = useTokenDispatch();
+
+    const handleChange = (e) => {
+        e.persist();
+        setName(e.target.value);
+    };
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        await setLoading(true);
+
+        setSingleTokenValue({
+            parent: activeToken,
+            name: [path, name].join('.'),
+            value: {},
+            newGroup: true,
+        });
+
+        updateTokens();
+        setShowNewGroupForm(false);
+    };
+
+    const handleReset = () => {
+        setShowNewGroupForm(false);
+    };
+
+    return (
+        <Modal isOpen close={handleReset} title={title}>
+            <form onSubmit={handleSubmit} className="space-y-4 flex flex-col justify-start">
+                <Input required full label="Name" value={name} onChange={handleChange} type="text" name="name" />
+
+                <div className="flex space-x-2 justify-end">
+                    <button className="button button-link" type="button" onClick={handleReset}>
+                        Cancel
+                    </button>
+                    <button className="button button-primary" type="submit">
+                        Create
+                    </button>
+                </div>
+            </form>
+        </Modal>
+    );
+};
+
+export default NewGroupForm;

--- a/src/app/components/TokenButton.tsx
+++ b/src/app/components/TokenButton.tsx
@@ -9,7 +9,7 @@ const TokenButton = ({type, property, name, path, token, editMode, showForm}) =>
     const {colorMode, displayType, selectionValues, tokenData, disabled} = useTokenState();
     const {setNodeData, setShowOptions, setLoading, deleteToken} = useTokenDispatch();
     const realTokenValue = tokenData.getAliasValue(token);
-    const displayValue = realTokenValue || token;
+    const displayValue = tokenData.getTokenValue(token);
     let style;
     let showValue = true;
     let showEditButton = false;
@@ -18,7 +18,7 @@ const TokenButton = ({type, property, name, path, token, editMode, showForm}) =>
 
     const handleEditClick = () => {
         setShowOptions(property);
-        showForm({name, token, path});
+        showForm({name, value: token, path});
     };
 
     const handleDeleteClick = () => {
@@ -129,7 +129,7 @@ const TokenButton = ({type, property, name, path, token, editMode, showForm}) =>
     const onClick = (givenProperties, isActive = active) => {
         const propsToSet = Array.isArray(givenProperties) ? givenProperties : new Array(givenProperties);
         if (editMode) {
-            showForm({name, token, path});
+            showForm({name, value: token, path});
         } else {
             const tokenValue = [path, name].join('.');
             let value = isActive ? 'delete' : tokenValue;

--- a/src/app/components/TokenButton.tsx
+++ b/src/app/components/TokenButton.tsx
@@ -147,11 +147,9 @@ const TokenButton = ({type, property, name, path, token, editMode, showForm}) =>
     const getTokenDisplay = (tokenVal) => {
         const valueToCheck = tokenVal.value ?? tokenVal;
         if (isTypographyToken(valueToCheck)) {
-            console.log('is typo', tokenVal);
             return `${valueToCheck.fontFamily} / ${valueToCheck.fontWeight}`;
         }
         if (typeof valueToCheck !== 'string' && typeof valueToCheck !== 'number') {
-            console.log('is object or arra', valueToCheck);
             return JSON.stringify(valueToCheck, null, 2);
         }
 

--- a/src/app/components/TokenButton.tsx
+++ b/src/app/components/TokenButton.tsx
@@ -8,7 +8,6 @@ import {lightOrDark, colorByHashCode, isTypographyToken} from './utils';
 const TokenButton = ({type, property, name, path, token, editMode, showForm}) => {
     const {colorMode, displayType, selectionValues, tokenData, disabled} = useTokenState();
     const {setNodeData, setShowOptions, setLoading, deleteToken} = useTokenDispatch();
-    const realTokenValue = tokenData.getAliasValue(token);
     const displayValue = tokenData.getTokenValue(token);
     let style;
     let showValue = true;
@@ -146,7 +145,6 @@ const TokenButton = ({type, property, name, path, token, editMode, showForm}) =>
     };
 
     const getTokenDisplay = (tokenVal) => {
-        console.log('checking token', tokenVal);
         const valueToCheck = tokenVal.value ?? tokenVal;
         if (isTypographyToken(valueToCheck)) {
             console.log('is typo', tokenVal);

--- a/src/app/components/TokenButton.tsx
+++ b/src/app/components/TokenButton.tsx
@@ -3,7 +3,7 @@ import Tooltip from './Tooltip';
 import MoreButton from './MoreButton';
 import {useTokenState, useTokenDispatch} from '../store/TokenContext';
 import Icon from './Icon';
-import {lightOrDark, colorByHashCode} from './utils';
+import {lightOrDark, colorByHashCode, isTypographyToken} from './utils';
 
 const TokenButton = ({type, property, name, path, token, editMode, showForm}) => {
     const {colorMode, displayType, selectionValues, tokenData, disabled} = useTokenState();
@@ -145,6 +145,21 @@ const TokenButton = ({type, property, name, path, token, editMode, showForm}) =>
         }
     };
 
+    const getTokenDisplay = (tokenVal) => {
+        console.log('checking token', tokenVal);
+        const valueToCheck = tokenVal.value ?? tokenVal;
+        if (isTypographyToken(valueToCheck)) {
+            console.log('is typo', tokenVal);
+            return `${valueToCheck.fontFamily} / ${valueToCheck.fontWeight}`;
+        }
+        if (typeof valueToCheck !== 'string' && typeof valueToCheck !== 'number') {
+            console.log('is object or arra', valueToCheck);
+            return JSON.stringify(valueToCheck, null, 2);
+        }
+
+        return valueToCheck;
+    };
+
     return (
         <div
             className={`relative mb-1 mr-1 flex button button-property ${buttonClass.join(' ')} ${
@@ -161,9 +176,7 @@ const TokenButton = ({type, property, name, path, token, editMode, showForm}) =>
                 path={path}
                 mode={editMode ? 'edit' : 'list'}
             >
-                <Tooltip
-                    label={`${name}: ${JSON.stringify(token, null, 2)}${realTokenValue ? `: ${realTokenValue}` : ''}`}
-                >
+                <Tooltip label={`${name}: ${getTokenDisplay(token)}`}>
                     <button
                         className="w-full h-full"
                         disabled={editMode ? false : disabled}

--- a/src/app/components/TokenData.tsx
+++ b/src/app/components/TokenData.tsx
@@ -133,13 +133,10 @@ export default class TokenData {
 
         const assigned = mergeDeep({}, ...reducedTokens);
 
-        console.log('assigned', assigned);
-
         return assigned;
     }
 
     getMergedTokens(): TokenGroup {
-        console.log('Merged tokens are', this.mergedTokens);
         return this.mergedTokens;
     }
 

--- a/src/app/components/TokenData.tsx
+++ b/src/app/components/TokenData.tsx
@@ -202,15 +202,12 @@ export default class TokenData {
 
     getAliasValue(token: SingleToken, tokens = this.mergedTokens): string | null {
         if (this.checkIfAlias(token)) {
-            console.log('getting alias value', token);
             let returnedValue = this.checkIfValueToken(token) ? (token.value as string) : (token as string);
-            console.log('returned value', returnedValue);
             const tokenRegex = /(\$[^\s,]+)/g;
             const tokenReferences = returnedValue.toString().match(tokenRegex);
             if (tokenReferences.length > 0) {
                 const resolvedReferences = tokenReferences.map((ref) => objectPath.get(tokens, ref.substring(1)));
                 tokenReferences.forEach((reference, index) => {
-                    console.log('aliased value', resolvedReferences[index]);
                     returnedValue = returnedValue.replace(
                         reference,
                         resolvedReferences[index].value ?? resolvedReferences[index]

--- a/src/app/components/TokenData.tsx
+++ b/src/app/components/TokenData.tsx
@@ -133,10 +133,13 @@ export default class TokenData {
 
         const assigned = mergeDeep({}, ...reducedTokens);
 
+        console.log('assigned', assigned);
+
         return assigned;
     }
 
     getMergedTokens(): TokenGroup {
+        console.log('Merged tokens are', this.mergedTokens);
         return this.mergedTokens;
     }
 
@@ -186,24 +189,28 @@ export default class TokenData {
         }, []);
     }
 
-    setAllAliases(): void {
-        const aliases = this.findAllAliases({arr: Object.entries(this.mergedTokens)});
+    setAllAliases(aliasArray = Object.entries(this.mergedTokens)): void {
+        const aliases = this.findAllAliases({arr: aliasArray});
 
         if (aliases.length > 0) {
             aliases.forEach((alias) => {
                 this.setResolvedAlias(this.mergedTokens, alias[0], this.getAliasValue(alias[1], this.mergedTokens));
             });
+            this.setAllAliases();
         }
     }
 
     getAliasValue(token: SingleToken, tokens = this.mergedTokens): string | null {
         if (this.checkIfAlias(token)) {
+            console.log('getting alias value', token);
             let returnedValue = this.checkIfValueToken(token) ? (token.value as string) : (token as string);
+            console.log('returned value', returnedValue);
             const tokenRegex = /(\$[^\s,]+)/g;
             const tokenReferences = returnedValue.toString().match(tokenRegex);
             if (tokenReferences.length > 0) {
                 const resolvedReferences = tokenReferences.map((ref) => objectPath.get(tokens, ref.substring(1)));
                 tokenReferences.forEach((reference, index) => {
+                    console.log('aliased value', resolvedReferences[index]);
                     returnedValue = returnedValue.replace(
                         reference,
                         resolvedReferences[index].value ?? resolvedReferences[index]

--- a/src/app/components/TokenListing.tsx
+++ b/src/app/components/TokenListing.tsx
@@ -8,6 +8,7 @@ import Icon from './Icon';
 import Modal from './Modal';
 import renderKeyValue from './renderKeyValue';
 import Tooltip from './Tooltip';
+import NewGroupForm from './NewGroupForm';
 
 const TokenListing = ({
     label,
@@ -33,7 +34,7 @@ const TokenListing = ({
     type?: string;
     values?: string | object;
 }) => {
-    const {collapsed, showEditForm, showOptions, tokenData, displayType} = useTokenState();
+    const {collapsed, showEditForm, showNewGroupForm, showOptions, tokenData, displayType} = useTokenState();
     const {
         setStringTokens,
         setCollapsed,
@@ -41,6 +42,7 @@ const TokenListing = ({
         updateTokens,
         setLoading,
         setShowEditForm,
+        setShowNewGroupForm,
         setShowOptions,
         setDisplayType,
     } = useTokenDispatch();
@@ -55,18 +57,21 @@ const TokenListing = ({
         name: '',
         path: '',
     });
-    function setSingleTokenValue({parent, name, value, options, oldName}) {
-        console.log('setting single token val', parent, name, value, options, oldName);
+    function setSingleTokenValue({parent, name, value, options, oldName, newGroup = false}) {
         const obj = JSON5.parse(tokenData.tokens[parent].values);
-        console.log('setting value', name, value, options);
-        const newValue = options
-            ? {
-                  value,
-                  ...options,
-              }
-            : {
-                  value,
-              };
+        let newValue;
+        if (newGroup) {
+            newValue = {};
+        } else {
+            newValue = options
+                ? {
+                      value,
+                      ...options,
+                  }
+                : {
+                      value,
+                  };
+        }
         const newName = name.toString();
         objectPath.set(obj, newName, newValue);
         if (oldName === newName || !oldName) {
@@ -86,22 +91,15 @@ const TokenListing = ({
     };
 
     const showForm = ({value, name, path}) => {
-        console.log('show form', value, name);
         setShowEditForm(true);
         setEditToken({value, name, path});
     };
 
-    const showNewForm = (path, formSchema) => {
-        let initialToken = '';
-        if (formSchema) {
-            initialToken = formSchema;
-        }
-
-        showForm({value: initialToken, name: '', path});
+    const showNewForm = (path) => {
+        showForm({value: '', name: '', path});
     };
 
     const submitTokenValue = async ({value, name, path, options}) => {
-        console.log('setting token value', name, value, options);
         setEditToken({value, name, path});
         setSingleTokenValue({
             parent: activeToken,
@@ -216,6 +214,9 @@ const TokenListing = ({
                                     optionsSchema={schema?.options}
                                 />
                             )}
+                            {showNewGroupForm && (
+                                <NewGroupForm path={values[0]} setSingleTokenValue={setSingleTokenValue} />
+                            )}
 
                             <div className="px-4 pb-4">
                                 {renderKeyValue({
@@ -247,7 +248,7 @@ const TokenListing = ({
                                         <button
                                             type="button"
                                             className="button button-ghost"
-                                            onClick={() => showNewForm(values[0], schema)}
+                                            onClick={() => showNewForm(values[0])}
                                         >
                                             <Icon name="add" />
                                         </button>
@@ -257,7 +258,7 @@ const TokenListing = ({
                                             className="button button-ghost"
                                             type="button"
                                             onClick={() => {
-                                                showNewForm(values[0], {});
+                                                setShowNewGroupForm(true);
                                             }}
                                         >
                                             <Icon name="folder" />

--- a/src/app/components/TokenListing.tsx
+++ b/src/app/components/TokenListing.tsx
@@ -191,7 +191,7 @@ const TokenListing = ({
                             type="button"
                             onClick={() => {
                                 setShowOptions(values[0]);
-                                showNewForm(values[0], schema);
+                                showNewForm(values[0]);
                             }}
                         >
                             <Icon name="add" />

--- a/src/app/components/TokenListing.tsx
+++ b/src/app/components/TokenListing.tsx
@@ -53,6 +53,7 @@ const TokenListing = ({
         path: '',
     });
     function setSingleTokenValue({parent, name, value, options, oldName}) {
+        console.log('setting single token val', parent, name, value, options, oldName);
         const obj = JSON5.parse(tokenData.tokens[parent].values);
         const newValue = options
             ? {
@@ -63,11 +64,14 @@ const TokenListing = ({
                   value,
               };
         objectPath.set(obj, name, newValue);
-        if (oldName === name) {
+        if (oldName === name || !oldName) {
             setStringTokens({parent, tokens: JSON.stringify(obj, null, 2)});
         } else {
             objectPath.del(obj, oldName);
-            setStringTokens({parent, tokens: JSON.stringify(obj, null, 2).replace(`$${oldName}`, `$${name}`)});
+            setStringTokens({
+                parent,
+                tokens: JSON.stringify(obj, null, 2).split(`$${oldName}`).join(`$${name}`),
+            });
         }
     }
 
@@ -92,13 +96,14 @@ const TokenListing = ({
     };
 
     const submitTokenValue = async ({value, name, path, options}) => {
+        console.log('setting token value', value, name, path, options, editToken);
         setEditToken({value, name, path});
         setSingleTokenValue({
             parent: activeToken,
             name: [path, name].join('.'),
             value,
             options,
-            oldName: [path, editToken.name].join('.'),
+            oldName: editToken.name ? [path, editToken.name].join('.') : null,
         });
         await setLoading(true);
         updateTokens();

--- a/src/app/components/TokenListing.tsx
+++ b/src/app/components/TokenListing.tsx
@@ -21,7 +21,10 @@ const TokenListing = ({
     values,
 }: {
     label: string;
-    schema?: object;
+    schema?: {
+        value: object | string;
+        options: object | string;
+    };
     explainer?: string;
     help?: string;
     createButton?: boolean;
@@ -55,6 +58,7 @@ const TokenListing = ({
     function setSingleTokenValue({parent, name, value, options, oldName}) {
         console.log('setting single token val', parent, name, value, options, oldName);
         const obj = JSON5.parse(tokenData.tokens[parent].values);
+        console.log('setting value', name, value, options);
         const newValue = options
             ? {
                   value,
@@ -97,7 +101,7 @@ const TokenListing = ({
     };
 
     const submitTokenValue = async ({value, name, path, options}) => {
-        console.log('setting token value', value, name, path, options, editToken);
+        console.log('setting token value', name, value, options);
         setEditToken({value, name, path});
         setSingleTokenValue({
             parent: activeToken,
@@ -208,6 +212,8 @@ const TokenListing = ({
                                     property={property}
                                     isPristine={editToken.name === ''}
                                     initialValue={editToken.value}
+                                    schema={schema?.value}
+                                    optionsSchema={schema?.options}
                                 />
                             )}
 

--- a/src/app/components/TokenListing.tsx
+++ b/src/app/components/TokenListing.tsx
@@ -48,18 +48,20 @@ const TokenListing = ({
     const [isIntCollapsed, setIntCollapsed] = React.useState(false);
 
     const [editToken, setEditToken] = React.useState({
-        token: '',
+        value: '',
         name: '',
         path: '',
     });
-    function setSingleTokenValue({parent, name, token, options, oldName}) {
+    function setSingleTokenValue({parent, name, value, options, oldName}) {
         const obj = JSON5.parse(tokenData.tokens[parent].values);
         const newValue = options
             ? {
-                  value: token,
+                  value,
                   ...options,
               }
-            : token;
+            : {
+                  value,
+              };
         objectPath.set(obj, name, newValue);
         if (oldName === name) {
             setStringTokens({parent, tokens: JSON.stringify(obj, null, 2)});
@@ -74,31 +76,32 @@ const TokenListing = ({
         setShowEditForm(false);
     };
 
-    const showNewForm = (path, schema) => {
-        let initialToken = '';
-        if (schema) {
-            initialToken = schema;
-        }
-
-        showForm({token: initialToken, name: '', path});
+    const showForm = ({value, name, path}) => {
+        console.log('show form', value, name);
+        setShowEditForm(true);
+        setEditToken({value, name, path});
     };
 
-    const submitTokenValue = async ({token, name, path, options}) => {
-        setEditToken({token, name, path});
+    const showNewForm = (path, formSchema) => {
+        let initialToken = '';
+        if (formSchema) {
+            initialToken = formSchema;
+        }
+
+        showForm({value: initialToken, name: '', path});
+    };
+
+    const submitTokenValue = async ({value, name, path, options}) => {
+        setEditToken({value, name, path});
         setSingleTokenValue({
             parent: activeToken,
             name: [path, name].join('.'),
-            token,
+            value,
             options,
             oldName: [path, editToken.name].join('.'),
         });
         await setLoading(true);
         updateTokens();
-    };
-
-    const showForm = ({token, name, path}) => {
-        setShowEditForm(true);
-        setEditToken({token, name, path});
     };
 
     React.useEffect(() => {
@@ -198,7 +201,7 @@ const TokenListing = ({
                                     path={editToken.path}
                                     property={property}
                                     isPristine={editToken.name === ''}
-                                    initialToken={editToken.token}
+                                    initialValue={editToken.value}
                                 />
                             )}
 

--- a/src/app/components/TokenListing.tsx
+++ b/src/app/components/TokenListing.tsx
@@ -63,8 +63,9 @@ const TokenListing = ({
             : {
                   value,
               };
-        objectPath.set(obj, name, newValue);
-        if (oldName === name || !oldName) {
+        const newName = name.toString();
+        objectPath.set(obj, newName, newValue);
+        if (oldName === newName || !oldName) {
             setStringTokens({parent, tokens: JSON.stringify(obj, null, 2)});
         } else {
             objectPath.del(obj, oldName);

--- a/src/app/components/Tokens.tsx
+++ b/src/app/components/Tokens.tsx
@@ -80,7 +80,7 @@ const Tokens = () => {
                                     createButton
                                     help="If a (local) style is found with the same name it will match to that, if not, will use hex value. Use 'Create Style' to batch-create styles from your tokens (e.g. in your design library). In the future we'll load all 'remote' styles and reference them inside the JSON."
                                     label="Colors"
-                                    property="Colors"
+                                    property="Color"
                                     type="fill"
                                     schema={{
                                         value: 'color',

--- a/src/app/components/Tokens.tsx
+++ b/src/app/components/Tokens.tsx
@@ -83,9 +83,7 @@ const Tokens = () => {
                                     property="Colors"
                                     type="fill"
                                     schema={{
-                                        value: {
-                                            value: 'color',
-                                        },
+                                        value: 'color',
                                         options: {
                                             description: '',
                                         },

--- a/src/app/components/Tokens.tsx
+++ b/src/app/components/Tokens.tsx
@@ -79,9 +79,17 @@ const Tokens = () => {
                                     showDisplayToggle
                                     createButton
                                     help="If a (local) style is found with the same name it will match to that, if not, will use hex value. Use 'Create Style' to batch-create styles from your tokens (e.g. in your design library). In the future we'll load all 'remote' styles and reference them inside the JSON."
-                                    label="Fill"
-                                    property="Fill"
+                                    label="Colors"
+                                    property="Colors"
                                     type="fill"
+                                    schema={{
+                                        value: {
+                                            value: 'color',
+                                        },
+                                        options: {
+                                            description: '',
+                                        },
+                                    }}
                                     values={tokenValues}
                                 />
                             </div>
@@ -107,7 +115,17 @@ const Tokens = () => {
                                     label="Typography"
                                     property="Typography"
                                     type="typography"
-                                    schema={{fontFamily: '', fontWeight: '', lineHeight: '', fontSize: ''}}
+                                    schema={{
+                                        value: {
+                                            fontFamily: '',
+                                            fontWeight: '',
+                                            lineHeight: '',
+                                            fontSize: '',
+                                        },
+                                        options: {
+                                            description: '',
+                                        },
+                                    }}
                                     values={tokenValues}
                                 />
                             </div>

--- a/src/app/components/renderKeyValue.tsx
+++ b/src/app/components/renderKeyValue.tsx
@@ -18,6 +18,7 @@ const renderKeyValue = ({
     <div className="flex justify-start flex-row flex-wrap">
         {tokenValues.map(([key, value]) => {
             const stringPath = [path, key].filter((n) => n).join('.');
+
             return (
                 <React.Fragment key={stringPath}>
                     {typeof value === 'object' && !isTypographyToken(value) && !isSingleToken(value) ? (
@@ -30,7 +31,7 @@ const renderKeyValue = ({
                                             className="button button-ghost"
                                             type="button"
                                             onClick={() => {
-                                                showNewForm([path, key].join('.'), schema);
+                                                showNewForm([path, key].join('.'));
                                             }}
                                         >
                                             <Icon name="add" />

--- a/src/app/components/renderKeyValue.tsx
+++ b/src/app/components/renderKeyValue.tsx
@@ -3,7 +3,7 @@ import Heading from './Heading';
 import Icon from './Icon';
 import TokenButton from './TokenButton';
 import Tooltip from './Tooltip';
-import {isTypographyToken} from './utils';
+import {isSingleToken, isTypographyToken} from './utils';
 
 const renderKeyValue = ({
     tokenValues,
@@ -20,7 +20,7 @@ const renderKeyValue = ({
             const stringPath = [path, key].filter((n) => n).join('.');
             return (
                 <React.Fragment key={stringPath}>
-                    {typeof value === 'object' && !isTypographyToken(value) ? (
+                    {typeof value === 'object' && !isTypographyToken(value) && !isSingleToken(value) ? (
                         <div className="property-wrapper w-full">
                             <div className="flex items-center justify-between">
                                 <Heading size="small">{key}</Heading>

--- a/src/app/components/utils.tsx
+++ b/src/app/components/utils.tsx
@@ -40,8 +40,8 @@ export function isTypographyToken(token) {
     return 'fontFamily' in token || 'fontWeight' in token || 'fontSize' in token || 'lineHeight' in token;
 }
 
-export function isSingleToken(token) {
-    return 'value' in token;
+export function isSingleToken(token): token is {value: string} {
+    return typeof token === 'object' && 'value' in token;
 }
 
 export function convertToRgb(color: string) {

--- a/src/app/components/utils.tsx
+++ b/src/app/components/utils.tsx
@@ -36,6 +36,7 @@ export function mergeDeep(target, ...sources) {
 }
 
 export function isTypographyToken(token) {
+    if (typeof token !== 'object') return false;
     return 'fontFamily' in token || 'fontWeight' in token || 'fontSize' in token || 'lineHeight' in token;
 }
 

--- a/src/app/components/utils.tsx
+++ b/src/app/components/utils.tsx
@@ -39,6 +39,10 @@ export function isTypographyToken(token) {
     return 'fontFamily' in token || 'fontWeight' in token || 'fontSize' in token || 'lineHeight' in token;
 }
 
+export function isSingleToken(token) {
+    return 'value' in token;
+}
+
 export function convertToRgb(color: string) {
     if (typeof color !== 'string') {
         return color;

--- a/src/app/store/TokenContext.tsx
+++ b/src/app/store/TokenContext.tsx
@@ -29,6 +29,7 @@ export enum ActionType {
     SetSelectionValues = 'SET_SELECTION_VALUES',
     ResetSelectionValues = 'RESET_SELECTION_VALUES',
     SetShowEditForm = 'SET_SHOW_EDIT_FORM',
+    SetShowNewGroupForm = 'SET_SHOW_NEW_GROUP_FORM',
     SetShowOptions = 'SET_SHOW_OPTIONS',
     SetDisplayType = 'SET_DISPLAY_TYPE',
     ToggleColorMode = 'TOGGLE_COLOR_MODE',
@@ -60,6 +61,7 @@ const emptyState = {
     displayType: 'GRID',
     colorMode: false,
     showEditForm: false,
+    showNewGroupForm: false,
     showOptions: false,
     updatePageOnly: true,
 };
@@ -68,7 +70,6 @@ const TokenStateContext = React.createContext(emptyState);
 const TokenDispatchContext = React.createContext(null);
 
 function updateTokens(state: any) {
-    console.log('tokendata', state.tokenData);
     parent.postMessage(
         {
             pluginMessage: {
@@ -209,6 +210,11 @@ function stateReducer(state, action) {
                 ...state,
                 showEditForm: action.bool,
             };
+        case ActionType.SetShowNewGroupForm:
+            return {
+                ...state,
+                showNewGroupForm: action.bool,
+            };
         case ActionType.SetShowOptions:
             return {
                 ...state,
@@ -293,6 +299,9 @@ function TokenProvider({children}) {
             },
             setShowEditForm: (bool: boolean) => {
                 dispatch({type: ActionType.SetShowEditForm, bool});
+            },
+            setShowNewGroupForm: (bool: boolean) => {
+                dispatch({type: ActionType.SetShowNewGroupForm, bool});
             },
             setShowOptions: (data: string) => {
                 dispatch({type: ActionType.SetShowOptions, data});

--- a/src/app/store/TokenContext.tsx
+++ b/src/app/store/TokenContext.tsx
@@ -68,6 +68,7 @@ const TokenStateContext = React.createContext(emptyState);
 const TokenDispatchContext = React.createContext(null);
 
 function updateTokens(state: any) {
+    console.log('tokendata', state.tokenData);
     parent.postMessage(
         {
             pluginMessage: {

--- a/src/config/default.json
+++ b/src/config/default.json
@@ -183,37 +183,41 @@
         "body": 16
     },
     "typography": {
-        "H1/Bold": {
-            "fontFamily": "$fontFamilies.heading",
-            "fontWeight": "$fontWeights.headingBold",
-            "lineHeight": "$lineHeights.heading",
-            "fontSize": "$fontSizes.h1",
-            "paragraphSpacing": "$paragraphSpacing.h1",
-            "letterSpacing": "$letterSpacing.decreased"
+        "H1": {
+            "Bold": {
+                "fontFamily": "$fontFamilies.heading",
+                "fontWeight": "$fontWeights.headingBold",
+                "lineHeight": "$lineHeights.heading",
+                "fontSize": "$fontSizes.h1",
+                "paragraphSpacing": "$paragraphSpacing.h1",
+                "letterSpacing": "$letterSpacing.decreased"
+            },
+            "Regular": {
+                "fontFamily": "$fontFamilies.heading",
+                "fontWeight": "$fontWeights.headingRegular",
+                "lineHeight": "$lineHeights.heading",
+                "fontSize": "$fontSizes.h1",
+                "paragraphSpacing": "$paragraphSpacing.h1",
+                "letterSpacing": "$letterSpacing.decreased"
+            }
         },
-        "H1/Regular": {
-            "fontFamily": "$fontFamilies.heading",
-            "fontWeight": "$fontWeights.headingRegular",
-            "lineHeight": "$lineHeights.heading",
-            "fontSize": "$fontSizes.h1",
-            "paragraphSpacing": "$paragraphSpacing.h1",
-            "letterSpacing": "$letterSpacing.decreased"
-        },
-        "H2/Bold": {
-            "fontFamily": "$fontFamilies.heading",
-            "fontWeight": "$fontWeights.headingBold",
-            "lineHeight": "$lineHeights.heading",
-            "fontSize": "$fontSizes.h2",
-            "paragraphSpacing": "$paragraphSpacing.h2",
-            "letterSpacing": "$letterSpacing.decreased"
-        },
-        "H2/Regular": {
-            "fontFamily": "$fontFamilies.heading",
-            "fontWeight": "$fontWeights.headingRegular",
-            "lineHeight": "$lineHeights.heading",
-            "fontSize": "$fontSizes.h2",
-            "paragraphSpacing": "$paragraphSpacing.h2",
-            "letterSpacing": "$letterSpacing.decreased"
+        "H2": {
+            "Bold": {
+                "fontFamily": "$fontFamilies.heading",
+                "fontWeight": "$fontWeights.headingBold",
+                "lineHeight": "$lineHeights.heading",
+                "fontSize": "$fontSizes.h2",
+                "paragraphSpacing": "$paragraphSpacing.h2",
+                "letterSpacing": "$letterSpacing.decreased"
+            },
+            "Regular": {
+                "fontFamily": "$fontFamilies.heading",
+                "fontWeight": "$fontWeights.headingRegular",
+                "lineHeight": "$lineHeights.heading",
+                "fontSize": "$fontSizes.h2",
+                "paragraphSpacing": "$paragraphSpacing.h2",
+                "letterSpacing": "$letterSpacing.decreased"
+            }
         },
         "Body": {
             "fontFamily": "$fontFamilies.body",

--- a/src/plugin/controller.ts
+++ b/src/plugin/controller.ts
@@ -57,8 +57,9 @@ figma.ui.onmessage = async (msg) => {
             }
             return;
         case 'update': {
+            console.log('Tokens', msg.tokens);
+            console.log('TokenValues', msg.tokenValues);
             const allWithData = findAllWithData({pageOnly: msg.updatePageOnly});
-            console.log('tokens', msg.tokens, msg.tokenValues);
             setTokenData(msg.tokenValues);
             updateStyles(msg.tokens, false);
             updateNodes(allWithData, msg.tokens);

--- a/src/plugin/controller.ts
+++ b/src/plugin/controller.ts
@@ -58,6 +58,7 @@ figma.ui.onmessage = async (msg) => {
             return;
         case 'update': {
             const allWithData = findAllWithData({pageOnly: msg.updatePageOnly});
+            console.log('tokens', msg.tokens, msg.tokenValues);
             setTokenData(msg.tokenValues);
             updateStyles(msg.tokens, false);
             updateNodes(allWithData, msg.tokens);

--- a/src/plugin/controller.ts
+++ b/src/plugin/controller.ts
@@ -57,8 +57,6 @@ figma.ui.onmessage = async (msg) => {
             }
             return;
         case 'update': {
-            console.log('Tokens', msg.tokens);
-            console.log('TokenValues', msg.tokenValues);
             const allWithData = findAllWithData({pageOnly: msg.updatePageOnly});
             setTokenData(msg.tokenValues);
             updateStyles(msg.tokens, false);

--- a/src/plugin/node.ts
+++ b/src/plugin/node.ts
@@ -4,10 +4,21 @@ import {fetchAllPluginData} from './pluginData';
 import store from './store';
 import * as pjs from '../../package.json';
 import {setValuesOnNode} from './updateNode';
+import {isSingleToken} from '../app/components/utils';
 
 export function mapValuesToTokens(object, values) {
-    const array = Object.entries(values).map(([key, value]) => ({[key]: objectPath.get(object, value)}));
+    const array = Object.entries(values).map(([key, token]) => {
+        const resolvedValue = objectPath.get(object, token);
+        const value = isSingleToken(resolvedValue) ? resolvedValue.value : resolvedValue;
+
+        console.log('value is', resolvedValue, value);
+
+        return {
+            [key]: value,
+        };
+    });
     array.map((item) => ({[item.key]: item.value}));
+    console.log('array is', array);
     return Object.assign({}, ...array);
 }
 

--- a/src/plugin/node.ts
+++ b/src/plugin/node.ts
@@ -11,14 +11,11 @@ export function mapValuesToTokens(object, values) {
         const resolvedValue = objectPath.get(object, token);
         const value = isSingleToken(resolvedValue) ? resolvedValue.value : resolvedValue;
 
-        console.log('value is', resolvedValue, value);
-
         return {
             [key]: value,
         };
     });
     array.map((item) => ({[item.key]: item.value}));
-    console.log('array is', array);
     return Object.assign({}, ...array);
 }
 

--- a/src/plugin/styles.ts
+++ b/src/plugin/styles.ts
@@ -15,10 +15,12 @@ const dot = new Dot('/');
 
 interface TypographyToken {
     value: {
-        familyName: string;
-        fontWeight: string;
-        fontSize: number;
-        lineHeight: string | number;
+        fontFamily?: string;
+        fontWeight?: string;
+        fontSize?: string;
+        lineHeight?: string | number;
+        letterSpacing?: string;
+        paragraphSpacing?: string;
     };
     description?: string;
 }
@@ -172,8 +174,12 @@ export function pullStyles(styleTypes): void {
                 if (paint.type === 'SOLID') {
                     const {r, g, b} = paint.color;
                     const a = paint.opacity;
-                    const description = style.description ?? null;
-                    return [style.name, {value: figmaRGBToHex({r, g, b, a}), description}];
+                    const styleObject: ColorToken = {value: figmaRGBToHex({r, g, b, a})};
+
+                    if (style.description) {
+                        styleObject.description = style.description;
+                    }
+                    return [style.name, styleObject];
                 }
                 return null;
             });
@@ -240,9 +246,12 @@ export function pullStyles(styleTypes): void {
                     paragraphSpacing.find((el: number[]) => el[1] === style.paragraphSpacing)[0]
                 }`,
             };
-            const description = style.description ?? null;
+            const styleObject: TypographyToken = {value: obj};
 
-            return [style.name, {value: obj, description}];
+            if (style.description) {
+                styleObject.description = style.description;
+            }
+            return [style.name, styleObject];
         });
     }
     notifyStyleValues({

--- a/src/plugin/styles.ts
+++ b/src/plugin/styles.ts
@@ -30,16 +30,19 @@ interface ColorToken {
 
 const updateColorStyles = (colorTokens, shouldCreate = false) => {
     const cols = dot.dot(colorTokens);
-    console.log('cols are', cols);
+    console.log('cols are', colorTokens);
     const paints = figma.getLocalPaintStyles();
     Object.entries(cols).map(([key, token]: [string, ColorToken]) => {
         const splitKey = key.split('/');
+        // not working for color styles with description and value
         if (splitKey[splitKey.length - 1] === 'value') splitKey.pop();
         const styleKey = splitKey.join('/');
 
         const value = isSingleToken(token) ? token.value : token;
-        if (paints.length < 1) return;
-        const matchingStyle = paints.filter((n) => n.name === styleKey);
+        let matchingStyle = [];
+        if (paints.length > 0) {
+            matchingStyle = paints.filter((n) => n.name === styleKey);
+        }
         if (typeof value === 'string') {
             const {color, opacity} = convertToFigmaColor(value);
             if (matchingStyle.length) {


### PR DESCRIPTION
This PR does multiple things:
- All tokens are now stored under a `value` prop of the Token.
- Reading old "non-value" style Tokens is still possible, editing them via UI will however create a token with that `value` prop.
- Descriptions can now be added to color styles and typography styles. Should expand that later to all tokens, as mentioned in #11
- Prepares a schema-like structure for tokens to prepare for custom UI handlers such as a color input mentioned in #6

I realize this could make the JSON output less useful to some (who may want a simple JSON structure and not a structure that stores token's values under a `value` property, however we should strive to store more data on each token so this is the only way to go, as well as being more compliant to (potential standards)