### PR TITLE
renaming tokens now replaces references

### DIFF
--- a/src/app/components/EditTokenForm.tsx
+++ b/src/app/components/EditTokenForm.tsx
@@ -12,6 +12,8 @@ const EditTokenForm = () => {
     const dispatch = useDispatch<Dispatch>();
     const [currentEditToken, setCurrentEditToken] = React.useState(editToken);
 
+    const isValid = currentEditToken.value && currentEditToken.name.match(/^\S*$/);
+
     const handleChange = (e) => {
         e.persist();
         setCurrentEditToken({...currentEditToken, [e.target.name]: e.target.value});
@@ -64,8 +66,10 @@ const EditTokenForm = () => {
 
     const handleSubmit = (e) => {
         e.preventDefault();
-        submitTokenValue(currentEditToken);
-        dispatch.uiState.setShowEditForm(false);
+        if (isValid) {
+            submitTokenValue(currentEditToken);
+            dispatch.uiState.setShowEditForm(false);
+        }
     };
 
     const handleReset = () => {
@@ -139,7 +143,7 @@ const EditTokenForm = () => {
                 <button className="button button-link" type="button" onClick={handleReset}>
                     Cancel
                 </button>
-                <button disabled={!currentEditToken.value} className="button button-primary" type="submit">
+                <button disabled={!isValid} className="button button-primary" type="submit">
                     {currentEditToken.isPristine ? 'Create' : 'Update'}
                 </button>
             </div>

--- a/src/app/store/models/tokenState.test.ts
+++ b/src/app/store/models/tokenState.test.ts
@@ -1,0 +1,81 @@
+import {init} from '@rematch/core';
+import {models, RootModel} from './index';
+
+describe('editToken', () => {
+    let store;
+    beforeEach(() => {
+        store = init<RootModel>({
+            redux: {
+                initialState: {
+                    tokenState: {
+                        tokens: {
+                            global: [
+                                {
+                                    name: 'primary',
+                                    value: '1',
+                                },
+                                {
+                                    name: 'alias',
+                                    value: '$primary',
+                                },
+                                {
+                                    name: 'primary50',
+                                    value: '0.50',
+                                },
+                                {
+                                    name: 'alias50',
+                                    value: '$primary50',
+                                },
+                            ],
+                            options: [
+                                {
+                                    name: 'background',
+                                    value: '$primary',
+                                },
+                            ],
+                        },
+                        usedTokenSet: ['global'],
+                    },
+                },
+            },
+            models,
+        });
+    });
+
+    it('calls updateAliases if old name differs from new name', async () => {
+        await store.dispatch.tokenState.editToken({
+            parent: 'global',
+            oldName: 'primary',
+            name: 'brand.primary',
+            value: '1',
+        });
+
+        const {tokens} = store.getState().tokenState;
+        expect(tokens.global[1].value).toEqual('{brand.primary}');
+    });
+
+    it('doesnt interfere with tokens that have a similar name', async () => {
+        await store.dispatch.tokenState.editToken({
+            parent: 'global',
+            oldName: 'primary',
+            name: 'secondary',
+            value: '1',
+        });
+
+        const {tokens} = store.getState().tokenState;
+        expect(tokens.global[1].value).toEqual('{secondary}');
+        expect(tokens.global[3].value).toEqual('$primary50');
+    });
+
+    it('also updates tokens from other sets', async () => {
+        await store.dispatch.tokenState.editToken({
+            parent: 'global',
+            oldName: 'primary',
+            name: 'secondary',
+            value: '1',
+        });
+
+        const {tokens} = store.getState().tokenState;
+        expect(tokens.options[0].value).toEqual('{secondary}');
+    });
+});

--- a/src/app/store/models/tokenState.tsx
+++ b/src/app/store/models/tokenState.tsx
@@ -7,6 +7,7 @@ import defaultJSON from '@/config/default.json';
 import parseTokenValues from '@/utils/parseTokenValues';
 import {notifyToUI} from '@/plugin/notifiers';
 import {reduceToValues} from '@/plugin/tokenHelpers';
+import {replaceReferences} from '@/utils/findReferences';
 import {RootModel} from '.';
 import updateTokensOnSources from '../updateSources';
 import * as pjs from '../../../../package.json';
@@ -263,6 +264,37 @@ export const tokenState = createModel<RootModel>()({
 
             return newState;
         },
+        updateAliases: (state, data: {oldName: string; newName: string}) => {
+            const newTokens = Object.entries(state.tokens).reduce(
+                (acc, [key, values]: [string, SingleTokenObject[]]) => {
+                    const newValues = values.map((token) => {
+                        if (typeof token.value === 'object') {
+                            return {
+                                ...token,
+                                value: Object.entries(token.value).reduce((a, [k, v]: [string, string]) => {
+                                    a[k] = replaceReferences(v, data.oldName, data.newName);
+                                    return a;
+                                }, {}),
+                            };
+                        }
+
+                        return {
+                            ...token,
+                            value: replaceReferences(token.value, data.oldName, data.newName),
+                        };
+                    });
+
+                    acc[key] = newValues;
+                    return acc;
+                },
+                {}
+            );
+
+            return {
+                ...state,
+                tokens: newTokens,
+            };
+        },
     },
     effects: (dispatch) => ({
         setDefaultTokens: (payload) => {
@@ -272,6 +304,10 @@ export const tokenState = createModel<RootModel>()({
             dispatch.tokenState.setTokenData({values: []});
         },
         editToken(payload, rootState) {
+            if (payload.oldName && payload.oldName !== payload.name) {
+                dispatch.tokenState.updateAliases({oldName: payload.oldName, newName: payload.name});
+            }
+
             if (payload.shouldUpdate && rootState.settings.updateOnChange) {
                 dispatch.tokenState.updateDocument();
             }

--- a/src/app/store/useTokens.tsx
+++ b/src/app/store/useTokens.tsx
@@ -2,7 +2,7 @@ import {postToFigma} from '@/plugin/notifiers';
 import {useSelector} from 'react-redux';
 import {MessageToPluginTypes} from 'Types/messages';
 import checkIfAlias from '@/utils/checkIfAlias';
-import {getAliasValue} from '@/utils/aliases';
+import getAliasValue from '@/utils/aliases';
 import {SingleTokenObject} from 'Types/tokens';
 import stringifyTokens from '@/utils/stringifyTokens';
 import formatTokens from '@/utils/formatTokens';

--- a/src/plugin/tokenHelpers.ts
+++ b/src/plugin/tokenHelpers.ts
@@ -1,5 +1,5 @@
 import {appendTypeToToken} from '@/app/components/createTokenObj';
-import {getAliasValue} from '@/utils/aliases';
+import getAliasValue from '@/utils/aliases';
 import checkIfAlias from '@/utils/checkIfAlias';
 import {SingleTokenObject} from 'Types/tokens';
 import {mergeDeep} from './helpers';

--- a/src/utils/aliases.tsx
+++ b/src/utils/aliases.tsx
@@ -1,14 +1,13 @@
 import {checkAndEvaluateMath, convertToRgb} from '@/app/components/utils';
 import {SingleTokenObject} from 'Types/tokens';
 import checkIfValueToken from './checkIfValueToken';
+import {findReferences} from './findReferences';
 
-export const aliasRegex = /(\$[^\s,]+\w)|({[^\s]+})/g;
-
-export function getAliasValue(token: SingleTokenObject, tokens = []): string | null {
+export default function getAliasValue(token: SingleTokenObject, tokens = []): string | null {
     try {
         let returnedValue = checkIfValueToken(token) ? (token.value as string) : (token as string);
 
-        const tokenReferences = returnedValue?.toString().match(aliasRegex);
+        const tokenReferences = findReferences(returnedValue);
         if (tokenReferences?.length > 0) {
             const resolvedReferences = tokenReferences.map((ref) => {
                 if (ref.length > 1) {
@@ -29,7 +28,7 @@ export function getAliasValue(token: SingleTokenObject, tokens = []): string | n
             }
         }
         if (typeof returnedValue !== 'undefined') {
-            if (!returnedValue.toString().match(aliasRegex)) {
+            if (!tokenReferences) {
                 return convertToRgb(checkAndEvaluateMath(returnedValue));
             }
             return returnedValue;

--- a/src/utils/checkIfAlias.tsx
+++ b/src/utils/checkIfAlias.tsx
@@ -1,5 +1,6 @@
 import {SingleTokenObject} from '@types/tokens';
-import {aliasRegex, getAliasValue} from './aliases';
+import getAliasValue from './aliases';
+import {aliasRegex} from './findReferences';
 
 // Checks if token is an alias token and if it has a valid reference
 export default function checkIfAlias(token: SingleTokenObject, allTokens = []): boolean {

--- a/src/utils/findReferences.test.ts
+++ b/src/utils/findReferences.test.ts
@@ -1,0 +1,58 @@
+import {findMatchingReferences, findReferences, replaceReferences} from './findReferences';
+
+describe('findReferences', () => {
+    it('returns references in a string', () => {
+        expect(findReferences('$colors.blue')).toEqual(['$colors.blue']);
+        expect(findReferences('{colors.blue}')).toEqual(['{colors.blue}']);
+        expect(findReferences('rgba({colors.blue})')).toEqual(['{colors.blue}']);
+        expect(findReferences('{colors.blue} * 2')).toEqual(['{colors.blue}']);
+        expect(findReferences('{colors.blue} * {colors.red}')).toEqual(['{colors.blue}', '{colors.red}']);
+    });
+});
+
+describe('findMatchingReferences', () => {
+    it('returns references in a string that match token name', () => {
+        expect(findMatchingReferences('$colors.blue', 'colors.blue')).toEqual(['$colors.blue']);
+        expect(findMatchingReferences('{colors.blue}', 'colors.blue')).toEqual(['{colors.blue}']);
+        expect(findMatchingReferences('rgba({colors.blue})', 'colors.blue')).toEqual(['{colors.blue}']);
+        expect(findMatchingReferences('{colors.blue} * 2', 'colors.blue')).toEqual(['{colors.blue}']);
+        expect(findMatchingReferences('{colors.blue} * {colors.red}', 'colors.blue')).toEqual(['{colors.blue}']);
+    });
+
+    it('returns empty if it doesnt match', () => {
+        expect(findMatchingReferences('$colors.blue', 'colors.red')).toEqual([]);
+        expect(findMatchingReferences('{colors.blue}', 'colors.red')).toEqual([]);
+        expect(findMatchingReferences('rgba({colors.blue})', 'colors.red')).toEqual([]);
+        expect(findMatchingReferences('{colors.blue} * 2', 'colors.red')).toEqual([]);
+        expect(findMatchingReferences('{colors.blue} * {colors.red}', 'colors.yellow')).toEqual([]);
+    });
+});
+
+describe('replaceReferences', () => {
+    it('replaces references with new name', () => {
+        expect(replaceReferences('{colors.blue}', 'colors.blue', 'colors.yellow')).toEqual('{colors.yellow}');
+        expect(replaceReferences('rgba({colors.blue})', 'colors.blue', 'colors.yellow')).toEqual(
+            'rgba({colors.yellow})'
+        );
+        expect(replaceReferences('{colors.blue} * 2', 'colors.blue', 'colors.yellow')).toEqual('{colors.yellow} * 2');
+        expect(replaceReferences('{colors.blue} * {colors.red}', 'colors.blue', 'colors.yellow')).toEqual(
+            '{colors.yellow} * {colors.red}'
+        );
+    });
+
+    it('replaces references with new name and changes alias syntax', () => {
+        expect(replaceReferences('$colors.blue', 'colors.blue', 'colors.yellow')).toEqual('{colors.yellow}');
+    });
+
+    it('doesnt replace anything if it doesnt match empty if it doesnt match', () => {
+        expect(replaceReferences('$colors.blue', 'colors.other', 'colors.yellow')).toEqual('$colors.blue');
+        expect(replaceReferences('{colors.blue}', 'colors.other', 'colors.yellow')).toEqual('{colors.blue}');
+        expect(replaceReferences('rgba({colors.blue})', 'colors.other', 'colors.yellow')).toEqual(
+            'rgba({colors.blue})'
+        );
+        expect(replaceReferences('{colors.blue} * 2', 'colors.other', 'colors.yellow')).toEqual('{colors.blue} * 2');
+        expect(replaceReferences('{colors.blue} * {colors.red}', 'colors.other', 'colors.yellow')).toEqual(
+            '{colors.blue} * {colors.red}'
+        );
+    });
+});

--- a/src/utils/findReferences.tsx
+++ b/src/utils/findReferences.tsx
@@ -1,0 +1,28 @@
+export const aliasRegex = /(\$[^\s,]+\w)|({[^\s]+})/g;
+
+export const findReferences = (tokenValue: string) => {
+    return tokenValue?.toString().match(aliasRegex);
+};
+
+export const findMatchingReferences = (tokenValue: string, valueToLookFor: string) => {
+    const references = findReferences(tokenValue);
+
+    if (references) {
+        return references.filter((ref) => {
+            const name = ref.startsWith('{') ? ref.slice(1, ref.length - 1) : ref.substring(1);
+            if (name === valueToLookFor) return ref;
+        });
+    }
+};
+
+export const replaceReferences = (tokenValue: string, oldName: string, newName: string) => {
+    if (tokenValue.includes(oldName)) {
+        const references = findMatchingReferences(tokenValue, oldName);
+        let newValue = tokenValue;
+        references.forEach((reference) => {
+            newValue = newValue.replace(reference, `{${newName}}`);
+        });
+        return newValue;
+    }
+    return tokenValue;
+};

--- a/src/utils/findReferences.tsx
+++ b/src/utils/findReferences.tsx
@@ -13,6 +13,7 @@ export const findMatchingReferences = (tokenValue: string, valueToLookFor: strin
             if (name === valueToLookFor) return ref;
         });
     }
+    return [];
 };
 
 export const replaceReferences = (tokenValue: string, oldName: string, newName: string) => {


### PR DESCRIPTION
Before, when you renamed a token that was being referenced, nothing would change and references would break.

With this PR, any reference to that token will be changed to the new reference. It will also change the alias style to `{name}`, because this will be the preferred way to declare aliases from now on (much safer).

Also, this PR adds checks to editing tokens that names cannot contain spaces.