### PR TITLE
Fix renaming tokens side-effects with arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "figma-tokens",
 	"version": "1.0.0",
-	"plugin_version": "70",
+	"plugin_version": "71",
 	"description": "Figma Tokens",
 	"license": "ISC",
 	"scripts": {

--- a/src/app/store/models/tokenState.test.ts
+++ b/src/app/store/models/tokenState.test.ts
@@ -1,6 +1,25 @@
 import {init} from '@rematch/core';
 import {models, RootModel} from './index';
 
+const shadowArray = [
+    {
+        type: 'innerShadow',
+        color: '#00000080',
+        x: '0',
+        y: '0',
+        blur: '2',
+        spread: '4',
+    },
+    {
+        type: 'dropShadow',
+        color: '#000000',
+        x: '0',
+        y: '4',
+        blur: '4',
+        spread: '4',
+    },
+];
+
 describe('editToken', () => {
     let store;
     beforeEach(() => {
@@ -33,6 +52,20 @@ describe('editToken', () => {
                                         fontWeight: '400',
                                         fontSize: '16',
                                     },
+                                },
+                                {
+                                    name: 'header 1',
+                                    type: 'typography',
+                                    value: {
+                                        fontWeight: '400',
+                                        fontSize: '16',
+                                    },
+                                },
+                                {
+                                    name: 'shadow.mixed',
+                                    type: 'boxShadow',
+                                    description: 'the one with mixed shadows',
+                                    value: shadowArray,
                                 },
                             ],
                             options: [
@@ -78,6 +111,19 @@ describe('editToken', () => {
         const {tokens} = store.getState().tokenState;
         expect(tokens.global[1].value).toEqual('{secondary}');
         expect(tokens.global[3].value).toEqual('$primary50');
+        expect(tokens.global[3].value).toEqual('$primary50');
+    });
+
+    it('doesnt interfere with other tokens', async () => {
+        await store.dispatch.tokenState.editToken({
+            parent: 'global',
+            oldName: 'primary',
+            name: 'secondary',
+            value: '1',
+        });
+
+        const {tokens} = store.getState().tokenState;
+        expect(tokens.global[6].value).toEqual(shadowArray);
     });
 
     it('also updates tokens from other sets', async () => {

--- a/src/app/store/models/tokenState.tsx
+++ b/src/app/store/models/tokenState.tsx
@@ -293,6 +293,17 @@ export const tokenState = createModel<RootModel>()({
             const newTokens = Object.entries(state.tokens).reduce(
                 (acc, [key, values]: [string, SingleTokenObject[]]) => {
                     const newValues = values.map((token) => {
+                        if (Array.isArray(token.value)) {
+                            return {
+                                ...token,
+                                value: token.value.map((t) =>
+                                    Object.entries(t).reduce((a, [k, v]: [string, string]) => {
+                                        a[k] = replaceReferences(v.toString(), data.oldName, data.newName);
+                                        return a;
+                                    }, {})
+                                ),
+                            };
+                        }
                         if (typeof token.value === 'object') {
                             return {
                                 ...token,


### PR DESCRIPTION
This PR fixes a bug that would mess with array tokens (boxShadow for now) when renaming any token