### PR TITLE
Share tokens with other plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ cypress/videos
 .env
 .env.production
 package
+.idea

--- a/src/plugin/pluginData.ts
+++ b/src/plugin/pluginData.ts
@@ -101,16 +101,19 @@ export function removePluginData(nodes, key?) {
         } finally {
             if (key) {
                 node.setPluginData(key, '');
+                node.setSharedPluginData('tokens', key, '');
                 // TODO: Introduce setting asking user if values should be removed?
                 removeValuesFromNode(node, key);
             } else {
                 Object.keys(properties).forEach((prop) => {
                     node.setPluginData(prop, '');
+                    node.setSharedPluginData('tokens', prop, '');
                     // TODO: Introduce setting asking user if values should be removed?
                     removeValuesFromNode(node, prop);
                 });
             }
             node.setPluginData('values', '');
+            node.setSharedPluginData('tokens', 'values', '');
             store.successfulNodes.push(node);
         }
     });
@@ -129,14 +132,19 @@ export function updatePluginData(nodes, values) {
                 // Pre-Version 53 had horizontalPadding and verticalPadding.
                 case 'horizontalPadding':
                     node.setPluginData('paddingLeft', JSON.stringify(value));
+                    node.setSharedPluginData('tokens', 'paddingLeft', JSON.stringify(value));
                     node.setPluginData('paddingRight', JSON.stringify(value));
+                    node.setSharedPluginData('tokens', 'paddingRight', JSON.stringify(value));
                     break;
                 case 'verticalPadding':
                     node.setPluginData('paddingTop', JSON.stringify(value));
+                    node.setSharedPluginData('tokens', 'paddingTop', JSON.stringify(value));
                     node.setPluginData('paddingBottom', JSON.stringify(value));
+                    node.setSharedPluginData('tokens', 'paddingBottom', JSON.stringify(value));
                     break;
                 default:
                     node.setPluginData(key, JSON.stringify(value));
+                    node.setSharedPluginData('tokens', key, JSON.stringify(value));
                     break;
             }
         });
@@ -160,6 +168,7 @@ export function updatePluginData(nodes, values) {
             }
         } finally {
             node.setPluginData('values', '');
+            node.setSharedPluginData('tokens', 'values', '');
         }
     });
 }


### PR DESCRIPTION
# Overview
This contribution introduces storing information about tokens used for specific layers in shared plugins space, so other plugins would use it.

# Motivation
Developers need to know, where to use which token. One of possibilities to solve this is to let them inspect tokens in Figma. This however creates risk of corruption of Design Tokens, for example by mistakenly changing their structure, or values.

## Inspecting token values
That's why I created this dead simple inspector plugin (https://github.com/jhajduk-sage/figma-tokens-inspector) for tokens applied with Figma Tokens plugin. To make it work, design tokens information are needed to be stored in shared 'tokens' space.

I decided to add `setSharedlugnData` next to `setPluginData` (and not instead of) to be sure, that any accidental changes to the shared plugin data won't crash Figma Tokens Plugin.

## Other plugins
This shared data can also be used in other plugins for example to generate Design Token usage documentation. Together with tokens list which is already stored in shared space, this can introduce whole lot of possibilities.