### PR TITLE
Fixing zero values

### DIFF
--- a/src/plugin/figmaTransforms/generic.test.ts
+++ b/src/plugin/figmaTransforms/generic.test.ts
@@ -1,4 +1,4 @@
-import {convertTypographyNumberToFigma} from './generic';
+import {convertTypographyNumberToFigma, fakeZeroForFigma} from './generic';
 
 describe('convertTypographyNumberToFigma', () => {
     it('converts an input number-like string and returns a transformed value', () => {
@@ -12,5 +12,19 @@ describe('convertTypographyNumberToFigma', () => {
         expect(numberStringValue).toBe(144);
         const numberValue = convertTypographyNumberToFigma(72);
         expect(numberValue).toBe(72);
+    });
+});
+
+describe('fakeZeroForFigma', () => {
+    it('should return 0.01 for certain 0 values', () => {
+        const zeroNumber = fakeZeroForFigma(0);
+        expect(zeroNumber).toBe(0.001);
+        const zeroString = fakeZeroForFigma('0');
+        expect(zeroString).toBe(0.001);
+
+        const otherNumber = fakeZeroForFigma(1);
+        expect(otherNumber).toBe(1);
+        const otherString = fakeZeroForFigma('Test');
+        expect(otherString).toBe('Test');
     });
 });

--- a/src/plugin/figmaTransforms/generic.ts
+++ b/src/plugin/figmaTransforms/generic.ts
@@ -2,6 +2,10 @@ export function convertNumberToFigma(value) {
     return parseInt(value, 10);
 }
 
+export function fakeZeroForFigma(value) {
+    return Number(value) === 0 ? 0.001 : value;
+}
+
 export function convertTypographyNumberToFigma(value) {
     const baseFontSize = 16;
     if (typeof value === 'string' && (value.endsWith('em') || value.endsWith('rem'))) {

--- a/src/plugin/helpers.ts
+++ b/src/plugin/helpers.ts
@@ -55,21 +55,10 @@ export async function getUserId() {
 export function transformValue(value, type) {
     switch (type) {
         case 'borderWidth':
-            return fakeZeroForFigma(value);
         case 'width':
-            return fakeZeroForFigma(value);
         case 'height':
-            return fakeZeroForFigma(value);
         case 'sizing':
-            return fakeZeroForFigma(value);
-        case 'fontSizes':
-            return convertTypographyNumberToFigma(value);
-        case 'letterSpacing':
-            return convertLetterSpacingToFigma(value);
-        case 'lineHeights':
-            return convertLineHeightToFigma(value);
-        case 'opacity':
-            return convertOpacityToFigma(value.toString());
+            return fakeZeroForFigma(convertTypographyNumberToFigma(value));
         case 'borderRadius':
         case 'borderRadiusTopLeft':
         case 'borderRadiusTopRight':
@@ -85,6 +74,14 @@ export function transformValue(value, type) {
         case 'itemSpacing':
         case 'boxShadow':
         case 'paragraphSpacing':
+        case 'fontSizes':
+            return convertTypographyNumberToFigma(value);
+        case 'letterSpacing':
+            return convertLetterSpacingToFigma(value);
+        case 'lineHeights':
+            return convertLineHeightToFigma(value);
+        case 'opacity':
+            return convertOpacityToFigma(value.toString());
         default:
             return value;
     }

--- a/src/plugin/helpers.ts
+++ b/src/plugin/helpers.ts
@@ -1,4 +1,4 @@
-import {convertTypographyNumberToFigma} from './figmaTransforms/generic';
+import {convertTypographyNumberToFigma, fakeZeroForFigma} from './figmaTransforms/generic';
 import {convertLetterSpacingToFigma} from './figmaTransforms/letterSpacing';
 import {convertLineHeightToFigma} from './figmaTransforms/lineHeight';
 import convertOpacityToFigma from './figmaTransforms/opacity';
@@ -54,25 +54,14 @@ export async function getUserId() {
 
 export function transformValue(value, type) {
     switch (type) {
-        case 'borderRadius':
-        case 'borderRadiusTopLeft':
-        case 'borderRadiusTopRight':
-        case 'borderRadiusBottomRight':
-        case 'borderRadiusBottomLeft':
-        case 'width':
-        case 'height':
-        case 'sizing':
-        case 'spacing':
-        case 'horizontalPadding':
-        case 'verticalPadding':
-        case 'paddingTop':
-        case 'paddingRight':
-        case 'paddingBottom':
-        case 'paddingLeft':
-        case 'itemSpacing':
         case 'borderWidth':
-        case 'boxShadow':
-        case 'paragraphSpacing':
+            return fakeZeroForFigma(value);
+        case 'width':
+            return fakeZeroForFigma(value);
+        case 'height':
+            return fakeZeroForFigma(value);
+        case 'sizing':
+            return fakeZeroForFigma(value);
         case 'fontSizes':
             return convertTypographyNumberToFigma(value);
         case 'letterSpacing':
@@ -81,6 +70,21 @@ export function transformValue(value, type) {
             return convertLineHeightToFigma(value);
         case 'opacity':
             return convertOpacityToFigma(value.toString());
+        case 'borderRadius':
+        case 'borderRadiusTopLeft':
+        case 'borderRadiusTopRight':
+        case 'borderRadiusBottomRight':
+        case 'borderRadiusBottomLeft':
+        case 'spacing':
+        case 'horizontalPadding':
+        case 'verticalPadding':
+        case 'paddingTop':
+        case 'paddingRight':
+        case 'paddingBottom':
+        case 'paddingLeft':
+        case 'itemSpacing':
+        case 'boxShadow':
+        case 'paragraphSpacing':
         default:
             return value;
     }

--- a/src/plugin/updateNode.ts
+++ b/src/plugin/updateNode.ts
@@ -6,92 +6,69 @@ import setTextValuesOnTarget from './setTextValuesOnTarget';
 export default async function setValuesOnNode(node, values, data) {
     try {
         // BORDER RADIUS
-        if (values.borderRadius) {
-            if (typeof node.cornerRadius !== 'undefined') {
-                node.cornerRadius = transformValue(values.borderRadius || values.borderRadiusTopLeft, 'borderRadius');
-            }
+        if (typeof values.borderRadius !== 'undefined' && typeof node.cornerRadius !== 'undefined') {
+            node.cornerRadius = transformValue(values.borderRadius, 'borderRadius');
         }
-        if (values.borderRadiusTopLeft) {
-            if (typeof node.topLeftRadius !== 'undefined') {
-                node.topLeftRadius = transformValue(values.borderRadiusTopLeft, 'borderRadius');
-            }
+        if (typeof values.borderRadiusTopLeft !== 'undefined' && typeof node.topLeftRadius !== 'undefined') {
+            node.topLeftRadius = transformValue(values.borderRadiusTopLeft, 'borderRadius');
         }
-        if (values.borderRadiusTopRight) {
-            if (typeof node.topRightRadius !== 'undefined') {
-                node.topRightRadius = transformValue(values.borderRadiusTopRight, 'borderRadius');
-            }
+        if (typeof values.borderRadiusTopRight !== 'undefined' && typeof node.topRightRadius !== 'undefined') {
+            node.topRightRadius = transformValue(values.borderRadiusTopRight, 'borderRadius');
         }
-        if (values.borderRadiusBottomRight) {
-            if (typeof node.bottomRightRadius !== 'undefined') {
-                node.bottomRightRadius = transformValue(values.borderRadiusBottomRight, 'borderRadius');
-            }
+        if (typeof values.borderRadiusBottomRight !== 'undefined' && typeof node.bottomRightRadius !== 'undefined') {
+            node.bottomRightRadius = transformValue(values.borderRadiusBottomRight, 'borderRadius');
         }
-        if (values.borderRadiusBottomLeft) {
-            if (typeof node.bottomLeftRadius !== 'undefined') {
-                node.bottomLeftRadius = transformValue(values.borderRadiusBottomLeft, 'borderRadius');
-            }
+        if (typeof values.borderRadiusBottomLeft !== 'undefined' && typeof node.bottomLeftRadius !== 'undefined') {
+            node.bottomLeftRadius = transformValue(values.borderRadiusBottomLeft, 'borderRadius');
         }
 
         // BOX SHADOW
-        if (values.boxShadow) {
-            if (typeof node.effects !== 'undefined') {
-                // get all effects, but remove DROP_SHADOW, since we're about to add it
-                const effects = node.effects.filter((effect) => effect.type !== 'DROP_SHADOW');
-                const {x, y, spread, color, blur} = values.boxShadow;
-                const {
-                    color: {r, g, b},
-                    opacity,
-                } = convertToFigmaColor(color);
+        if (typeof values.boxShadow !== 'undefined' && typeof node.effects !== 'undefined') {
+            // get all effects, but remove DROP_SHADOW, since we're about to add it
+            const effects = node.effects.filter((effect) => effect.type !== 'DROP_SHADOW');
+            const {x, y, spread, color, blur} = values.boxShadow;
+            const {
+                color: {r, g, b},
+                opacity,
+            } = convertToFigmaColor(color);
 
-                const effect: ShadowEffect = {
-                    type: 'DROP_SHADOW',
-                    visible: true,
-                    blendMode: 'NORMAL',
-                    color: {r, g, b, a: opacity},
-                    offset: {x: transformValue(x, 'boxShadow'), y: transformValue(y, 'boxShadow')},
-                    radius: transformValue(blur, 'boxShadow'),
-                    spread: transformValue(spread, 'boxShadow'),
-                };
+            const effect: ShadowEffect = {
+                type: 'DROP_SHADOW',
+                visible: true,
+                blendMode: 'NORMAL',
+                color: {r, g, b, a: opacity},
+                offset: {x: transformValue(x, 'boxShadow'), y: transformValue(y, 'boxShadow')},
+                radius: transformValue(blur, 'boxShadow'),
+                spread: transformValue(spread, 'boxShadow'),
+            };
 
-                effects.push(effect);
-                node.effects = effects;
-            }
+            effects.push(effect);
+            node.effects = effects;
         }
 
         // BORDER WIDTH
-        if (values.borderWidth) {
-            // Has to be larger than 0
-            if (typeof node.strokeWeight !== 'undefined' && transformValue(values.borderWidth, 'borderWidth') >= 0) {
-                node.strokeWeight = transformValue(values.borderWidth, 'borderWidth');
-            }
+        if (typeof values.borderWidth !== 'undefined' && typeof node.strokeWeight !== 'undefined') {
+            node.strokeWeight = transformValue(values.borderWidth, 'borderWidth');
         }
 
         // OPACITY
-        if (values.opacity) {
-            if (typeof node.opacity !== 'undefined') {
-                node.opacity = transformValue(values.opacity, 'opacity');
-            }
+        if (typeof values.opacity !== 'undefined' && typeof node.opacity !== 'undefined') {
+            node.opacity = transformValue(values.opacity, 'opacity');
         }
 
         // SIZING: BOTH
-        if (values.sizing) {
-            if (typeof node.resize !== 'undefined') {
-                node.resize(transformValue(values.sizing, 'sizing'), transformValue(values.sizing, 'sizing'));
-            }
+        if (typeof values.sizing !== 'undefined' && typeof node.resize !== 'undefined') {
+            node.resize(transformValue(values.sizing, 'sizing'), transformValue(values.sizing, 'sizing'));
         }
 
         // SIZING: WIDTH
-        if (values.width) {
-            if (typeof node.resize !== 'undefined') {
-                node.resize(transformValue(values.width, 'sizing'), node.height);
-            }
+        if (typeof values.width !== 'undefined' && typeof node.resize !== 'undefined') {
+            node.resize(transformValue(values.width, 'sizing'), node.height);
         }
 
         // SIZING: HEIGHT
-        if (values.height) {
-            if (typeof node.resize !== 'undefined') {
-                node.resize(node.width, transformValue(values.height, 'sizing'));
-            }
+        if (typeof values.height !== 'undefined' && typeof node.resize !== 'undefined') {
+            node.resize(node.width, transformValue(values.height, 'sizing'));
         }
 
         // FILL
@@ -147,8 +124,8 @@ export default async function setValuesOnNode(node, values, data) {
             }
         }
 
-        // BORDER WIDTH
-        if (values.border) {
+        // BORDER COLOR
+        if (typeof values.border !== 'undefined') {
             if (typeof node.strokes !== 'undefined') {
                 const paints = figma.getLocalPaintStyles();
                 const path = data.border.split('.');
@@ -166,52 +143,36 @@ export default async function setValuesOnNode(node, values, data) {
         }
 
         // SPACING
-        if (values.spacing) {
-            if (typeof node.paddingLeft !== 'undefined') {
-                node.paddingLeft = transformValue(values.spacing, 'spacing');
-                node.paddingRight = transformValue(values.spacing, 'spacing');
-                node.paddingTop = transformValue(values.spacing, 'spacing');
-                node.paddingBottom = transformValue(values.spacing, 'spacing');
-                node.itemSpacing = transformValue(values.spacing, 'spacing');
-            }
+        if (typeof values.spacing !== 'undefined' && typeof node.paddingLeft !== 'undefined') {
+            node.paddingLeft = transformValue(values.spacing, 'spacing');
+            node.paddingRight = transformValue(values.spacing, 'spacing');
+            node.paddingTop = transformValue(values.spacing, 'spacing');
+            node.paddingBottom = transformValue(values.spacing, 'spacing');
+            node.itemSpacing = transformValue(values.spacing, 'spacing');
         }
-        if (values.horizontalPadding) {
-            if (typeof node.paddingLeft !== 'undefined') {
-                node.paddingLeft = transformValue(values.horizontalPadding, 'spacing');
-                node.paddingRight = transformValue(values.horizontalPadding, 'spacing');
-            }
+        if (typeof values.horizontalPadding !== 'undefined' && typeof node.paddingLeft !== 'undefined') {
+            node.paddingLeft = transformValue(values.horizontalPadding, 'spacing');
+            node.paddingRight = transformValue(values.horizontalPadding, 'spacing');
         }
-        if (values.verticalPadding) {
-            if (typeof node.paddingTop !== 'undefined') {
-                node.paddingTop = transformValue(values.verticalPadding, 'spacing');
-                node.paddingBottom = transformValue(values.verticalPadding, 'spacing');
-            }
+        if (typeof values.verticalPadding !== 'undefined' && typeof node.paddingTop !== 'undefined') {
+            node.paddingTop = transformValue(values.verticalPadding, 'spacing');
+            node.paddingBottom = transformValue(values.verticalPadding, 'spacing');
         }
-        if (values.itemSpacing) {
-            if (typeof node.itemSpacing !== 'undefined') {
-                node.itemSpacing = transformValue(values.itemSpacing, 'spacing');
-            }
+        if (typeof values.itemSpacing !== 'undefined' && typeof node.itemSpacing !== 'undefined') {
+            node.itemSpacing = transformValue(values.itemSpacing, 'spacing');
         }
 
-        if (values.paddingTop) {
-            if (typeof node.paddingTop !== 'undefined') {
-                node.paddingTop = transformValue(values.paddingTop, 'spacing');
-            }
+        if (typeof values.paddingTop !== 'undefined' && typeof node.paddingTop !== 'undefined') {
+            node.paddingTop = transformValue(values.paddingTop, 'spacing');
         }
-        if (values.paddingRight) {
-            if (typeof node.paddingRight !== 'undefined') {
-                node.paddingRight = transformValue(values.paddingRight, 'spacing');
-            }
+        if (typeof values.paddingRight !== 'undefined' && typeof node.paddingRight !== 'undefined') {
+            node.paddingRight = transformValue(values.paddingRight, 'spacing');
         }
-        if (values.paddingBottom) {
-            if (typeof node.paddingBottom !== 'undefined') {
-                node.paddingBottom = transformValue(values.paddingBottom, 'spacing');
-            }
+        if (typeof values.paddingBottom !== 'undefined' && typeof node.paddingBottom !== 'undefined') {
+            node.paddingBottom = transformValue(values.paddingBottom, 'spacing');
         }
-        if (values.paddingLeft) {
-            if (typeof node.paddingLeft !== 'undefined') {
-                node.paddingLeft = transformValue(values.paddingLeft, 'spacing');
-            }
+        if (typeof values.paddingLeft !== 'undefined' && typeof node.paddingLeft !== 'undefined') {
+            node.paddingLeft = transformValue(values.paddingLeft, 'spacing');
         }
 
         // Raw value for text layers


### PR DESCRIPTION
Currently the plugin doesn't support zero `0` values for tokens, the check `if (values.opacity)` for example skips the update because `0 === false` and then it won't update the styles.

I've updated the checks to `typeof prop !== 'undefined'` so it also works for 0 values and added an extra value check for properties that don't allow 0 values in Figma (ie. width, height, border width, …) and convert the 0 to 0.001.

This way I can set my opacity to 0 or hide elements.

What do you think?