### PR TITLE
Fix for rgba values without spaces

### DIFF
--- a/src/app/components/utils.test.ts
+++ b/src/app/components/utils.test.ts
@@ -79,10 +79,12 @@ describe('isTypographyToken', () => {
 
 describe('convertToRgb', () => {
     it('transforms a color string to rgb values', () => {
-        const rgbhex = 'rgb(#ff0000, 0.5)';
+        const rgbhexWithSpace = 'rgb(#ff0000, 0.5)';
+        const rgbahexWithOutSpace = 'rgba(#ff0000,0.5)';
         const hex = '#ff0000';
 
-        expect(convertToRgb(rgbhex)).toBe('#ff000080');
+        expect(convertToRgb(rgbhexWithSpace)).toBe('#ff000080');
+        expect(convertToRgb(rgbahexWithOutSpace)).toBe('#ff000080');
         expect(convertToRgb(hex)).toBe('#ff0000');
     });
 

--- a/src/app/components/utils.tsx
+++ b/src/app/components/utils.tsx
@@ -54,7 +54,7 @@ export function convertToRgb(color: string) {
                     let alpha = '1';
                     if (matchesHex) {
                         ({r, g, b} = hexToRgb(matchesHex[0]));
-                        alpha = matchedColor.split(', ').pop();
+                        alpha = matchedColor.split(',').pop().trim();
                     } else {
                         [r, g, b, alpha = '1'] = matchedColor.split(',').map((n) => n.trim());
                     }

--- a/src/utils/aliases.tsx
+++ b/src/utils/aliases.tsx
@@ -2,7 +2,7 @@ import {checkAndEvaluateMath, convertToRgb} from '@/app/components/utils';
 import {SingleTokenObject} from 'Types/tokens';
 import checkIfValueToken from './checkIfValueToken';
 
-export const aliasRegex = /(\$[^\s]+\w)|({[^\s]+})/g;
+export const aliasRegex = /(\$[^\s,]+\w)|({[^\s]+})/g;
 
 export function getAliasValue(token: SingleTokenObject, tokens = []): string | null {
     try {


### PR DESCRIPTION
Currently only this is valid `rgba($brand.primary, 0.5)` and this won't work `rgba($brand.primary,0.5)`.

This PR fixes this issue, because a token name should never contain a `,`
![before](https://user-images.githubusercontent.com/3016302/131095652-7d1a2598-08e9-4f2c-8e2d-81f549b2ebed.png)
![after](https://user-images.githubusercontent.com/3016302/131095654-9c5fc15b-0d40-43fa-bded-efc6869c0c1b.png)
