### PR TITLE
fixes #140

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "figma-tokens",
 	"version": "1.0.0",
-	"plugin_version": "51",
+	"plugin_version": "52",
 	"description": "Figma Design Tokens",
 	"license": "ISC",
 	"scripts": {

--- a/src/plugin/updateColorStyles.ts
+++ b/src/plugin/updateColorStyles.ts
@@ -10,7 +10,13 @@ export default function updateColorStyles(colorTokens, shouldCreate = false) {
     colorTokenArray.map(([key, value]: [string, ColorToken]) => {
         let matchingStyles = [];
         if (paints.length > 0) {
-            matchingStyles = paints.filter((n) => n.name === key);
+            matchingStyles = paints.filter(
+                (n) =>
+                    n.name
+                        .split('/')
+                        .map((i) => i.trim())
+                        .join('/') === key
+            );
         }
         if (matchingStyles.length) {
             setColorValuesOnTarget(matchingStyles[0], value);


### PR DESCRIPTION
Fixes comparison behaviour when old Figma style names with a space before / after delimiter are used, e.g.

`Volcano / 1` vs `Volcano/1`