### PR TITLE
Url sync & UI Polish

### DIFF
--- a/src/app/components/App.tsx
+++ b/src/app/components/App.tsx
@@ -20,7 +20,7 @@ const App = () => {
     const activeTab = useSelector((state: RootState) => state.uiState.activeTab);
 
     return (
-        <>
+        <div className="content">
             <Initiator />
             <LoadingBar />
             <div className="h-full flex flex-col">
@@ -39,7 +39,7 @@ const App = () => {
                 <ConfirmDialog />
                 <WindowResizer />
             </div>
-        </>
+        </div>
     );
 };
 

--- a/src/app/components/App.tsx
+++ b/src/app/components/App.tsx
@@ -14,6 +14,7 @@ import Changelog from './Changelog';
 import ImportedTokensDialog from './ImportedTokensDialog';
 import {RootState} from '../store';
 import ConfirmDialog from './ConfirmDialog';
+import WindowResizer from './WindowResizer';
 
 const App = () => {
     const activeTab = useSelector((state: RootState) => state.uiState.activeTab);
@@ -36,6 +37,7 @@ const App = () => {
                 <Changelog />
                 <ImportedTokensDialog />
                 <ConfirmDialog />
+                <WindowResizer />
             </div>
         </>
     );

--- a/src/app/components/JSONEditor.tsx
+++ b/src/app/components/JSONEditor.tsx
@@ -18,7 +18,6 @@ const JSONEditor = () => {
     const {getStringTokens} = useTokens();
     const {confirm} = useConfirm();
 
-    const [confirmModalVisible, showConfirmModal] = React.useState('');
     const [exportModalVisible, showExportModal] = React.useState(false);
     const [presetModalVisible, showPresetModal] = React.useState(false);
     const [error, setError] = React.useState(null);

--- a/src/app/components/MoreButton.tsx
+++ b/src/app/components/MoreButton.tsx
@@ -52,9 +52,11 @@ const MoreButton = ({properties, children, path, value, onClick, onEdit, onDelet
     const visibleProperties = properties.filter((p) => p.label);
 
     return (
-        <div className="w-full">
+        <>
             <ContextMenu>
-                <ContextMenuTrigger id={`${path}-${value}`}>{children}</ContextMenuTrigger>
+                <ContextMenuTrigger as="div" id={`${path}-${value}`}>
+                    {children}
+                </ContextMenuTrigger>
                 <ContextMenuContent sideOffset={5} align="end" collisionTolerance={30}>
                     {visibleProperties.map((property) => {
                         const isActive = selectionValues[property.name] === value;
@@ -104,7 +106,7 @@ const MoreButton = ({properties, children, path, value, onClick, onEdit, onDelet
                     </ContextMenuItem>
                 </ContextMenuContent>
             </ContextMenu>
-        </div>
+        </>
     );
 };
 

--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -36,6 +36,8 @@ const transformProviderName = (provider) => {
     switch (provider) {
         case StorageProviderType.JSONBIN:
             return 'JSONBin.io';
+        case StorageProviderType.URL:
+            return 'URL';
         case StorageProviderType.ARCADE:
             return 'Arcade';
         default:

--- a/src/app/components/Settings.tsx
+++ b/src/app/components/Settings.tsx
@@ -1,30 +1,13 @@
 /* eslint-disable jsx-a11y/label-has-associated-control */
 import * as React from 'react';
 import {useDispatch, useSelector} from 'react-redux';
-import {useDebouncedCallback} from 'use-debounce';
 import Checkbox from './Checkbox';
 import Heading from './Heading';
 import {RootState, Dispatch} from '../store';
-import Input from './Input';
 
 const SyncSettings = () => {
-    const {uiWindow, ignoreFirstPartForStyles} = useSelector((state: RootState) => state.settings);
+    const {ignoreFirstPartForStyles} = useSelector((state: RootState) => state.settings);
     const dispatch = useDispatch<Dispatch>();
-
-    const debouncedChange = useDebouncedCallback(() => {
-        dispatch.settings.triggerWindowChange();
-    }, 1000);
-
-    const handleSizeChange = (e) => {
-        const value = Number(e.target.value.trim());
-        if (!Number.isNaN(value)) {
-            dispatch.settings.setWindowSize({
-                ...uiWindow,
-                [e.target.name]: value,
-            });
-            debouncedChange();
-        }
-    };
 
     const handleIgnoreChange = (bool) => {
         dispatch.settings.setIgnoreFirstPartForStyles(bool);
@@ -33,29 +16,6 @@ const SyncSettings = () => {
     return (
         <div className="flex flex-col flex-grow">
             <div className="p-4 space-y-4 border-b">
-                <div className="space-y-4">
-                    <Heading>Window size</Heading>
-                    <div className="flex flex-row space-x-2">
-                        <Input
-                            full
-                            label="Width"
-                            value={uiWindow.width}
-                            onChange={handleSizeChange}
-                            type="text"
-                            name="width"
-                            required
-                        />
-                        <Input
-                            full
-                            label="Height"
-                            value={uiWindow.height}
-                            onChange={handleSizeChange}
-                            type="text"
-                            name="height"
-                            required
-                        />
-                    </div>
-                </div>
                 <div className="space-y-4">
                     <Heading>Styles</Heading>
                     <div className="space-y-2">

--- a/src/app/components/StorageItem.tsx
+++ b/src/app/components/StorageItem.tsx
@@ -36,7 +36,7 @@ const StorageItem = ({item, onEdit = null}) => {
                     </button>
                 )}
             </div>
-            <div className="space-x-2">
+            <div className="space-x-2 flex-nowrap">
                 {onEdit && (
                     <Button id="button-storageitem-edit" variant="secondary" onClick={onEdit}>
                         Edit

--- a/src/app/components/StorageItemForm.tsx
+++ b/src/app/components/StorageItemForm.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import {useSelector} from 'react-redux';
-import {StorageProviderType} from '../../../types/api';
-import Button from './Button';
-import Input from './Input';
+import {StorageProviderType} from 'Types/api';
 import {RootState} from '../store';
+import JSONBinForm from './StorageItemForm/JSONBinForm';
+import URLForm from './StorageItemForm/URLForm';
 
 export default function EditStorageItemForm({
     isNew = false,
@@ -15,41 +15,29 @@ export default function EditStorageItemForm({
 }) {
     const {localApiState} = useSelector((state: RootState) => state.uiState);
 
-    return (
-        <form onSubmit={handleSubmit} className="space-y-4">
-            <Input full label="Name" value={values.name} onChange={handleChange} type="text" name="name" required />
-            <Input
-                full
-                label="Secret"
-                value={values.secret}
-                onChange={handleChange}
-                type="text"
-                name="secret"
-                required
-            />
-            <Input
-                full
-                label={`ID${localApiState.provider === StorageProviderType.JSONBIN ? ' (optional)' : ''}`}
-                value={values.id}
-                onChange={handleChange}
-                type="text"
-                name="id"
-                required={isNew ? localApiState.provider !== StorageProviderType.JSONBIN : true}
-            />
-            <div className="space-x-4">
-                <Button variant="secondary" size="large" onClick={handleCancel}>
-                    Cancel
-                </Button>
-
-                <Button variant="primary" type="submit" disabled={!values.secret && !values.name}>
-                    Save
-                </Button>
-            </div>
-            {hasErrored && (
-                <div className="bg-red-200 text-red-700 rounded p-4 text-xs font-bold" data-cy="provider-modal-error">
-                    There was an error connecting. Check your credentials.
-                </div>
-            )}
-        </form>
-    );
+    switch (localApiState.provider) {
+        case StorageProviderType.URL: {
+            return (
+                <URLForm
+                    handleChange={handleChange}
+                    handleSubmit={handleSubmit}
+                    handleCancel={handleCancel}
+                    values={values}
+                    hasErrored={hasErrored}
+                />
+            );
+        }
+        default: {
+            return (
+                <JSONBinForm
+                    isNew={isNew}
+                    handleChange={handleChange}
+                    handleSubmit={handleSubmit}
+                    handleCancel={handleCancel}
+                    values={values}
+                    hasErrored={hasErrored}
+                />
+            );
+        }
+    }
 }

--- a/src/app/components/StorageItemForm/JSONBinForm.tsx
+++ b/src/app/components/StorageItemForm/JSONBinForm.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import Button from '../Button';
+import Input from '../Input';
+
+export default function JSONBinForm({isNew = false, handleChange, handleSubmit, handleCancel, values, hasErrored}) {
+    return (
+        <form onSubmit={handleSubmit} className="space-y-4">
+            <Input full label="Name" value={values.name} onChange={handleChange} type="text" name="name" required />
+            <Input
+                full
+                label="Secret"
+                value={values.secret}
+                onChange={handleChange}
+                type="text"
+                name="secret"
+                required
+            />
+            <Input
+                full
+                label={`ID${isNew ? ' (optional)' : ''}`}
+                value={values.id}
+                onChange={handleChange}
+                type="text"
+                name="id"
+                required={!isNew}
+            />
+            <div className="space-x-4">
+                <Button variant="secondary" size="large" onClick={handleCancel}>
+                    Cancel
+                </Button>
+
+                <Button variant="primary" type="submit" disabled={!values.secret && !values.name}>
+                    Save
+                </Button>
+            </div>
+            {hasErrored && (
+                <div className="bg-red-200 text-red-700 rounded p-4 text-xs font-bold" data-cy="provider-modal-error">
+                    There was an error connecting. Check your credentials.
+                </div>
+            )}
+        </form>
+    );
+}

--- a/src/app/components/StorageItemForm/URLForm.tsx
+++ b/src/app/components/StorageItemForm/URLForm.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import Button from '../Button';
+import Input from '../Input';
+
+export default function URLForm({handleChange, handleSubmit, handleCancel, values, hasErrored}) {
+    return (
+        <form onSubmit={handleSubmit} className="space-y-4">
+            <Input full label="Name" value={values.name} onChange={handleChange} type="text" name="name" required />
+            <Input full label="Authorization" value={values.secret} onChange={handleChange} type="text" name="secret" />
+            <Input full label="URL" value={values.id} onChange={handleChange} type="text" name="id" required />
+            <div className="space-x-4">
+                <Button variant="secondary" size="large" onClick={handleCancel}>
+                    Cancel
+                </Button>
+
+                <Button variant="primary" type="submit" disabled={!values.secret && !values.name}>
+                    Save
+                </Button>
+            </div>
+            {hasErrored && (
+                <div className="bg-red-200 text-red-700 rounded p-4 text-xs font-bold" data-cy="provider-modal-error">
+                    There was an error connecting. Check your credentials.
+                </div>
+            )}
+        </form>
+    );
+}

--- a/src/app/components/StorageItemForm/URLForm.tsx
+++ b/src/app/components/StorageItemForm/URLForm.tsx
@@ -6,7 +6,7 @@ export default function URLForm({handleChange, handleSubmit, handleCancel, value
     return (
         <form onSubmit={handleSubmit} className="space-y-4">
             <Input full label="Name" value={values.name} onChange={handleChange} type="text" name="name" required />
-            <Input full label="Authorization" value={values.secret} onChange={handleChange} type="text" name="secret" />
+            <Input full label="Headers" value={values.secret} onChange={handleChange} type="text" name="secret" />
             <Input full label="URL" value={values.id} onChange={handleChange} type="text" name="id" required />
             <div className="space-x-4">
                 <Button variant="secondary" size="large" onClick={handleCancel}>

--- a/src/app/components/SyncSettings.tsx
+++ b/src/app/components/SyncSettings.tsx
@@ -33,7 +33,7 @@ const SyncSettings = () => {
     };
 
     const selectedRemoteProvider = () => {
-        return [StorageProviderType.JSONBIN, StorageProviderType.ARCADE].includes(
+        return [StorageProviderType.JSONBIN, StorageProviderType.URL, StorageProviderType.ARCADE].includes(
             localApiState?.provider as StorageProviderType
         );
     };
@@ -63,6 +63,8 @@ const SyncSettings = () => {
                         </a>
                     </div>
                 );
+            case StorageProviderType.URL:
+                return <div>Sync with a JSON stored on an external URL. This mode only allows Read Only.</div>;
             case StorageProviderType.ARCADE:
                 return (
                     <div>
@@ -123,6 +125,20 @@ const SyncSettings = () => {
                             }
                             text="Local document"
                             id={StorageProviderType.LOCAL}
+                        />
+                        <ProviderSelector
+                            isActive={localApiState?.provider === StorageProviderType.URL}
+                            isStored={storageType?.provider === StorageProviderType.URL}
+                            onClick={() => {
+                                dispatch.uiState.setLocalApiState({
+                                    name: '',
+                                    secret: '',
+                                    id: '',
+                                    provider: StorageProviderType.URL,
+                                });
+                            }}
+                            text="URL"
+                            id={StorageProviderType.URL}
                         />
                         <ProviderSelector
                             isActive={localApiState?.provider === StorageProviderType.JSONBIN}

--- a/src/app/components/TokenButton.tsx
+++ b/src/app/components/TokenButton.tsx
@@ -169,7 +169,7 @@ const TokenButton = ({
 
     return (
         <div
-            className={`relative mb-1 mr-1 flex button button-property ${buttonClass.join(' ')} ${
+            className={`relative mb-1 mr-1 button button-property ${buttonClass.join(' ')} ${
                 uiState.disabled && 'button-disabled'
             } `}
             style={style}

--- a/src/app/components/TokenListing.tsx
+++ b/src/app/components/TokenListing.tsx
@@ -105,7 +105,7 @@ const TokenListing = ({
                     </Tooltip>
                     <Heading size="small">{label}</Heading>
                 </button>
-                <div className="absolute right-0 mr-2">
+                <div className="flex absolute right-0 mr-2">
                     {showDisplayToggle && (
                         <Tooltip label={displayType === 'GRID' ? 'Show as List' : 'Show as Grid'}>
                             <button

--- a/src/app/components/TokenTooltip.tsx
+++ b/src/app/components/TokenTooltip.tsx
@@ -15,10 +15,10 @@ export default function TokenTooltip({token, resolvedTokens, shouldResolve = fal
             }
             return (
                 <div>
-                    <div>Font: {valueToCheck.fontFamily}</div>
-                    <div>Weight: {valueToCheck.fontWeight}</div>
-                    <div>Leading: {valueToCheck.lineHeight}</div>
-                    <div>Tracking: {valueToCheck.lineHeight}</div>
+                    <div>Font: {valueToCheck.fontFamily?.value || valueToCheck.fontFamily}</div>
+                    <div>Weight: {valueToCheck.fontWeight?.value || valueToCheck.fontWeight}</div>
+                    <div>Leading: {valueToCheck.lineHeight?.value || valueToCheck.lineHeight}</div>
+                    <div>Tracking: {valueToCheck.lineHeight?.value || valueToCheck.lineHeight}</div>
                 </div>
             );
         }

--- a/src/app/components/Tooltip.tsx
+++ b/src/app/components/Tooltip.tsx
@@ -33,7 +33,7 @@ export default ({
     side?: 'left' | 'bottom';
 }) => (
     <Tooltip.Root delayDuration={0}>
-        <Tooltip.Trigger as="span">{children}</Tooltip.Trigger>
+        <Tooltip.Trigger as="div">{children}</Tooltip.Trigger>
         <StyledContent side={side}>
             <StyledArrow offset={10} />
             {label}

--- a/src/app/components/WindowResizer.tsx
+++ b/src/app/components/WindowResizer.tsx
@@ -10,7 +10,6 @@ export default function WindowResizer() {
     const cornerRef = React.useRef<HTMLDivElement>(null);
 
     const handleSizeChange = (e) => {
-        console.log('Moving', e);
         const size = {
             width: Math.max(300, Math.floor(e.clientX + 5)),
             height: Math.max(200, Math.floor(e.clientY + 5)),
@@ -21,14 +20,10 @@ export default function WindowResizer() {
     };
 
     const onDown = (e) => {
-        console.log('Down', e);
-
         cornerRef.current.onpointermove = handleSizeChange;
         cornerRef.current.setPointerCapture(e.pointerId);
     };
     const onUp = (e) => {
-        console.log('|Up', e);
-
         cornerRef.current.onpointermove = null;
         cornerRef.current.releasePointerCapture(e.pointerId);
         dispatch.settings.triggerWindowChange();

--- a/src/app/components/WindowResizer.tsx
+++ b/src/app/components/WindowResizer.tsx
@@ -1,0 +1,41 @@
+/* eslint-disable jsx-a11y/label-has-associated-control */
+import * as React from 'react';
+import {useDispatch} from 'react-redux';
+import {Dispatch} from '../store';
+import IconResizeWindow from './icons/IconResizeWindow';
+
+export default function WindowResizer() {
+    const dispatch = useDispatch<Dispatch>();
+
+    const cornerRef = React.useRef<HTMLDivElement>(null);
+
+    const handleSizeChange = (e) => {
+        console.log('Moving', e);
+        const size = {
+            width: Math.max(300, Math.floor(e.clientX + 5)),
+            height: Math.max(200, Math.floor(e.clientY + 5)),
+        };
+        dispatch.settings.setWindowSize({
+            ...size,
+        });
+    };
+
+    const onDown = (e) => {
+        console.log('Down', e);
+
+        cornerRef.current.onpointermove = handleSizeChange;
+        cornerRef.current.setPointerCapture(e.pointerId);
+    };
+    const onUp = (e) => {
+        console.log('|Up', e);
+
+        cornerRef.current.onpointermove = null;
+        cornerRef.current.releasePointerCapture(e.pointerId);
+        dispatch.settings.triggerWindowChange();
+    };
+    return (
+        <div id="corner" onPointerDown={onDown} onPointerUp={onUp} ref={cornerRef}>
+            <IconResizeWindow />
+        </div>
+    );
+}

--- a/src/app/components/icons/IconResizeWindow.tsx
+++ b/src/app/components/icons/IconResizeWindow.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+const IconResizeWindow = () => (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M16 0V16H0L16 0Z" fill="white" />
+        <path d="M6.22577 16H3L16 3V6.22576L6.22577 16Z" fill="#8C8C8C" />
+        <path d="M11.8602 16H8.63441L16 8.63441V11.8602L11.8602 16Z" fill="#8C8C8C" />
+    </svg>
+);
+
+export default IconResizeWindow;

--- a/src/app/store/models/settings.tsx
+++ b/src/app/store/models/settings.tsx
@@ -1,8 +1,8 @@
 /* eslint-disable import/prefer-default-export */
-import {postToFigma} from '@/plugin/notifiers';
+import {postToFigma, postToUI} from '@/plugin/notifiers';
 import {track} from '@/utils/analytics';
 import {createModel} from '@rematch/core';
-import {MessageToPluginTypes} from 'Types/messages';
+import {MessageFromPluginTypes, MessageToPluginTypes} from 'Types/messages';
 import {UpdateMode} from 'Types/state';
 import {RootModel} from '.';
 
@@ -102,6 +102,13 @@ export const settings = createModel<RootModel>()({
         },
     },
     effects: (dispatch) => ({
+        setWindowSize: (payload, rootState) => {
+            postToFigma({
+                type: MessageToPluginTypes.RESIZE_WINDOW,
+                width: payload.width,
+                height: payload.height,
+            });
+        },
         setUpdateStyles: (payload, rootState) => {
             setUI(rootState.settings);
         },

--- a/src/app/store/models/tokenState.tsx
+++ b/src/app/store/models/tokenState.tsx
@@ -63,6 +63,12 @@ export const tokenState = createModel<RootModel>()({
         editProhibited: false,
     } as TokenState,
     reducers: {
+        setEditProhibited(state, payload: boolean) {
+            return {
+                ...state,
+                editProhibited: payload,
+            };
+        },
         toggleUsedTokenSet: (state, data: string) => {
             return {
                 ...state,
@@ -340,6 +346,7 @@ export const tokenState = createModel<RootModel>()({
                 dispatch.tokenState.updateDocument();
             }
         },
+
         toggleUsedTokenSet(payload, rootState) {
             dispatch.tokenState.updateDocument({updateRemote: false});
         },
@@ -360,7 +367,7 @@ export const tokenState = createModel<RootModel>()({
                     updatedAt: new Date().toString(),
                     lastUpdatedAt: rootState.uiState.lastUpdatedAt,
                     isLocal: rootState.uiState.storageType.provider === StorageProviderType.LOCAL,
-                    editProhibited: rootState.uiState.editProhibited,
+                    editProhibited: rootState.tokenState.editProhibited,
                     api: rootState.uiState.api,
                     storageType: rootState.uiState.storageType,
                     shouldUpdateRemote: params.updateRemote && rootState.settings.updateRemote,

--- a/src/app/store/models/uiState.tsx
+++ b/src/app/store/models/uiState.tsx
@@ -37,7 +37,6 @@ interface UIState {
     loading: boolean;
     activeTab: TabNames;
     projectURL: string;
-    editProhibited: boolean;
     storageType: StorageType;
     api: ApiDataType;
     apiProviders: ApiDataType[];
@@ -64,7 +63,6 @@ export const uiState = createModel<RootModel>()({
         loading: false,
         activeTab: 'start',
         projectURL: '',
-        editProhibited: false,
         storageType: {
             provider: StorageProviderType.LOCAL,
         },
@@ -164,17 +162,10 @@ export const uiState = createModel<RootModel>()({
                 projectURL: payload,
             };
         },
-        setEditProhibited(state, payload: boolean) {
-            return {
-                ...state,
-                editProhibited: payload,
-            };
-        },
         setStorage(state, payload: StorageType) {
             return {
                 ...state,
                 storageType: payload,
-                editProhibited: false,
             };
         },
         setApiData(state, payload: ApiDataType) {

--- a/src/app/store/providers/url.tsx
+++ b/src/app/store/providers/url.tsx
@@ -1,0 +1,65 @@
+import {useDispatch} from 'react-redux';
+import {Dispatch} from '@/app/store';
+import {StorageProviderType} from 'Types/api';
+import {MessageToPluginTypes} from 'Types/messages';
+import {TokenProps} from 'Types/tokens';
+import {notifyToUI, postToFigma} from '../../../plugin/notifiers';
+
+async function readTokensFromURL({secret, id}): Promise<TokenProps> | null {
+    const response = await fetch(id, {
+        method: 'GET',
+        headers: {
+            Authorization: secret,
+            Accept: 'application/json',
+        },
+    });
+
+    if (response.ok) {
+        const data = await response.json();
+        return data;
+    }
+    notifyToUI('There was an error connecting, check your sync settings');
+    return null;
+}
+
+export default function useURL() {
+    const dispatch = useDispatch<Dispatch>();
+
+    // Read tokens from URL
+    async function pullTokensFromURL(context): Promise<TokenProps> | null {
+        const {id, secret, name} = context;
+
+        if (!id && !secret) return;
+
+        try {
+            const data = await readTokensFromURL({id, secret});
+            dispatch.uiState.setProjectURL(id);
+
+            if (data) {
+                postToFigma({
+                    type: MessageToPluginTypes.CREDENTIALS,
+                    id,
+                    name,
+                    secret,
+                    provider: StorageProviderType.URL,
+                });
+                if (data) {
+                    const tokenObj = {
+                        values: data,
+                    };
+                    dispatch.tokenState.setTokenData(tokenObj);
+                    dispatch.tokenState.setEditProhibited(true);
+                    return tokenObj;
+                }
+
+                notifyToUI('No tokens stored on remote');
+            }
+        } catch (e) {
+            notifyToUI('Error fetching from URL, check console (F12)');
+            console.log('Error:', e);
+        }
+    }
+    return {
+        pullTokensFromURL,
+    };
+}

--- a/src/app/store/remoteTokens.tsx
+++ b/src/app/store/remoteTokens.tsx
@@ -3,6 +3,7 @@ import {StorageProviderType} from 'Types/api';
 import {MessageToPluginTypes} from 'Types/messages';
 import {postToFigma} from '../../plugin/notifiers';
 import {useJSONbin} from './providers/jsonbin';
+import useURL from './providers/url';
 import {Dispatch, RootState} from '../store';
 import useStorage from './useStorage';
 
@@ -12,6 +13,7 @@ export default function useRemoteTokens() {
 
     const {setStorageType} = useStorage();
     const {pullTokensFromJSONBin, addJSONBinCredentials, createNewJSONBin} = useJSONbin();
+    const {pullTokensFromURL} = useURL();
 
     const pullTokens = async (context = api) => {
         dispatch.uiState.setLoading(true);
@@ -21,6 +23,10 @@ export default function useRemoteTokens() {
         switch (context.provider) {
             case StorageProviderType.JSONBIN: {
                 tokenValues = await pullTokensFromJSONBin(context);
+                break;
+            }
+            case StorageProviderType.URL: {
+                tokenValues = await pullTokensFromURL(context);
                 break;
             }
             default:
@@ -51,6 +57,10 @@ export default function useRemoteTokens() {
                 } else {
                     data = await createNewJSONBin(context);
                 }
+                break;
+            }
+            case StorageProviderType.URL: {
+                data = await pullTokensFromURL(context);
                 break;
             }
             default:

--- a/src/app/store/useTokens.tsx
+++ b/src/app/store/useTokens.tsx
@@ -72,9 +72,13 @@ export default function useTokens() {
     // Calls Figma with all tokens to create styles
     function createStylesFromTokens() {
         const resolved = resolveTokenValues(computeMergedTokens(tokens, usedTokenSet));
+        const withoutIgnored = resolved.filter((token) => {
+            return !token.name.split('.').some((part) => part.startsWith('_'));
+        });
+
         postToFigma({
             type: MessageToPluginTypes.CREATE_STYLES,
-            tokens: resolved,
+            tokens: withoutIgnored,
             settings,
         });
     }

--- a/src/app/store/useTokens.tsx
+++ b/src/app/store/useTokens.tsx
@@ -23,7 +23,7 @@ export default function useTokens() {
 
     // Gets value of token
     function getTokenValue(token: SingleTokenObject, resolved) {
-        return getAliasValue(token, resolved);
+        return resolved.find((t) => t.name === token.name).value;
     }
 
     // Returns resolved value of a specific token

--- a/src/app/styles/tailwind.css
+++ b/src/app/styles/tailwind.css
@@ -473,4 +473,11 @@ form {
     border-radius: 50%;
 }
 
+#corner {
+    position: absolute;
+    right: 1px;
+    bottom: 2px;
+    cursor: nwse-resize;
+}
+
 @tailwind utilities;

--- a/src/app/styles/tailwind.css
+++ b/src/app/styles/tailwind.css
@@ -85,11 +85,13 @@
 
 body {
     @apply font-body text-sm leading-normal;
+}
 
+.content {
     overflow-y: scroll;
 }
 
-body::-webkit-scrollbar,
+.content::-webkit-scrollbar,
 .ReactModal__Content::-webkit-scrollbar,
 textarea::-webkit-scrollbar {
     width: 9px;
@@ -99,7 +101,7 @@ textarea::-webkit-scrollbar {
     height: 9px;
 }
 
-body::-webkit-scrollbar-thumb,
+.content::-webkit-scrollbar-thumb,
 .overflow-x-auto::-webkit-scrollbar-thumb,
 .ReactModal__Content::-webkit-scrollbar-thumb,
 textarea::-webkit-scrollbar-thumb {
@@ -474,7 +476,7 @@ form {
 }
 
 #corner {
-    position: absolute;
+    position: fixed;
     right: 1px;
     bottom: 2px;
     cursor: nwse-resize;

--- a/src/plugin/controller.ts
+++ b/src/plugin/controller.ts
@@ -57,6 +57,7 @@ figma.ui.onmessage = async (msg) => {
                 if (apiProviders) notifyAPIProviders(JSON.parse(apiProviders));
                 switch (storageType.provider) {
                     case StorageProviderType.JSONBIN:
+                    case StorageProviderType.URL:
                     case StorageProviderType.ARCADE: {
                         compareProvidersWithStored(apiProviders, storageType);
 
@@ -80,8 +81,8 @@ figma.ui.onmessage = async (msg) => {
             sendPluginValues(figma.currentPage.selection);
             return;
         case MessageToPluginTypes.CREDENTIALS: {
-            const {secret, id, provider, name} = msg;
-            updateCredentials({secret, id, name, provider});
+            const {type, ...context} = msg;
+            updateCredentials(context);
             break;
         }
         case MessageToPluginTypes.REMOVE_SINGLE_CREDENTIAL: {

--- a/src/plugin/controller.ts
+++ b/src/plugin/controller.ts
@@ -139,6 +139,9 @@ figma.ui.onmessage = async (msg) => {
         case MessageToPluginTypes.NOTIFY:
             notifyUI(msg.msg, msg.opts);
             break;
+        case MessageToPluginTypes.RESIZE_WINDOW:
+            figma.ui.resize(msg.width, msg.height);
+            break;
         case MessageToPluginTypes.SET_UI: {
             updateUISettings({
                 width: msg.uiWindow.width,

--- a/src/utils/convertTokens.tsx
+++ b/src/utils/convertTokens.tsx
@@ -3,13 +3,12 @@ import {isTypographyToken, isValueToken} from '../app/components/utils';
 
 function checkForTokens({
     obj,
-    originalToken,
+    token,
     root = null,
     returnValuesOnly = false,
     expandTypography = false,
 }): [SingleTokenObject[], SingleToken] {
     // replaces / in token name
-    const token = originalToken.name.split('/').join('.');
     let returnValue;
     const shouldExpandTypography = expandTypography ? isTypographyToken(token.value) : false;
     if (isValueToken(token) && !shouldExpandTypography) {
@@ -52,10 +51,14 @@ function checkForTokens({
         };
     }
 
+    if (returnValue?.name) {
+        returnValue.name = returnValue.name.split('/').join('.');
+    }
+
     return [obj, returnValue];
 }
 
 export default function convertToTokenArray({tokens, returnValuesOnly = false, expandTypography = false}) {
-    const [result] = checkForTokens({obj: [], originalToken: tokens, returnValuesOnly, expandTypography});
+    const [result] = checkForTokens({obj: [], token: tokens, returnValuesOnly, expandTypography});
     return Object.values(result);
 }

--- a/src/utils/convertTokens.tsx
+++ b/src/utils/convertTokens.tsx
@@ -3,11 +3,13 @@ import {isTypographyToken, isValueToken} from '../app/components/utils';
 
 function checkForTokens({
     obj,
-    token,
+    originalToken,
     root = null,
     returnValuesOnly = false,
     expandTypography = false,
 }): [SingleTokenObject[], SingleToken] {
+    // replaces / in token name
+    const token = originalToken.name.split('/').join('.');
     let returnValue;
     const shouldExpandTypography = expandTypography ? isTypographyToken(token.value) : false;
     if (isValueToken(token) && !shouldExpandTypography) {
@@ -54,6 +56,6 @@ function checkForTokens({
 }
 
 export default function convertToTokenArray({tokens, returnValuesOnly = false, expandTypography = false}) {
-    const [result] = checkForTokens({obj: [], token: tokens, returnValuesOnly, expandTypography});
+    const [result] = checkForTokens({obj: [], originalToken: tokens, returnValuesOnly, expandTypography});
     return Object.values(result);
 }

--- a/src/utils/convertTokensObjectToResolved.ts
+++ b/src/utils/convertTokensObjectToResolved.ts
@@ -3,7 +3,7 @@ import convertTokensToGroupedObject from './convertTokensToGroupedObject';
 import parseTokenValues from './parseTokenValues';
 
 // Takes Figma Tokens input, resolves all aliases while respecting user's theme choice and outputs an object with resolved tokens, ready to be consumed by style dictionary.
-export default function convertTokensObjectToResolved(tokens, usedSets = []) {
+export default function convertTokensObjectToResolved(tokens, usedSets = [], excludedSets = []) {
     // Parse tokens into array structure
     const parsed = parseTokenValues(tokens);
     // Merge to one giant array
@@ -11,6 +11,6 @@ export default function convertTokensObjectToResolved(tokens, usedSets = []) {
     // Resolve aliases
     const resolved = resolveTokenValues(merged);
     // Group back into one object
-    const object = convertTokensToGroupedObject(resolved);
+    const object = convertTokensToGroupedObject(resolved, excludedSets);
     return object;
 }

--- a/src/utils/convertTokensToGroupedObject.ts
+++ b/src/utils/convertTokensToGroupedObject.ts
@@ -1,9 +1,12 @@
 import {appendTypeToToken} from '@/app/components/createTokenObj';
 import set from 'set-value';
 
-export default function convertTokensToGroupedObject(tokens) {
+export default function convertTokensToGroupedObject(tokens, excludedSets) {
     let tokenObj = {};
     tokenObj = tokens.reduce((acc, token) => {
+        if (excludedSets.includes(token.internal__Parent)) {
+            return acc;
+        }
         const obj = acc || {};
         const tokenWithType = appendTypeToToken(token);
         delete tokenWithType.name;

--- a/src/utils/credentials.test.ts
+++ b/src/utils/credentials.test.ts
@@ -1,3 +1,4 @@
+import * as helpers from '@/plugin/helpers';
 import {StorageProviderType} from '../../types/api';
 import {removeSingleCredential, updateCredentials} from './credentials';
 
@@ -5,28 +6,60 @@ describe('updateCredentials', () => {
     afterEach(() => {
         jest.clearAllMocks();
     });
+    const generateIdSpy = jest.spyOn(helpers, 'generateId').mockImplementation(() => 'idMock');
+
+    // Mock id for test
+
     it('sets credentials when no credentials existed before', async () => {
-        const apiObject = {id: '123', secret: 'foo', name: 'mytokens', provider: StorageProviderType.ARCADE};
+        const apiObject = {id: '123', secret: 'foo', name: 'mytokens', provider: StorageProviderType.JSONBIN};
         figma.clientStorage.getAsync
             .mockResolvedValueOnce(undefined)
             .mockResolvedValueOnce(JSON.stringify([apiObject]));
         await updateCredentials(apiObject);
 
-        expect(figma.clientStorage.setAsync).toHaveBeenCalledWith('apiProviders', JSON.stringify([apiObject]));
+        expect(figma.clientStorage.setAsync).toHaveBeenCalledWith(
+            'apiProviders',
+            JSON.stringify([{...apiObject, internalId: 'idMock'}])
+        );
+        expect(generateIdSpy).toHaveBeenCalled();
     });
 
     it('updates credentials when there have been existing', async () => {
-        const apiArray = [{id: '123', secret: 'abc', name: 'mytokens', provider: StorageProviderType.ARCADE}];
-        const newObject = {id: '456', secret: 'foo', name: 'mytokens', provider: StorageProviderType.ARCADE};
-        const newArray = [...apiArray, newObject];
+        const apiArray = [{id: '123', secret: 'abc', name: 'mytokens', provider: StorageProviderType.JSONBIN}];
+        const newObject = {id: '456', secret: 'foo', name: 'mytokens', provider: StorageProviderType.JSONBIN};
+        const newArray = [
+            ...apiArray,
+            {
+                ...newObject,
+                internalId: 'idMock',
+            },
+        ];
+        figma.clientStorage.getAsync.mockResolvedValue(JSON.stringify(apiArray));
+        await updateCredentials(newObject);
+        expect(figma.clientStorage.setAsync).toHaveBeenCalledWith('apiProviders', JSON.stringify(newArray));
+        expect(generateIdSpy).toHaveBeenCalled();
+    });
+
+    it('merges credentials when there have been existing that match', async () => {
+        const apiArray = [{id: '123', secret: 'abc', name: 'mytokens', provider: StorageProviderType.JSONBIN}];
+        const newObject = {id: '123', secret: 'abc', name: 'my new name', provider: StorageProviderType.JSONBIN};
+        const newArray = [newObject];
         figma.clientStorage.getAsync.mockResolvedValue(JSON.stringify(apiArray));
         await updateCredentials(newObject);
         expect(figma.clientStorage.setAsync).toHaveBeenCalledWith('apiProviders', JSON.stringify(newArray));
     });
 
-    it('merges credentials when there have been existing that match', async () => {
-        const apiArray = [{id: '123', secret: 'abc', name: 'mytokens', provider: StorageProviderType.ARCADE}];
-        const newObject = {id: '123', secret: 'abc', name: 'my new name', provider: StorageProviderType.ARCADE};
+    it('merges credentials when there have been existing that match internalId', async () => {
+        const apiArray = [
+            {id: '123', internalId: 'abc', secret: 'abc', name: 'mytokens', provider: StorageProviderType.JSONBIN},
+        ];
+        const newObject = {
+            id: '456',
+            internalId: 'abc',
+            secret: 'abc',
+            name: 'my new name',
+            provider: StorageProviderType.JSONBIN,
+        };
         const newArray = [newObject];
         figma.clientStorage.getAsync.mockResolvedValue(JSON.stringify(apiArray));
         await updateCredentials(newObject);
@@ -39,7 +72,7 @@ describe('removeSingleCredential', () => {
         jest.clearAllMocks();
     });
     it('removes credential if found and only one entry existed', async () => {
-        const apiObject = {id: '123', secret: 'foo', name: 'mytokens', provider: StorageProviderType.ARCADE};
+        const apiObject = {id: '123', secret: 'foo', name: 'mytokens', provider: StorageProviderType.JSONBIN};
         const oldArray = [apiObject];
         figma.clientStorage.getAsync.mockResolvedValue(JSON.stringify(oldArray));
         await removeSingleCredential({secret: apiObject.secret, id: apiObject.id});
@@ -48,8 +81,8 @@ describe('removeSingleCredential', () => {
     });
 
     it('removes credential if found and multiple existed', async () => {
-        const apiObject = {id: '123', secret: 'foo', name: 'mytokens', provider: StorageProviderType.ARCADE};
-        const otherObject = {id: '456', secret: 'bar', name: 'mytokens', provider: StorageProviderType.ARCADE};
+        const apiObject = {id: '123', secret: 'foo', name: 'mytokens', provider: StorageProviderType.JSONBIN};
+        const otherObject = {id: '456', secret: 'bar', name: 'mytokens', provider: StorageProviderType.JSONBIN};
         const oldArray = [apiObject, otherObject];
         figma.clientStorage.getAsync.mockResolvedValueOnce(JSON.stringify(oldArray));
         await removeSingleCredential({id: otherObject.id, secret: otherObject.secret});

--- a/src/utils/parseTokenValues.ts
+++ b/src/utils/parseTokenValues.ts
@@ -1,7 +1,6 @@
 import convertToTokenArray from './convertTokens';
 
 export default function parseTokenValues(tokens) {
-    console.log('Parsing token values', tokens);
     // If we receive an array of tokens, move them all to the global set
     if (Array.isArray(tokens)) {
         return {

--- a/src/utils/transform.ts
+++ b/src/utils/transform.ts
@@ -1,7 +1,7 @@
 import convertTokensObjectToResolved from './convertTokensObjectToResolved';
 
-function transform(input, sets) {
-    return convertTokensObjectToResolved(input, sets);
+function transform(input, sets, excludes) {
+    return convertTokensObjectToResolved(input, sets, excludes);
 }
 
 export default transform;

--- a/src/utils/uiSettings.ts
+++ b/src/utils/uiSettings.ts
@@ -34,8 +34,8 @@ export async function getUISettings() {
                     ? false
                     : parsedData.ignoreFirstPartForStyles;
             notifyUISettings({
-                width,
-                height,
+                width: Math.max(300, width),
+                height: Math.max(200, height),
                 updateMode,
                 updateOnChange,
                 updateRemote,

--- a/token-transformer/README.md
+++ b/token-transformer/README.md
@@ -1,0 +1,17 @@
+# Token Transformer
+
+Converts tokens from Figma Tokens to something Style Dictionary can read, removing any math operations or aliases, only resulting in raw values.
+
+## How to use
+`npm run token-transformer input output sets excludes`
+
+`npm run token-transformer input.json output.json global,dark,components global`
+
+## Parameters
+Input: Filename of input
+
+Output: Filename of output
+
+Sets: Sets to be used, comma-seperated
+
+Excludes: Sets that should not be part of the export (e.g. a global color scale)

--- a/token-transformer/index.js
+++ b/token-transformer/index.js
@@ -13,7 +13,9 @@ function writeFile(path, contents, cb) {
 }
 
 function transform() {
-    const [input, output, ...sets] = process.argv.slice(2);
+    const [input, output, rawSets, rawExcludes] = process.argv.slice(2);
+    const sets = rawSets.split(',');
+    const excludes = rawExcludes ? rawExcludes.split(',') : [];
     if (!input) {
         process.stdout.write(`ERROR: Specify an input first (e.g. tokens.json)`);
 
@@ -29,9 +31,13 @@ function transform() {
     if (fs.existsSync(input)) {
         const tokens = fs.readFileSync(input, {encoding: 'utf8', flag: 'r'});
         const parsed = JSON.parse(tokens);
-        const transformed = transformTokens(parsed, sets);
+        const transformed = transformTokens(parsed, sets, excludes);
         writeFile(output, JSON.stringify(transformed, null, 2), () => {
-            process.stdout.write(`Transformed tokens from ${input} to ${output}, using sets ${sets.join(', ')}`);
+            process.stdout.write(
+                `Transformed tokens from ${input} to ${output}, using sets ${sets.join(', ')}${
+                    excludes.length > 0 ? `excluding ${excludes.join(', ')}` : ''
+                }`
+            );
         });
     } else {
         process.stdout.write(`ERROR: Input not found at ${input}`);

--- a/token-transformer/package.json
+++ b/token-transformer/package.json
@@ -1,13 +1,12 @@
 {
-    "name": "token-transformer",
-    "version": "0.0.9",
-    "description": "A utility that transforms tokens from Figma Tokens to a format that is readable by Style Dictionary.",
-    "main": "index.js",
-    "scripts": {
-      "test": "echo \"Error: no test specified\" && exit 1"
-    },
-    "author": "six7",
-    "license": "ISC",
-    "bin": "index.js"
-  }
-  
+  "name": "token-transformer",
+  "version": "0.0.12",
+  "description": "A utility that transforms tokens from Figma Tokens to a format that is readable by Style Dictionary.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "six7",
+  "license": "ISC",
+  "bin": "index.js"
+}

--- a/types/api.tsx
+++ b/types/api.tsx
@@ -16,8 +16,8 @@ export enum StorageProviderType {
     LOCAL = 'local',
     ARCADE = 'arcade',
     JSONBIN = 'jsonbin',
+    URL = 'url',
 }
-
 export interface ContextObject extends ApiDataType {
     secret: string;
     id: string;

--- a/types/messages.tsx
+++ b/types/messages.tsx
@@ -25,4 +25,5 @@ export enum MessageToPluginTypes {
     SET_STORAGE_TYPE = 'set-storage-type',
     NOTIFY = 'notify',
     SET_UI = 'set_ui',
+    RESIZE_WINDOW = 'resize_window',
 }


### PR DESCRIPTION
This PR adds:

- URL sync option (Add an external URL to sync as a Read Only user. You can also add a JSONBin and access it as a read only user provided you have the credentials) - fixes #251 
- Remove Resize Window from Options. You can now drag the bottom right corner of the plugin window to do that.
- You can now exclude tokens from being created as styles by having their names begin with a `_`, e.g. `colors.blue._hue` or whole groups by using `_global.blue.100` - fixes #264
- Token names that contain a `/` in it's name are now automatically transformed to names containing `.` instead. Fixes #274
- Fixed a bug with colors when displayed in list mode - fixes #275
- Fixed a bug with color thumbnails not being displayed correctly - fixes #266 
