### PR TITLE
added abbility to create global palette of values

### DIFF
--- a/src/app/components/TokenData.tsx
+++ b/src/app/components/TokenData.tsx
@@ -149,6 +149,11 @@ export default class TokenData {
                 }, [])
             );
 
+            // Allows for referencing values form 'palette' set in each other set.
+            if ('palette' in this.tokens) {
+                this.mergedTokens.palette = JSON.parse(this.tokens.palette.values);
+            }
+
             this.setAllAliases();
         }
     }


### PR DESCRIPTION
This code gives possibiblity to create global palette set, which can be referenced in other sets.
It happens by creating set with "palette" name. It then gives you possibiblity to reference to it by setting value to $palette.colors.blue.400

Creating such global generic set accessible from all sets allows you to create defined scale of values to use in other sets, which should help with keeping consistency.