### PR TITLE
resolves #208

### DIFF
--- a/src/app/components/utils.test.ts
+++ b/src/app/components/utils.test.ts
@@ -1,4 +1,46 @@
-import {convertToRgb, isTypographyToken, lightOrDark, slugify} from './utils';
+import {convertToRgb, isTypographyToken, lightOrDark, slugify, checkAndEvaluateMath, isSingleToken} from './utils';
+
+describe('checkmath', () => {
+    it('calculates math', () => {
+        const input = '25 * 4.5 + 0.175';
+        const output = 112.675;
+        expect(checkAndEvaluateMath(input)).toEqual(output);
+    });
+});
+
+describe('isSingleToken', () => {
+    it('correctly asserts a single token', () => {
+        const basic = {
+            type: 'color',
+            name: 'colors.blue',
+            value: '#0000ff',
+        };
+        const extraData = {
+            type: 'color',
+            name: 'colors.blue',
+            value: '#0000ff',
+            description: 'Such wow.',
+        };
+        expect(isSingleToken(basic)).toBe(true);
+        expect(isSingleToken(extraData)).toBe(true);
+    });
+    it('rejects token groups', () => {
+        const wrongToken = {
+            label: {
+                type: 'color',
+                name: 'colors.blue',
+                value: '#0000ff',
+            },
+            value: {
+                type: 'color',
+                name: 'colors.blue',
+                value: '#0000ff',
+            },
+        };
+
+        expect(isSingleToken(wrongToken)).toBe(false);
+    });
+});
 
 describe('isTypographyToken', () => {
     it('returns truthiness of a typography token and only accepts tokens that feature required values', () => {

--- a/src/app/components/utils.tsx
+++ b/src/app/components/utils.tsx
@@ -28,7 +28,7 @@ export function isTypographyToken(token) {
 }
 
 export function isSingleToken(token): token is {value: string} {
-    return typeof token === 'object' && 'value' in token;
+    return typeof token === 'object' && 'value' in token && 'type' in token && 'name' in token;
 }
 
 // Convert non-conform colors to RGB value that can be used throughout the plugin
@@ -107,25 +107,6 @@ export function lightOrDark(color: string) {
         console.error(e);
     }
     return 'light';
-}
-
-// Sets random color depending on Hash for use in colorful UI
-export function colorByHashCode(value) {
-    let hash = 0;
-    if (value.length === 0) return hash;
-    for (let i = 0; i < value.length; i += 1) {
-        hash = value.charCodeAt(i) * 30 + hash;
-    }
-    const shortened = Math.abs(hash % 360);
-    return `${shortened},100%,85%`;
-}
-
-// Not in use for now, converts string to hashCode
-export function hashCode(s) {
-    return s.split('').reduce(function (a, b) {
-        a = (a << 5) - a + b.charCodeAt(0);
-        return a & a;
-    }, 0);
 }
 
 // Converts string to slug

--- a/src/app/store/useTokens.tsx
+++ b/src/app/store/useTokens.tsx
@@ -3,7 +3,7 @@ import {useSelector} from 'react-redux';
 import {MessageToPluginTypes} from 'Types/messages';
 import checkIfAlias from '@/utils/checkIfAlias';
 import {getAliasValue} from '@/utils/aliases';
-import {SingleToken, SingleTokenObject} from 'Types/tokens';
+import {SingleTokenObject} from 'Types/tokens';
 import stringifyTokens from '@/utils/stringifyTokens';
 import formatTokens from '@/utils/formatTokens';
 import {computeMergedTokens, resolveTokenValues} from '@/plugin/tokenHelpers';
@@ -15,10 +15,10 @@ export default function useTokens() {
     const settings = useSelector((state: RootState) => state.settings);
 
     // Finds token that matches name
-    function findToken(token: string) {
-        const resolved = resolveTokenValues(computeMergedTokens(tokens, usedTokenSet));
+    function findToken(name: string) {
+        const resolved = resolveTokenValues(computeMergedTokens(tokens, [...usedTokenSet, activeTokenSet]));
 
-        return resolved.find((n) => n.name === token);
+        return resolved.find((n) => n.name === name);
     }
 
     // Gets value of token

--- a/src/plugin/node.test.ts
+++ b/src/plugin/node.test.ts
@@ -2,7 +2,7 @@ import {mapValuesToTokens, returnValueToLookFor} from './node';
 
 describe('mapValuesToTokens', () => {
     it('maps values to tokens', () => {
-        const tokens = [{name: 'global.colors.blue', value: '#0000ff'}];
+        const tokens = [{name: 'global.colors.blue', type: 'color', value: '#0000ff'}];
 
         const values = {fill: 'global.colors.blue'};
         expect(mapValuesToTokens(tokens, values)).toEqual({


### PR DESCRIPTION
Fixes a bug when when a token was created that used `value` as a name (which the plugin used to assert if that is a token or a token group).

Changed the code to rely on not just `value` but also `name` and `type`, which all tokens have at this point.

The plugin could still break if a user was to create a token group containing all 3 tokens named `value`, `type`, `name`. We should fix this in the future to use a better naming structure for internal fields.