### PR TITLE
fixes #97: setting typography and text tokens directly on nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "figma-tokens",
-	"version": "44",
+	"version": "45",
 	"description": "Figma Design Tokens",
 	"license": "ISC",
 	"scripts": {

--- a/src/app/components/Initiator.tsx
+++ b/src/app/components/Initiator.tsx
@@ -68,6 +68,7 @@ export default function Initiator({setActive, setRemoteComponents}) {
                     case MessageFromPluginTypes.STYLES:
                         setLoading(false);
                         if (values) {
+                            track('Import styles');
                             setTokensFromStyles(values);
                             setActive('tokens');
                         }

--- a/src/plugin/updateNode.ts
+++ b/src/plugin/updateNode.ts
@@ -100,7 +100,7 @@ export default async function setValuesOnNode(node, values, data) {
             if (matchingStyles.length) {
                 node.textStyleId = matchingStyles[0].id;
             } else {
-                setTextValuesOnTarget(node, values.typography);
+                setTextValuesOnTarget(node, {value: values.typography});
             }
         }
     } else if (
@@ -113,12 +113,14 @@ export default async function setValuesOnNode(node, values, data) {
     ) {
         if (node.type === 'TEXT') {
             setTextValuesOnTarget(node, {
-                fontFamily: values.fontFamilies,
-                fontWeight: values.fontWeights,
-                lineHeight: values.lineHeights,
-                fontSize: values.fontSizes,
-                letterSpacing: values.letterSpacing,
-                paragraphSpacing: values.paragraphSpacing,
+                value: {
+                    fontFamily: values.fontFamilies,
+                    fontWeight: values.fontWeights,
+                    lineHeight: values.lineHeights,
+                    fontSize: values.fontSizes,
+                    letterSpacing: values.letterSpacing,
+                    paragraphSpacing: values.paragraphSpacing,
+                },
             });
         }
     }


### PR DESCRIPTION
Fixes a bug reported for typography and text tokens when settings these directly on nodes