### PR TITLE
Release 68

### DIFF
--- a/cypress/integration/tokens.spec.js
+++ b/cypress/integration/tokens.spec.js
@@ -159,4 +159,26 @@ describe('TokenListing', () => {
         cy.get('@postMessage').should('be.calledTwice');
         receiveRemoteComponents();
     });
+
+    it('token listing stays collapsed after creating a new token', () => {
+        cy.receiveTokenValues({
+            version: '5',
+            values: {
+                options: [
+                    {
+                        name: 'sizing.xs',
+                        value: 4,
+                    },
+                ],
+            },
+        });
+        cy.receiveStorageTypeLocal();
+        cy.get('[data-cy=tokenlisting-header-sizing]').click({timeout: 1000});
+        cy.get('[data-cy=tokenlisting-opacity] [data-cy=button-add-new-token]').click({timeout: 1000});
+        fillTokenForm({
+            name: 'sizing.sm',
+            value: '4',
+        });
+        cy.get('[data-cy=tokenlisting-sizing-content]').should('have.class', 'hidden');
+    });
 });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "figma-tokens",
 	"version": "1.0.0",
-	"plugin_version": "67",
+	"plugin_version": "68",
 	"description": "Figma Tokens",
 	"license": "ISC",
 	"scripts": {

--- a/src/app/components/MoreButton.tsx
+++ b/src/app/components/MoreButton.tsx
@@ -22,32 +22,19 @@ const RightSlot = styled('div', {
     '[data-disabled] &': {color: '$disabled'},
 });
 
-const MoreButton = ({properties, children, path, value, onClick, onEdit, onDelete, onDuplicate}) => {
+const MoreButton = ({
+    properties,
+    documentationProperties,
+    children,
+    path,
+    value,
+    onClick,
+    onEdit,
+    onDelete,
+    onDuplicate,
+}) => {
     const {selectionValues} = useSelector((state: RootState) => state.uiState);
     const {editProhibited} = useSelector((state: RootState) => state.tokenState);
-
-    const extraProperties = [
-        {
-            label: 'Name',
-            name: 'tokenName',
-            clear: ['tokenValue', 'value', 'description'],
-        },
-        {
-            label: 'Raw value',
-            name: 'tokenValue',
-            clear: ['tokenName', 'value', 'description'],
-        },
-        {
-            label: 'Value',
-            name: 'value',
-            clear: ['tokenName', 'tokenValue', 'description'],
-        },
-        {
-            label: 'Description',
-            name: 'description',
-            clear: ['tokenName', 'tokenValue', 'value'],
-        },
-    ];
 
     const visibleProperties = properties.filter((p) => p.label);
 
@@ -82,7 +69,7 @@ const MoreButton = ({properties, children, path, value, onClick, onEdit, onDelet
                             </RightSlot>
                         </ContextMenuTriggerItem>
                         <ContextMenuContent sideOffset={2} alignOffset={-5} collisionTolerance={30}>
-                            {extraProperties.map((property) => {
+                            {documentationProperties.map((property) => {
                                 const isActive = selectionValues[property.name] === value;
 
                                 return (

--- a/src/app/components/MoreButton.tsx
+++ b/src/app/components/MoreButton.tsx
@@ -57,7 +57,7 @@ const MoreButton = ({properties, children, path, value, onClick, onEdit, onDelet
                 <ContextMenuTrigger as="div" id={`${path}-${value}`}>
                     {children}
                 </ContextMenuTrigger>
-                <ContextMenuContent sideOffset={5} align="end" collisionTolerance={30}>
+                <ContextMenuContent sideOffset={5} collisionTolerance={30}>
                     {visibleProperties.map((property) => {
                         const isActive = selectionValues[property.name] === value;
 
@@ -86,12 +86,16 @@ const MoreButton = ({properties, children, path, value, onClick, onEdit, onDelet
                                 const isActive = selectionValues[property.name] === value;
 
                                 return (
-                                    <ContextMenuItem key={property.label} onSelect={() => onClick(property, isActive)}>
-                                        <div className="flex items-center">
-                                            {isActive && <CheckIcon />}
-                                            {property.label}
-                                        </div>
-                                    </ContextMenuItem>
+                                    <ContextMenuCheckboxItem
+                                        key={property.label}
+                                        checked={isActive}
+                                        onCheckedChange={() => onClick(property, isActive)}
+                                    >
+                                        <ContextMenuItemIndicator>
+                                            <CheckIcon />
+                                        </ContextMenuItemIndicator>
+                                        {property.label}
+                                    </ContextMenuCheckboxItem>
                                 );
                             })}
                         </ContextMenuContent>

--- a/src/app/components/TokenButton.tsx
+++ b/src/app/components/TokenButton.tsx
@@ -161,7 +161,7 @@ const TokenButton = ({
         const tokenValue = name;
         track('Apply Token', {givenProperties});
         let value = isActive ? 'delete' : tokenValue;
-        if (propsToSet[0].clear && !active) {
+        if (propsToSet[0].clear && !isActive) {
             value = 'delete';
             propsToSet[0].forcedValue = tokenValue;
         }

--- a/src/app/components/TokenButton.tsx
+++ b/src/app/components/TokenButton.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {track} from '@/utils/analytics';
 import {useDispatch, useSelector} from 'react-redux';
 import {SingleTokenObject} from 'Types/tokens';
+import getAliasValue from '@/utils/aliases';
 import Tooltip from './Tooltip';
 import MoreButton from './MoreButton';
 import {lightOrDark} from './utils';
@@ -35,12 +36,12 @@ const TokenButton = ({
 }) => {
     const uiState = useSelector((state: RootState) => state.uiState);
     const {activeTokenSet} = useSelector((state: RootState) => state.tokenState);
-    const {setNodeData, getTokenValue} = useTokens();
+    const {setNodeData} = useTokens();
     const {deleteSingleToken, duplicateSingleToken} = useManageTokens();
     const dispatch = useDispatch<Dispatch>();
     const {isAlias} = useTokens();
 
-    const displayValue = getTokenValue(token, resolvedTokens);
+    const displayValue = getAliasValue(token, resolvedTokens);
 
     let style;
     let showValue = true;

--- a/src/app/components/TokenButton.tsx
+++ b/src/app/components/TokenButton.tsx
@@ -137,7 +137,7 @@ const TokenButton = ({
 
             style = {
                 '--backgroundColor': displayValue,
-                '--borderColor': lightOrDark(displayValue) === 'light' ? '#f5f5f5' : 'white',
+                '--borderColor': lightOrDark(displayValue) === 'light' ? '#e7e7e7' : 'white',
             };
             buttonClass.push('button-property-color');
             if (uiState.displayType === 'LIST') {

--- a/src/app/components/TokenButton.tsx
+++ b/src/app/components/TokenButton.tsx
@@ -149,7 +149,30 @@ const TokenButton = ({
             break;
     }
 
-    const active = useGetActiveState(properties, type, name);
+    const documentationProperties = [
+        {
+            label: 'Name',
+            name: 'tokenName',
+            clear: ['tokenValue', 'value', 'description'],
+        },
+        {
+            label: 'Raw value',
+            name: 'tokenValue',
+            clear: ['tokenName', 'value', 'description'],
+        },
+        {
+            label: 'Value',
+            name: 'value',
+            clear: ['tokenName', 'tokenValue', 'description'],
+        },
+        {
+            label: 'Description',
+            name: 'description',
+            clear: ['tokenName', 'tokenValue', 'value'],
+        },
+    ];
+
+    const active = useGetActiveState([...properties, ...documentationProperties], type, name);
 
     if (active) {
         buttonClass.push('button-active');
@@ -181,6 +204,7 @@ const TokenButton = ({
         >
             <MoreButton
                 properties={properties}
+                documentationProperties={documentationProperties}
                 onClick={onClick}
                 onDelete={handleDeleteClick}
                 onDuplicate={handleDuplicateClick}

--- a/src/app/components/TokenListing.tsx
+++ b/src/app/components/TokenListing.tsx
@@ -61,10 +61,8 @@ const TokenListing = ({
     };
 
     React.useEffect(() => {
-        if (values) {
-            setIntCollapsed(collapsed);
-        }
-    }, [collapsed, values]);
+        setIntCollapsed(collapsed);
+    }, [collapsed]);
 
     const handleSetIntCollapsed = (e) => {
         e.stopPropagation();
@@ -84,10 +82,11 @@ const TokenListing = ({
                     className={`flex items-center w-full h-full p-4 space-x-2 hover:bg-gray-100 focus:outline-none ${
                         isIntCollapsed ? 'opacity-50' : null
                     }`}
+                    data-cy={`tokenlisting-header-${tokenKey}`}
                     type="button"
                     onClick={handleSetIntCollapsed}
                 >
-                    <Tooltip label="Alt + Click to collapse all">
+                    <Tooltip label={`Alt + Click to ${collapsed ? 'expand' : 'collapse'} all`}>
                         <div className="p-2 -m-2">
                             {isIntCollapsed ? (
                                 <svg width="6" height="6" viewBox="0 0 6 6" xmlns="http://www.w3.org/2000/svg">
@@ -133,7 +132,10 @@ const TokenListing = ({
                 </div>
             </div>
             {values && (
-                <div className={`px-4 pb-4 ${isIntCollapsed ? 'hidden' : null}`}>
+                <div
+                    className={`px-4 pb-4 ${isIntCollapsed ? 'hidden' : null}`}
+                    data-cy={`tokenlisting-${tokenKey}-content`}
+                >
                     <TokenTree
                         tokenValues={values}
                         showNewForm={showNewForm}

--- a/src/app/components/TokenTooltip.tsx
+++ b/src/app/components/TokenTooltip.tsx
@@ -1,9 +1,10 @@
+import getAliasValue from '@/utils/aliases';
 import React from 'react';
 
 // Returns token value in display format
 export default function TokenTooltip({token, resolvedTokens, shouldResolve = false}) {
     try {
-        const valueToCheck = shouldResolve ? resolvedTokens.find((t) => t.name === token.name).value : token.value;
+        const valueToCheck = shouldResolve ? getAliasValue(token, resolvedTokens) : token.value;
 
         if (token.type === 'typography') {
             if (shouldResolve) {

--- a/src/app/components/TokenTooltip.tsx
+++ b/src/app/components/TokenTooltip.tsx
@@ -10,7 +10,7 @@ export default function TokenTooltip({token, resolvedTokens, shouldResolve = fal
             if (shouldResolve) {
                 return (
                     <div>
-                        {valueToCheck.fontFamily} / {valueToCheck.fontWeight}
+                        {valueToCheck.fontFamily} {valueToCheck.fontWeight} / {valueToCheck.fontSize}
                     </div>
                 );
             }
@@ -20,6 +20,11 @@ export default function TokenTooltip({token, resolvedTokens, shouldResolve = fal
                     <div>Weight: {valueToCheck.fontWeight?.value || valueToCheck.fontWeight}</div>
                     <div>Leading: {valueToCheck.lineHeight?.value || valueToCheck.lineHeight}</div>
                     <div>Tracking: {valueToCheck.lineHeight?.value || valueToCheck.lineHeight}</div>
+                    <div>
+                        Paragraph Spacing: {valueToCheck.paragraphSpacing?.value || valueToCheck.paragraphSpacing}
+                    </div>
+                    <div>Text Case: {valueToCheck.textCase?.value || valueToCheck.textCase}</div>
+                    <div>Text Decoration: {valueToCheck.textDecoration?.value || valueToCheck.textDecoration}</div>
                 </div>
             );
         }

--- a/src/app/components/utils.test.ts
+++ b/src/app/components/utils.test.ts
@@ -88,26 +88,28 @@ describe('convertToRgb', () => {
         const rgbhexWithSpace = 'rgb(#ff0000, 0.5)';
         const rgbahexWithOutSpace = 'rgba(#ff0000,0.5)';
         const hex = '#ff0000';
+        const hsla = 'hsla(210, 50%, 100%, 1)';
 
         expect(convertToRgb(rgbhexWithSpace)).toBe('#ff000080');
         expect(convertToRgb(rgbahexWithOutSpace)).toBe('#ff000080');
         expect(convertToRgb(hex)).toBe('#ff0000');
+        expect(convertToRgb(hsla)).toBe('#ffffff');
     });
 
     it('transforms a gradient string to rgb values', () => {
         const gradient1 = 'linear-gradient(rgb(#ff0000, 0.5) 0%, #ffffff 100%)';
-        const gradient2 = 'linear-gradient(rgb(#ff0000, 0.5) 0%, rgba(#ffffff, 1) 100%)';
+        const gradient2 = 'linear-gradient(rgb(#ff0000, 0.5) 0%, rgba(#ffffff, 0.25) 100%)';
         const gradient3 = 'linear-gradient(rgba(255, 255, 0, 0.5) 0%, rgba(#000000, 0) 100%)';
 
         expect(convertToRgb(gradient1)).toBe('linear-gradient(#ff000080 0%, #ffffff 100%)');
-        expect(convertToRgb(gradient2)).toBe('linear-gradient(#ff000080 0%, #ffffffff 100%)');
+        expect(convertToRgb(gradient2)).toBe('linear-gradient(#ff000080 0%, #ffffff40 100%)');
         expect(convertToRgb(gradient3)).toBe('linear-gradient(#ffff0080 0%, #00000000 100%)');
     });
 
     it('transforms multiple color stops to rgb values', () => {
-        const gradient1 = 'linear-gradient(#ff0000 0%, rgb(#ff0000, 0.3) 50%, rgb(255, 0, 0, 1) 100%)';
+        const gradient1 = 'linear-gradient(#ff0000 0%, rgb(#ff0000, 0.3) 50%, rgb(255, 0, 0, 0.25) 100%)';
 
-        expect(convertToRgb(gradient1)).toBe('linear-gradient(#ff0000 0%, #ff00004d 50%, #ff0000ff 100%)');
+        expect(convertToRgb(gradient1)).toBe('linear-gradient(#ff0000 0%, #ff00004d 50%, #ff000040 100%)');
     });
 });
 
@@ -122,11 +124,9 @@ describe('lightToDark', () => {
     });
     it('knows when a color is dark', () => {
         const black = '#000';
-        const darkEnough = '#F3F3F3';
         const darkRgb = 'rgb(0,0,0)';
         const darkRgba = 'rgba(0,0,0,1)';
         expect(lightOrDark(black)).toBe('dark');
-        expect(lightOrDark(darkEnough)).toBe('dark');
         expect(lightOrDark(darkRgb)).toBe('dark');
         expect(lightOrDark(darkRgba)).toBe('dark');
     });

--- a/src/app/components/utils.tsx
+++ b/src/app/components/utils.tsx
@@ -1,8 +1,8 @@
 import {Parser} from 'expr-eval';
 import convertOpacityToFigma from '@/plugin/figmaTransforms/opacity';
+import {parseToRgba, readableColorIsBlack, toHex} from 'color2k';
 import {postToFigma} from '../../plugin/notifiers';
 import {MessageToPluginTypes} from '../../../types/messages';
-import {hexToRgb, RGBAToHexA} from '../../plugin/figmaTransforms/colors';
 
 const parser = new Parser();
 
@@ -38,28 +38,35 @@ export function convertToRgb(color: string) {
             return color;
         }
         const hexRegex = /#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})/g;
+        const hslaRegex = /(hsla?\(.*?\))/g;
         const rgbaRegex = /(rgba?\(.*?\))/g;
         let returnedColor = color;
 
         try {
-            const matchesRgba = Array.from(color.matchAll(rgbaRegex), (m) => m[0]);
+            const matchesRgba = Array.from(returnedColor.matchAll(rgbaRegex), (m) => m[0]);
+            const matchesHsla = Array.from(returnedColor.matchAll(hslaRegex), (m) => m[0]);
+            if (matchesHsla.length > 0) {
+                matchesHsla.map((match) => {
+                    returnedColor = returnedColor.replace(match, toHex(match));
+                });
+            }
             if (matchesRgba.length > 0) {
                 matchesRgba.map((match) => {
                     const matchedString = match;
                     const matchedColor = match.replace(/rgba?\(/g, '').replace(')', '');
-                    const matchesHex = matchedColor.match(hexRegex);
+                    const matchesHexInsideRgba = matchedColor.match(hexRegex);
                     let r;
                     let g;
                     let b;
                     let alpha = '1';
-                    if (matchesHex) {
-                        ({r, g, b} = hexToRgb(matchesHex[0]));
+                    if (matchesHexInsideRgba) {
+                        [r, g, b] = parseToRgba(matchesHexInsideRgba[0]);
                         alpha = matchedColor.split(',').pop().trim();
                     } else {
                         [r, g, b, alpha = '1'] = matchedColor.split(',').map((n) => n.trim());
                     }
                     const a = convertOpacityToFigma(alpha);
-                    returnedColor = returnedColor.split(matchedString).join(RGBAToHexA(r, g, b, a));
+                    returnedColor = returnedColor.split(matchedString).join(toHex(`rgba(${r}, ${g}, ${b}, ${a})`));
                 });
             }
         } catch (e) {
@@ -76,37 +83,7 @@ export function lightOrDark(color: string) {
     if (typeof color !== 'string') {
         return 'light';
     }
-    try {
-        let r: number | string;
-        let g: number | string;
-        let b: number | string;
-
-        // Check the format of the color, HEX or RGB?
-        if (color.match(/^rgb/)) {
-            // If RGB --> store the red, green, blue values in separate variables
-            [, r, g, b] = color.match(/^rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d+(?:\.\d+)?))?\)$/);
-        } else {
-            // If hex --> Convert it to RGB: http://gist.github.com/983661
-            const baseColor = color.slice(0, 7);
-            const extractedColor = +`0x${baseColor.slice(1).replace(baseColor.length < 5 && /./g, '$&$&')}`;
-
-            r = extractedColor >> 16;
-            g = (extractedColor >> 8) & 255;
-            b = extractedColor & 255;
-        }
-        // HSP (Highly Sensitive Poo) equation from http://alienryderflex.com/hsp.html
-        const hsp = Math.sqrt(
-            0.299 * (Number(r) * Number(r)) + 0.587 * (Number(g) * Number(g)) + 0.114 * (Number(b) * Number(b))
-        );
-
-        // Using the HSP value, determine whether the color is light or dark
-        if (hsp < 245.5) {
-            return 'dark';
-        }
-    } catch (e) {
-        console.error(color, e);
-    }
-    return 'light';
+    return readableColorIsBlack(color) ? 'light' : 'dark';
 }
 
 // Converts string to slug

--- a/src/app/components/utils.tsx
+++ b/src/app/components/utils.tsx
@@ -83,7 +83,11 @@ export function lightOrDark(color: string) {
     if (typeof color !== 'string') {
         return 'light';
     }
-    return readableColorIsBlack(color) ? 'light' : 'dark';
+    try {
+        return readableColorIsBlack(color) ? 'light' : 'dark';
+    } catch (e) {
+        return 'light';
+    }
 }
 
 // Converts string to slug

--- a/src/config/properties.js
+++ b/src/config/properties.js
@@ -28,6 +28,8 @@ export default {
     typography: {},
     letterSpacing: {},
     paragraphSpacing: {},
+    textCase: {},
+    textDecoration: {},
     tokenValue: {},
     value: {},
     tokenName: {},

--- a/src/config/tokenTypes.js
+++ b/src/config/tokenTypes.js
@@ -93,6 +93,8 @@ export default {
                 fontSize: '',
                 letterSpacing: '',
                 paragraphSpacing: '',
+                textDecoration: '',
+                textCase: '',
             },
             options: {
                 description: '',
@@ -163,6 +165,28 @@ export default {
                 description: '',
             },
         },
+    },
+    textCase: {
+        label: 'Text Case',
+        property: 'TextCase',
+        type: 'textCase',
+        schema: {
+            options: {
+                description: '',
+            },
+        },
+        explainer: 'none | uppercase | lowercase | capitalize',
+    },
+    textDecoration: {
+        label: 'Text Decoration',
+        property: 'TextDecoration',
+        type: 'textDecoration',
+        schema: {
+            options: {
+                description: '',
+            },
+        },
+        explainer: 'none | underline | line-through',
     },
     other: {
         label: 'Other',

--- a/src/plugin/figmaTransforms/colors.test.ts
+++ b/src/plugin/figmaTransforms/colors.test.ts
@@ -1,5 +1,5 @@
 import {convertToRgb} from '@/app/components/utils';
-import {convertToFigmaColor, hexToRgb, hslaToRgba} from './colors';
+import {convertToFigmaColor, hslaToRgba} from './colors';
 
 describe('hslaToRgba', () => {
     it('converts hsla to rgba', () => {
@@ -7,20 +7,6 @@ describe('hslaToRgba', () => {
         expect(hsl).toEqual([64, 128, 191, 1]);
         const hsla = hslaToRgba([210, 50, 50, 0.5]);
         expect(hsla).toEqual([64, 128, 191, 0.5]);
-    });
-});
-
-describe('hexToRgb', () => {
-    it('converts hex to rgb', () => {
-        const color = '#ff0000';
-
-        expect(hexToRgb(color)).toEqual({r: 255, g: 0, b: 0});
-    });
-
-    it('returns null if no match', () => {
-        const color = 'rgb(0000)';
-
-        expect(hexToRgb(color)).toBe(null);
     });
 });
 

--- a/src/plugin/figmaTransforms/colors.ts
+++ b/src/plugin/figmaTransforms/colors.ts
@@ -8,17 +8,6 @@ interface RGBA {
     a?: number;
 }
 
-export function hexToRgb(hex) {
-    const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-    return result
-        ? {
-              r: parseInt(result[1], 16),
-              g: parseInt(result[2], 16),
-              b: parseInt(result[3], 16),
-          }
-        : null;
-}
-
 export function RGBAToHexA(red, green, blue, alpha) {
     const r = parseInt(red, 10);
     const g = parseInt(green, 10);

--- a/src/plugin/figmaTransforms/textCase.test.ts
+++ b/src/plugin/figmaTransforms/textCase.test.ts
@@ -1,0 +1,31 @@
+import {convertFigmaToTextCase, convertTextCaseToFigma} from './textCase';
+
+describe('convertTextCaseToFigma', () => {
+    it('converts text case to figma compliant string', () => {
+        expect(convertTextCaseToFigma('none')).toBe('ORIGINAL');
+        expect(convertTextCaseToFigma('original')).toBe('ORIGINAL');
+        expect(convertTextCaseToFigma('capitalize')).toBe('TITLE');
+        expect(convertTextCaseToFigma('title')).toBe('TITLE');
+        expect(convertTextCaseToFigma('lowercase')).toBe('LOWER');
+        expect(convertTextCaseToFigma('lower')).toBe('LOWER');
+        expect(convertTextCaseToFigma('uppercase')).toBe('UPPER');
+        expect(convertTextCaseToFigma('upper')).toBe('UPPER');
+        expect(convertTextCaseToFigma('small_caps')).toBe('SMALL_CAPS');
+        expect(convertTextCaseToFigma('small-caps')).toBe('SMALL_CAPS');
+        expect(convertTextCaseToFigma('small_caps_forced')).toBe('SMALL_CAPS_FORCED');
+    });
+    it('converts non-compliant textCase to ORIGINAL', () => {
+        expect(convertTextCaseToFigma('something')).toBe('ORIGINAL');
+    });
+});
+
+describe('convertFigmaToTextCase', () => {
+    it('converts figma text case to token compliant string', () => {
+        expect(convertFigmaToTextCase('ORIGINAL')).toBe('none');
+        expect(convertFigmaToTextCase('LOWER')).toBe('lowercase');
+        expect(convertFigmaToTextCase('UPPER')).toBe('uppercase');
+        expect(convertFigmaToTextCase('TITLE')).toBe('capitalize');
+        expect(convertFigmaToTextCase('SMALL_CAPS')).toBe('small_caps');
+        expect(convertFigmaToTextCase('SMALL_CAPS_FORCED')).toBe('small_caps_forced');
+    });
+});

--- a/src/plugin/figmaTransforms/textCase.ts
+++ b/src/plugin/figmaTransforms/textCase.ts
@@ -1,0 +1,38 @@
+export function convertTextCaseToFigma(value: string) {
+    switch (value.toLowerCase()) {
+        case 'uppercase':
+        case 'upper':
+            return 'UPPER';
+        case 'lowercase':
+        case 'lower':
+            return 'LOWER';
+        case 'capitalize':
+        case 'title':
+            return 'TITLE';
+        case 'small-caps':
+        case 'small_caps':
+            return 'SMALL_CAPS';
+        case 'all-small-caps':
+        case 'small_caps_forced':
+            return 'SMALL_CAPS_FORCED';
+        default:
+            return 'ORIGINAL';
+    }
+}
+
+export function convertFigmaToTextCase(value: string) {
+    switch (value) {
+        case 'UPPER':
+            return 'uppercase';
+        case 'LOWER':
+            return 'lowercase';
+        case 'TITLE':
+            return 'capitalize';
+        case 'SMALL_CAPS':
+            return 'small_caps';
+        case 'SMALL_CAPS_FORCED':
+            return 'small_caps_forced';
+        default:
+            return 'none';
+    }
+}

--- a/src/plugin/figmaTransforms/textDecoration.test.ts
+++ b/src/plugin/figmaTransforms/textDecoration.test.ts
@@ -1,0 +1,21 @@
+import {convertFigmaToTextDecoration, convertTextDecorationToFigma} from './textDecoration';
+
+describe('convertTextDecorationToFigma', () => {
+    it('converts text decoration to figma compliant string', () => {
+        expect(convertTextDecorationToFigma('none')).toBe('NONE');
+        expect(convertTextDecorationToFigma('underline')).toBe('UNDERLINE');
+        expect(convertTextDecorationToFigma('line-through')).toBe('STRIKETHROUGH');
+        expect(convertTextDecorationToFigma('strikethrough')).toBe('STRIKETHROUGH');
+    });
+    it('converts non-compliant textDecoration to NONE', () => {
+        expect(convertTextDecorationToFigma('something')).toBe('NONE');
+    });
+});
+
+describe('convertFigmaToTextDecoration', () => {
+    it('converts text decoration to figma compliant string', () => {
+        expect(convertFigmaToTextDecoration('NONE')).toBe('none');
+        expect(convertFigmaToTextDecoration('UNDERLINE')).toBe('underline');
+        expect(convertFigmaToTextDecoration('STRIKETHROUGH')).toBe('line-through');
+    });
+});

--- a/src/plugin/figmaTransforms/textDecoration.ts
+++ b/src/plugin/figmaTransforms/textDecoration.ts
@@ -1,0 +1,22 @@
+export function convertTextDecorationToFigma(value: string) {
+    switch (value.toLowerCase()) {
+        case 'underline':
+            return 'UNDERLINE';
+        case 'line-through':
+        case 'strikethrough':
+            return 'STRIKETHROUGH';
+        default:
+            return 'NONE';
+    }
+}
+
+export function convertFigmaToTextDecoration(value: string) {
+    switch (value) {
+        case 'UNDERLINE':
+            return 'underline';
+        case 'STRIKETHROUGH':
+            return 'line-through';
+        default:
+            return 'none';
+    }
+}

--- a/src/plugin/helpers.ts
+++ b/src/plugin/helpers.ts
@@ -2,6 +2,8 @@ import {convertTypographyNumberToFigma, fakeZeroForFigma} from './figmaTransform
 import {convertLetterSpacingToFigma} from './figmaTransforms/letterSpacing';
 import {convertLineHeightToFigma} from './figmaTransforms/lineHeight';
 import convertOpacityToFigma from './figmaTransforms/opacity';
+import {convertTextCaseToFigma} from './figmaTransforms/textCase';
+import {convertTextDecorationToFigma} from './figmaTransforms/textDecoration';
 
 export function isObject(item) {
     return item && typeof item === 'object' && !Array.isArray(item);
@@ -82,6 +84,10 @@ export function transformValue(value, type) {
             return convertLineHeightToFigma(value);
         case 'opacity':
             return convertOpacityToFigma(value.toString());
+        case 'textCase':
+            return convertTextCaseToFigma(value.toString());
+        case 'textDecoration':
+            return convertTextDecorationToFigma(value.toString());
         default:
             return value;
     }

--- a/src/plugin/node.ts
+++ b/src/plugin/node.ts
@@ -1,7 +1,7 @@
 /* eslint-disable default-case */
 import {fetchAllPluginData} from './pluginData';
 import store from './store';
-import setValuesOnNode from './updateNode';
+import setValuesOnNode from './setValuesOnNode';
 import {TokenProps} from '../../types/tokens';
 import {ContextObject, StorageProviderType, StorageType} from '../../types/api';
 import {isSingleToken} from '../app/components/utils';

--- a/src/plugin/pullStyles.test.ts
+++ b/src/plugin/pullStyles.test.ts
@@ -1,0 +1,185 @@
+import pullStyles from './pullStyles';
+
+import * as notifiers from './notifiers';
+
+describe('pullStyles', () => {
+    const notifyStyleValuesSpy = jest.spyOn(notifiers, 'notifyStyleValues');
+
+    it('pulls color styles', async () => {
+        figma.getLocalPaintStyles.mockReturnValue([
+            {
+                name: 'red/500',
+                id: '456',
+                description: 'the red one',
+                paints: [{type: 'SOLID', color: {r: 1, g: 0, b: 0}, opacity: 1}],
+            },
+            {
+                name: 'blue/500',
+                id: '567',
+                description: 'the blue one',
+                paints: [{type: 'SOLID', color: {r: 0, g: 0, b: 1}, opacity: 0.5}],
+            },
+        ]);
+        await pullStyles({colorStyles: true});
+
+        expect(notifyStyleValuesSpy).toHaveBeenCalledWith({
+            colors: [
+                {
+                    name: 'red.500',
+                    type: 'color',
+                    value: '#ff0000',
+                    description: 'the red one',
+                },
+                {
+                    name: 'blue.500',
+                    type: 'color',
+                    value: '#0000ff80',
+                    description: 'the blue one',
+                },
+            ],
+            typography: [],
+            fontFamilies: [],
+            lineHeights: [],
+            fontWeights: [],
+            fontSizes: [],
+            letterSpacing: [],
+            paragraphSpacing: [],
+            textCase: [],
+            textDecoration: [],
+        });
+    });
+
+    it('pulls text styles', async () => {
+        figma.getLocalTextStyles.mockReturnValue([
+            {
+                name: 'heading/h1/bold',
+                id: '456',
+                description: 'the big one',
+                fontSize: 24,
+                fontName: {
+                    family: 'Inter',
+                    style: 'Bold',
+                },
+                lineHeight: {
+                    unit: 'AUTO',
+                },
+                paragraphSpacing: 0,
+                letterSpacing: {
+                    unit: 'PERCENT',
+                    value: 0,
+                },
+                textCase: 'ORIGINAL',
+                textDecoration: 'NONE',
+            },
+            {
+                name: 'heading/h2/regular',
+                id: '456',
+                description: 'the small regular one',
+                fontSize: 16,
+                fontName: {
+                    family: 'Inter',
+                    style: 'Regular',
+                },
+                lineHeight: {
+                    unit: 'AUTO',
+                },
+                paragraphSpacing: 0,
+                letterSpacing: {
+                    unit: 'PERCENT',
+                    value: 0,
+                },
+                textCase: 'ORIGINAL',
+                textDecoration: 'NONE',
+            },
+            {
+                name: 'copy/regular',
+                id: '121',
+                description: '',
+                fontSize: 16,
+                fontName: {
+                    family: 'Roboto',
+                    style: 'Regular',
+                },
+                lineHeight: {
+                    unit: 'AUTO',
+                },
+                paragraphSpacing: 0,
+                letterSpacing: {
+                    unit: 'PERCENT',
+                    value: 0,
+                },
+                textCase: 'ORIGINAL',
+                textDecoration: 'NONE',
+            },
+        ]);
+        await pullStyles({textStyles: true});
+
+        expect(notifyStyleValuesSpy).toHaveBeenCalledWith({
+            colors: [],
+            typography: [
+                {
+                    name: 'heading.h1.bold',
+                    type: 'typography',
+                    value: {
+                        fontFamily: '$fontFamilies.inter',
+                        fontWeight: '$fontWeights.inter-0',
+                        fontSize: '$fontSize.1',
+                        letterSpacing: '$letterSpacing.0',
+                        lineHeight: '$lineHeights.0',
+                        paragraphSpacing: '$paragraphSpacing.0',
+                        textCase: '$textCase.none',
+                        textDecoration: '$textDecoration.none',
+                    },
+                    description: 'the big one',
+                },
+                {
+                    name: 'heading.h2.regular',
+                    type: 'typography',
+                    value: {
+                        fontFamily: '$fontFamilies.inter',
+                        fontWeight: '$fontWeights.inter-1',
+                        fontSize: '$fontSize.0',
+                        letterSpacing: '$letterSpacing.0',
+                        lineHeight: '$lineHeights.0',
+                        paragraphSpacing: '$paragraphSpacing.0',
+                        textCase: '$textCase.none',
+                        textDecoration: '$textDecoration.none',
+                    },
+                    description: 'the small regular one',
+                },
+                {
+                    name: 'copy.regular',
+                    type: 'typography',
+                    value: {
+                        fontFamily: '$fontFamilies.roboto',
+                        fontWeight: '$fontWeights.roboto-2',
+                        fontSize: '$fontSize.0',
+                        letterSpacing: '$letterSpacing.0',
+                        lineHeight: '$lineHeights.0',
+                        paragraphSpacing: '$paragraphSpacing.0',
+                        textCase: '$textCase.none',
+                        textDecoration: '$textDecoration.none',
+                    },
+                },
+            ],
+            fontFamilies: [
+                {name: 'fontFamilies.inter', type: 'fontFamilies', value: 'Inter'},
+                {name: 'fontFamilies.roboto', type: 'fontFamilies', value: 'Roboto'},
+            ],
+            lineHeights: [{name: 'lineHeights.0', type: 'lineHeights', value: 'AUTO'}],
+            fontWeights: [
+                {name: 'fontWeights.inter-0', type: 'fontWeights', value: 'Bold'},
+                {name: 'fontWeights.inter-1', type: 'fontWeights', value: 'Regular'},
+                {name: 'fontWeights.roboto-2', type: 'fontWeights', value: 'Regular'},
+            ],
+            fontSizes: [
+                {name: 'fontSize.0', type: 'fontSizes', value: '16'},
+                {name: 'fontSize.1', type: 'fontSizes', value: '24'},
+            ],
+            letterSpacing: [{name: 'letterSpacing.0', type: 'letterSpacing', value: '0%'}],
+            paragraphSpacing: [{name: 'paragraphSpacing.0', type: 'paragraphSpacing', value: '0'}],
+            textCase: [{name: 'textCase.none', type: 'textCase', value: 'none'}],
+            textDecoration: [{name: 'textDecoration.none', type: 'textDecoration', value: 'none'}],
+        });
+    });
+});

--- a/src/plugin/setTextValuesOnTarget.test.ts
+++ b/src/plugin/setTextValuesOnTarget.test.ts
@@ -1,0 +1,49 @@
+import setTextValuesOnTarget from './setTextValuesOnTarget';
+
+describe('setTextValuesOnTarget', () => {
+    let textNodeMock;
+
+    beforeEach(() => {
+        textNodeMock = {
+            type: 'TEXT',
+            fontName: {
+                family: 'Inter',
+                style: 'Regular',
+            },
+            textCase: 'NONE',
+            textDecoration: 'NONE',
+            fontSize: 24,
+            paragraphSpacing: 0,
+            letterSpacing: 0,
+            lineHeight: 'AUTO',
+        };
+    });
+
+    it('sets fontSize if only fontSize is given', async () => {
+        await setTextValuesOnTarget(textNodeMock, {value: {fontSize: 24}});
+        expect(textNodeMock).toEqual({...textNodeMock, fontSize: 24});
+    });
+
+    it('sets fontFamily if that is given', async () => {
+        await setTextValuesOnTarget(textNodeMock, {value: {fontFamily: 'Roboto'}});
+        expect(textNodeMock).toEqual({...textNodeMock, fontName: {...textNodeMock.fontName, family: 'Roboto'}});
+    });
+
+    it('sets fontWeight if that is given', async () => {
+        await setTextValuesOnTarget(textNodeMock, {value: {fontWeight: 'Bold'}});
+        expect(textNodeMock).toEqual({...textNodeMock, fontName: {...textNodeMock.fontName, style: 'Bold'}});
+    });
+
+    it('sets textCase, textDecoration and description if those are given', async () => {
+        await setTextValuesOnTarget(textNodeMock, {
+            description: 'Use with care',
+            value: {textDecoration: 'STRIKETHROUGH', textCase: 'TITLE'},
+        });
+        expect(textNodeMock).toEqual({
+            ...textNodeMock,
+            description: 'Use with care',
+            textDecoration: 'STRIKETHROUGH',
+            textCase: 'TITLE',
+        });
+    });
+});

--- a/src/plugin/setTextValuesOnTarget.ts
+++ b/src/plugin/setTextValuesOnTarget.ts
@@ -1,14 +1,24 @@
+/* eslint-disable no-param-reassign */
 import {transformValue} from './helpers';
 
 export default async function setTextValuesOnTarget(target, token) {
     try {
         const {value, description} = token;
-        const {fontFamily, fontWeight, fontSize, lineHeight, letterSpacing, paragraphSpacing} = value.value || value;
+        const {
+            fontFamily,
+            fontWeight,
+            fontSize,
+            lineHeight,
+            letterSpacing,
+            paragraphSpacing,
+            textCase,
+            textDecoration,
+        } = value.value || value;
         const family = fontFamily || target.fontName.family;
         const style = fontWeight || target.fontName.style;
         await figma.loadFontAsync({family, style});
 
-        if (fontFamily && fontWeight) {
+        if (fontFamily || fontWeight) {
             target.fontName = {
                 family,
                 style,
@@ -26,6 +36,12 @@ export default async function setTextValuesOnTarget(target, token) {
         }
         if (paragraphSpacing) {
             target.paragraphSpacing = transformValue(paragraphSpacing, 'paragraphSpacing');
+        }
+        if (textCase) {
+            target.textCase = transformValue(textCase, 'textCase');
+        }
+        if (textDecoration) {
+            target.textDecoration = transformValue(textDecoration, 'textDecoration');
         }
         if (description) {
             target.description = description;

--- a/src/plugin/setValuesOnNode.test.ts
+++ b/src/plugin/setValuesOnNode.test.ts
@@ -1,0 +1,71 @@
+import setValuesOnNode from './setValuesOnNode';
+
+import * as setTextValuesOnTarget from './setTextValuesOnTarget';
+
+describe('updateNode', () => {
+    const setTextValuesOnTargetSpy = jest.spyOn(setTextValuesOnTarget, 'default');
+
+    const atomicValues = {
+        textCase: 'TITLE',
+        textDecoration: 'STRIKETHROUGH',
+    };
+
+    const typographyValues = {
+        typography: {
+            fontFamily: 'Inter',
+            fontWeight: 'Bold',
+            fontSize: '24',
+        },
+    };
+
+    const dataOnNode = {
+        typography: 'type.heading.h1',
+    };
+
+    let textNodeMock;
+    let solidNodeMock;
+
+    beforeEach(() => {
+        textNodeMock = {
+            type: 'TEXT',
+            fontName: {
+                family: 'Inter',
+                style: 'Regular',
+            },
+        };
+
+        solidNodeMock = {
+            type: 'SOLID',
+        };
+    });
+
+    it('calls setTextValuesOnTarget if text node and atomic typography tokens are given', () => {
+        setValuesOnNode(textNodeMock, atomicValues, dataOnNode);
+        expect(setTextValuesOnTargetSpy).toHaveBeenCalled();
+    });
+
+    it('doesnt call setTextValuesOnTarget if no text node', () => {
+        setValuesOnNode(solidNodeMock, atomicValues, dataOnNode);
+        expect(setTextValuesOnTargetSpy).not.toHaveBeenCalled();
+    });
+
+    it('calls setTextValuesOnTarget if text node and composite typography tokens are given', () => {
+        setValuesOnNode(textNodeMock, typographyValues, dataOnNode);
+        figma.getLocalTextStyles.mockReturnValue([]);
+        expect(setTextValuesOnTargetSpy).toHaveBeenCalled();
+    });
+
+    it('sets textstyle if matching Style is found', async () => {
+        figma.getLocalTextStyles.mockReturnValue([{name: 'type/heading/h1', id: '123'}]);
+        await setValuesOnNode(textNodeMock, typographyValues, dataOnNode);
+        expect(setTextValuesOnTargetSpy).not.toHaveBeenCalled();
+        expect(textNodeMock).toEqual({...textNodeMock, textStyleId: '123'});
+    });
+
+    it('sets textstyle if matching Style is found and first part is ignored', async () => {
+        figma.getLocalTextStyles.mockReturnValue([{name: 'heading/h1', id: '456'}]);
+        await setValuesOnNode(textNodeMock, typographyValues, dataOnNode, true);
+        expect(setTextValuesOnTargetSpy).not.toHaveBeenCalled();
+        expect(textNodeMock).toEqual({...textNodeMock, textStyleId: '456'});
+    });
+});

--- a/src/plugin/setValuesOnNode.ts
+++ b/src/plugin/setValuesOnNode.ts
@@ -93,7 +93,8 @@ export default async function setValuesOnNode(node, values, data, ignoreFirstPar
             if (node.type === 'TEXT') {
                 const styles = figma.getLocalTextStyles();
                 const path = data.typography.split('.'); // extract to helper fn
-                const pathname = path.slice(1, path.length).join('/');
+                const pathname = path.slice(ignoreFirstPartForStyles ? 1 : 0, path.length).join('/');
+
                 const matchingStyles = styles.filter((n) => n.name === pathname);
 
                 if (matchingStyles.length) {
@@ -108,7 +109,9 @@ export default async function setValuesOnNode(node, values, data, ignoreFirstPar
             values.lineHeights ||
             values.fontSizes ||
             values.letterSpacing ||
-            values.paragraphSpacing
+            values.paragraphSpacing ||
+            values.textCase ||
+            values.textDecoration
         ) {
             if (node.type === 'TEXT') {
                 setTextValuesOnTarget(node, {
@@ -119,6 +122,8 @@ export default async function setValuesOnNode(node, values, data, ignoreFirstPar
                         fontSize: values.fontSizes,
                         letterSpacing: values.letterSpacing,
                         paragraphSpacing: values.paragraphSpacing,
+                        textCase: values.textCase,
+                        textDecoration: values.textDecoration,
                     },
                 });
             }

--- a/src/plugin/tokenHelpers.test.ts
+++ b/src/plugin/tokenHelpers.test.ts
@@ -6,6 +6,12 @@ const tokens = [
     {name: 'boo', value: '{baz}'},
     {name: 'math', value: '{foo} * 2'},
     {name: 'mathWrong', value: '{foo} * {boo}'},
+    {name: 'colors.red.500', value: '#ff0000'},
+    {name: 'opacity.default', value: '0.2 + 0.2'},
+    {name: 'opacity.full', value: '{opacity.default} + 0.6'},
+    {name: 'theme.accent.default', value: 'rgba({colors.red.500}, 0.5)'},
+    {name: 'theme.accent.subtle', value: 'rgba({colors.red.500}, {opacity.default})'},
+    {name: 'theme.accent.deep', value: 'rgba({theme.accent.default}, {opacity.full})'},
 ];
 
 const output = [
@@ -35,6 +41,36 @@ const output = [
         name: 'mathWrong',
         rawValue: '{foo} * {boo}',
         value: '3 * {baz}',
+    },
+    {
+        name: 'colors.red.500',
+        rawValue: '#ff0000',
+        value: '#ff0000',
+    },
+    {
+        name: 'opacity.default',
+        rawValue: '0.2 + 0.2',
+        value: 0.4,
+    },
+    {
+        name: 'opacity.full',
+        rawValue: '{opacity.default} + 0.6',
+        value: 1,
+    },
+    {
+        name: 'theme.accent.default',
+        rawValue: 'rgba({colors.red.500}, 0.5)',
+        value: '#ff000080',
+    },
+    {
+        name: 'theme.accent.subtle',
+        rawValue: 'rgba({colors.red.500}, {opacity.default})',
+        value: '#ff000066',
+    },
+    {
+        name: 'theme.accent.deep',
+        rawValue: 'rgba({theme.accent.default}, {opacity.full})',
+        value: '#ff0000ff',
     },
 ];
 describe('resolveTokenValues', () => {

--- a/src/plugin/tokenHelpers.test.ts
+++ b/src/plugin/tokenHelpers.test.ts
@@ -70,7 +70,7 @@ const output = [
     {
         name: 'theme.accent.deep',
         rawValue: 'rgba({theme.accent.default}, {opacity.full})',
-        value: '#ff0000ff',
+        value: '#ff0000',
     },
 ];
 describe('resolveTokenValues', () => {

--- a/src/plugin/tokenHelpers.ts
+++ b/src/plugin/tokenHelpers.ts
@@ -23,18 +23,18 @@ export function reduceToValues(tokens) {
 export function resolveTokenValues(tokens, previousCount = undefined) {
     const aliases = findAllAliases(tokens);
     let returnedTokens = tokens;
-    returnedTokens = tokens.map((t) => {
+    returnedTokens = tokens.map((t, _, tokensInProgress) => {
         let returnValue;
         let failedToResolve;
         // Iterate over Typography and boxShadow Object to get resolved values
         if (['typography', 'boxShadow'].includes(t.type)) {
             returnValue = Object.entries(t.value).reduce((acc, [key, value]: [string, SingleTokenObject]) => {
-                acc[key] = getAliasValue(value, tokens);
+                acc[key] = getAliasValue(value, tokensInProgress);
                 return acc;
             }, {});
         } else {
             // If we're not dealing with special tokens, just return resolved value
-            returnValue = getAliasValue(t, tokens);
+            returnValue = getAliasValue(t, tokensInProgress);
 
             failedToResolve = returnValue === null || checkIfContainsAlias(returnValue);
         }
@@ -50,6 +50,7 @@ export function resolveTokenValues(tokens, previousCount = undefined) {
         }
         return returnObject;
     });
+
     if (aliases.length > 0 && (previousCount > aliases.length || !previousCount)) {
         return resolveTokenValues(returnedTokens, aliases.length);
     }

--- a/src/utils/aliases.test.ts
+++ b/src/utils/aliases.test.ts
@@ -24,18 +24,23 @@ describe('getAliasValue', () => {
         },
         {
             name: 'colors.lightness',
-            input: '$colors.lightness_base * 4 + 0.175',
-            value: 100.175,
+            input: '$colors.lightness_base * 3.5 + 0.175',
+            value: 87.675,
         },
         {
             name: 'colors.hsla_1',
-            input: 'hsl(172,50,$colors.lightness_base)',
-            value: 'hsl(172,50,25)',
+            input: 'hsl(172,50%,{colors.lightness_base}%)',
+            value: '#206057',
         },
         {
             name: 'colors.hsla_2',
-            input: 'hsl(172,50,$colors.lightness)',
-            value: 'hsl(172,50,100.175)',
+            input: 'hsl(172,50%,{colors.lightness}%)',
+            value: '#d0efeb',
+        },
+        {
+            name: 'colors.hsla_3',
+            input: 'hsla(172,50%,{colors.lightness}%, 0.5)',
+            value: '#d0efeb80',
         },
         {
             name: 'alias.complex',
@@ -71,6 +76,16 @@ describe('getAliasValue', () => {
             name: 'base.index',
             input: '400',
             value: 400,
+        },
+        {
+            name: 'alias.cantresolve',
+            input: 'rgba({notexisting}, 1)',
+            value: 'rgba({notexisting}, 1)',
+        },
+        {
+            name: 'alias.cantresolveopacity',
+            input: 'rgba(255, 255, 0, {notexisting})',
+            value: 'rgba(255, 255, 0, {notexisting})',
         },
     ];
 

--- a/src/utils/aliases.test.ts
+++ b/src/utils/aliases.test.ts
@@ -15,7 +15,7 @@ describe('getAliasValue', () => {
         {
             name: 'colors.rgbaalias',
             input: 'rgba($colors.hex, 0.5)',
-            value: 'rgba(#ff0000, 0.5)',
+            value: '#ff000080',
         },
         {
             name: 'colors.lightness_base',

--- a/src/utils/aliases.tsx
+++ b/src/utils/aliases.tsx
@@ -8,28 +8,30 @@ export default function getAliasValue(token: SingleTokenObject | string, tokens 
 
     try {
         const tokenReferences = findReferences(returnedValue);
+
         if (tokenReferences?.length > 0) {
             const resolvedReferences = tokenReferences.map((ref) => {
                 if (ref.length > 1) {
                     const nameToLookFor = ref.startsWith('{') ? ref.slice(1, ref.length - 1) : ref.substring(1);
 
                     const foundToken = tokens.find((t) => t.name === nameToLookFor);
-                    if (typeof foundToken !== 'undefined') return foundToken.value;
+                    if (typeof foundToken !== 'undefined') return getAliasValue(foundToken, tokens);
                 }
                 return ref;
             });
             tokenReferences.forEach((reference, index) => {
-                returnedValue = returnedValue.replace(
-                    reference,
-                    resolvedReferences[index]?.value ?? resolvedReferences[index]
-                );
+                const resolved = checkAndEvaluateMath(resolvedReferences[index]?.value ?? resolvedReferences[index]);
+                returnedValue = returnedValue.replace(reference, resolved);
             });
+
             if (returnedValue === 'null') {
                 returnedValue = null;
             }
         }
         if (typeof returnedValue !== 'undefined') {
-            if (!tokenReferences) {
+            const remainingReferences = findReferences(returnedValue);
+
+            if (!remainingReferences) {
                 return convertToRgb(checkAndEvaluateMath(returnedValue));
             }
         }

--- a/types/propertyTypes.ts
+++ b/types/propertyTypes.ts
@@ -8,6 +8,8 @@ export type TypographyObject = {
     lineHeight?: string | number;
     letterSpacing?: string;
     paragraphSpacing?: string;
+    textCase?: string;
+    textDecoration?: string;
 };
 
 export type TypographyToken = {


### PR DESCRIPTION
# New additions
- Added textCase and textDecoration tokens as own tokens and as part of typography tokens - fixes #95 

# Fixes
- Fixes calculation of deep nested aliases especially when using rgba() and calc inside of them
- Fixes token buttons not having enough contrast when using hsla colors - fixes #309
- Fixes token categories always re-opening when adding/editing tokens - fixes #295 
- Fixes ability to remove Documentation Tokens from a layer
- Fixes Documentation token isActive state