### PR TITLE
Add Duplicate Token feature

### DIFF
--- a/src/app/components/MoreButton.tsx
+++ b/src/app/components/MoreButton.tsx
@@ -22,7 +22,7 @@ const RightSlot = styled('div', {
     '[data-disabled] &': {color: '$disabled'},
 });
 
-const MoreButton = ({properties, children, path, value, onClick, onEdit, onDelete}) => {
+const MoreButton = ({properties, children, path, value, onClick, onEdit, onDelete, onDuplicate}) => {
     const {selectionValues} = useSelector((state: RootState) => state.uiState);
     const {editProhibited} = useSelector((state: RootState) => state.tokenState);
 
@@ -98,6 +98,9 @@ const MoreButton = ({properties, children, path, value, onClick, onEdit, onDelet
 
                     <ContextMenuItem onSelect={onEdit} disabled={editProhibited}>
                         Edit Token
+                    </ContextMenuItem>
+                    <ContextMenuItem onSelect={onDuplicate} disabled={editProhibited}>
+                        Duplicate Token
                     </ContextMenuItem>
                     <ContextMenuItem onSelect={onDelete} disabled={editProhibited}>
                         Delete Token

--- a/src/app/components/TokenButton.tsx
+++ b/src/app/components/TokenButton.tsx
@@ -35,7 +35,7 @@ const TokenButton = ({
     const uiState = useSelector((state: RootState) => state.uiState);
     const {activeTokenSet} = useSelector((state: RootState) => state.tokenState);
     const {setNodeData, getTokenValue} = useTokens();
-    const {deleteSingleToken} = useManageTokens();
+    const {deleteSingleToken, duplicateSingleToken} = useManageTokens();
     const dispatch = useDispatch<Dispatch>();
     const {isAlias} = useTokens();
 
@@ -56,6 +56,9 @@ const TokenButton = ({
 
     const handleDeleteClick = () => {
         deleteSingleToken({parent: activeTokenSet, path: name});
+    };
+    const handleDuplicateClick = () => {
+        duplicateSingleToken({parent: activeTokenSet, name});
     };
 
     function setPluginValue(value) {
@@ -178,6 +181,7 @@ const TokenButton = ({
                 properties={properties}
                 onClick={onClick}
                 onDelete={handleDeleteClick}
+                onDuplicate={handleDuplicateClick}
                 onEdit={handleEditClick}
                 value={name}
                 path={name}

--- a/src/app/store/models/tokenState.tsx
+++ b/src/app/store/models/tokenState.tsx
@@ -178,6 +178,30 @@ export const tokenState = createModel<RootModel>()({
                 },
             };
         },
+        duplicateToken: (state, data: TokenInput) => {
+            let newTokens = {};
+            const existingToken = state.tokens[data.parent].find((n) => n.name === data.name);
+            if (existingToken) {
+                const newName = `${data.name}-copy`;
+
+                newTokens = {
+                    [data.parent]: [
+                        ...state.tokens[data.parent],
+                        {
+                            ...existingToken,
+                            name: newName,
+                        },
+                    ],
+                };
+            }
+            return {
+                ...state,
+                tokens: {
+                    ...state.tokens,
+                    ...newTokens,
+                },
+            };
+        },
         // Imports received styles as tokens, if needed
         setTokensFromStyles: (state, receivedStyles) => {
             const newTokens = [];
@@ -342,6 +366,11 @@ export const tokenState = createModel<RootModel>()({
         },
         toggleUsedTokenSet(payload, rootState) {
             dispatch.tokenState.updateDocument({updateRemote: false});
+        },
+        duplicateToken(payload, rootState) {
+            if (payload.shouldUpdate && rootState.settings.updateOnChange) {
+                dispatch.tokenState.updateDocument();
+            }
         },
         createToken(payload, rootState) {
             if (payload.shouldUpdate && rootState.settings.updateOnChange) {

--- a/src/app/store/useManageTokens.tsx
+++ b/src/app/store/useManageTokens.tsx
@@ -5,7 +5,7 @@ import useConfirm from '../hooks/useConfirm';
 
 export default function useManageTokens() {
     const {activeTokenSet} = useSelector((state: RootState) => state.tokenState);
-    const {editToken, createToken, deleteToken, deleteTokenGroup} = useDispatch<Dispatch>().tokenState;
+    const {editToken, createToken, deleteToken, duplicateToken, deleteTokenGroup} = useDispatch<Dispatch>().tokenState;
 
     const dispatch = useDispatch<Dispatch>();
     const {confirm} = useConfirm();
@@ -63,6 +63,12 @@ export default function useManageTokens() {
         dispatch.uiState.setLoading(false);
     }
 
+    async function duplicateSingleToken(data) {
+        dispatch.uiState.setLoading(true);
+        duplicateToken(data);
+        dispatch.uiState.setLoading(false);
+    }
+
     async function deleteSingleToken(data) {
         const userConfirmation = await confirm({
             text: 'Delete token?',
@@ -87,5 +93,5 @@ export default function useManageTokens() {
         }
     }
 
-    return {editSingleToken, createSingleToken, deleteSingleToken, deleteGroup};
+    return {editSingleToken, createSingleToken, deleteSingleToken, deleteGroup, duplicateSingleToken};
 }


### PR DESCRIPTION
This PR enables `Duplicate Token` in a tokens' context menu.

It will essentially copy that token and append `-copy` at the end.

Fixes #142 