### PR TITLE
Reordering boxShadow values

### DIFF
--- a/src/config/tokenTypes.js
+++ b/src/config/tokenTypes.js
@@ -72,9 +72,9 @@ export default {
             value: {
                 x: '',
                 y: '',
+                blur: '',
                 spread: '',
                 color: '',
-                blur: '',
             },
         },
     },


### PR DESCRIPTION
Moved the blur key to between y and spread. If the edit token modal is pulling this index order to generate the fields, it will allow the user to input values in the same sequence as [CSS syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow#values) of "box-shadow: h-offset v-offset blur spread color;". This will also match the tab order of Figma's drop shadow values.