### PR TITLE
feat: options for token-transformer & expandTypography option for style-dictionary compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 		"@rematch/core": "^2.0.1",
 		"@sentry/react": "^6.2.5",
 		"@stitches/react": "^0.1.9",
+		"assert": "^2.0.0",
 		"autoprefixer": "^10.2.5",
 		"axios": "^0.21.2",
 		"color2k": "^1.2.4",
@@ -50,6 +51,7 @@
 		"mixpanel-figma": "^2.0.1",
 		"object-path": "^0.11.8",
 		"octokit-commit-multiple-files": "^3.2.1",
+		"path-browserify": "^1.0.1",
 		"postcss": "^8.2.10",
 		"react": "17.0.0",
 		"react-dnd": "^13.1.1",
@@ -63,7 +65,8 @@
 		"set-value": "^3.0.2",
 		"storyblok-js-client": "^3.3.1",
 		"tailwindcss": "^2.0.3",
-		"use-debounce": "^6.0.1"
+		"use-debounce": "^6.0.1",
+		"yargs": "^17.3.1"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.12.16",
@@ -79,6 +82,7 @@
 		"@types/lodash.isequal": "^4.5.5",
 		"@types/react": "^16.8.24",
 		"@types/react-dom": "^16.8.5",
+		"@types/yargs": "^17.0.8",
 		"babel-jest": "^26.6.3",
 		"babel-loader": "^8.2.2",
 		"concurrently": "^5.2.0",

--- a/src/app/components/createTokenObj.tsx
+++ b/src/app/components/createTokenObj.tsx
@@ -47,6 +47,7 @@ function transformName(name) {
 export function appendTypeToToken(token) {
     const hasTypeProp = token.type && token.type !== '' && token.type !== 'undefined';
     const typeToSet = hasTypeProp ? token.type : transformName(token.name.split('.').slice(0, 1).toString());
+
     return {
         ...token,
         type: typeToSet,

--- a/src/plugin/tokenHelpers.ts
+++ b/src/plugin/tokenHelpers.ts
@@ -56,6 +56,7 @@ export function resolveTokenValues(tokens, previousCount = undefined) {
             rawValue: t.rawValue || t.value,
             failedToResolve,
         };
+
         if (!failedToResolve) {
             delete returnObject.failedToResolve;
         }
@@ -82,5 +83,6 @@ export function mergeTokenGroups(tokens, usedSets = []): SingleTokenObject[] {
                 });
             }
         });
+
     return mergedTokens;
 }

--- a/src/utils/__snapshots__/convertTokensObjectToResolved.test.ts.snap
+++ b/src/utils/__snapshots__/convertTokensObjectToResolved.test.ts.snap
@@ -1,0 +1,88 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`convertTokensObjectToResolved converts object-like unresolved tokens to resolved object 1`] = `
+Object {
+  "colors": Object {
+    "blue": Object {
+      "type": "color",
+      "value": "#0000ff",
+    },
+    "primary": Object {
+      "type": "color",
+      "value": "#ff0000",
+    },
+    "red": Object {
+      "type": "color",
+      "value": "#ff0000",
+    },
+  },
+  "sizing": Object {
+    "base": Object {
+      "type": "sizing",
+      "value": 2,
+    },
+    "medium": Object {
+      "type": "sizing",
+      "value": 3,
+    },
+    "scale": Object {
+      "type": "sizing",
+      "value": 1.5,
+    },
+    "small": Object {
+      "type": "sizing",
+      "value": 2,
+    },
+  },
+}
+`;
+
+exports[`convertTokensObjectToResolved does not expand typography when not needed 1`] = `
+Object {
+  "typography": Object {
+    "h1": Object {
+      "type": "typography",
+      "value": Object {
+        "fontFamily": "Roboto",
+        "fontSize": 96,
+        "fontWeight": "Light",
+      },
+    },
+    "h2": Object {
+      "type": "typography",
+      "value": Object {
+        "fontFamily": "Roboto",
+        "fontSize": 60,
+        "fontWeight": "Light",
+      },
+    },
+    "h3": Object {
+      "type": "typography",
+      "value": Object {
+        "fontFamily": "Roboto",
+        "fontSize": 48,
+        "fontWeight": "Light",
+      },
+    },
+  },
+}
+`;
+
+exports[`convertTokensObjectToResolved respects used sets 1`] = `
+Object {
+  "colors": Object {
+    "background": Object {
+      "type": "color",
+      "value": "#ffffff",
+    },
+    "black": Object {
+      "type": "color",
+      "value": "#000000",
+    },
+    "white": Object {
+      "type": "color",
+      "value": "#ffffff",
+    },
+  },
+}
+`;

--- a/src/utils/convertTokens.tsx
+++ b/src/utils/convertTokens.tsx
@@ -60,5 +60,6 @@ function checkForTokens({
 
 export default function convertToTokenArray({tokens, returnValuesOnly = false, expandTypography = false}) {
     const [result] = checkForTokens({obj: [], token: tokens, returnValuesOnly, expandTypography});
+
     return Object.values(result);
 }

--- a/src/utils/convertTokensObjectToResolved.test.ts
+++ b/src/utils/convertTokensObjectToResolved.test.ts
@@ -43,40 +43,7 @@ describe('convertTokensObjectToResolved', () => {
             },
         };
 
-        expect(convertTokensObjectToResolved(tokens)).toEqual({
-            colors: {
-                red: {
-                    value: '#ff0000',
-                    type: 'color',
-                },
-                blue: {
-                    value: '#0000ff',
-                    type: 'color',
-                },
-                primary: {
-                    value: '#ff0000',
-                    type: 'color',
-                },
-            },
-            sizing: {
-                base: {
-                    value: 2,
-                    type: 'sizing',
-                },
-                scale: {
-                    value: 1.5,
-                    type: 'sizing',
-                },
-                small: {
-                    value: 2,
-                    type: 'sizing',
-                },
-                medium: {
-                    value: 3,
-                    type: 'sizing',
-                },
-            },
-        });
+        expect(convertTokensObjectToResolved(tokens)).toMatchSnapshot();
     });
 
     it('respects used sets', () => {
@@ -111,21 +78,42 @@ describe('convertTokensObjectToResolved', () => {
             },
         };
 
-        expect(convertTokensObjectToResolved(tokens, ['global', 'light'])).toEqual({
-            colors: {
-                white: {
-                    value: '#ffffff',
-                    type: 'color',
+        expect(convertTokensObjectToResolved(tokens, ['global', 'light'])).toMatchSnapshot();
+    });
+
+    it('does not expand typography when not needed', () => {
+        const tokens = {
+            options: [
+                {
+                    name: 'typography.h1',
+                    type: 'typography',
+                    value: {
+                        fontFamily: 'Roboto',
+                        fontSize: '96',
+                        fontWeight: 'Light',
+                    },
                 },
-                black: {
-                    value: '#000000',
-                    type: 'color',
+                {
+                    name: 'typography.h2',
+                    type: 'typography',
+                    value: {
+                        fontFamily: 'Roboto',
+                        fontSize: '60',
+                        fontWeight: 'Light',
+                    },
                 },
-                background: {
-                    value: '#ffffff',
-                    type: 'color',
+                {
+                    name: 'typography.h3',
+                    type: 'typography',
+                    value: {
+                        fontFamily: 'Roboto',
+                        fontSize: '48',
+                        fontWeight: 'Light',
+                    },
                 },
-            },
-        });
+            ],
+        };
+
+        expect(convertTokensObjectToResolved(tokens, [], [], {expandTypography: false})).toMatchSnapshot();
     });
 });

--- a/src/utils/convertTokensObjectToResolved.ts
+++ b/src/utils/convertTokensObjectToResolved.ts
@@ -8,7 +8,9 @@ export default function convertTokensObjectToResolved(
     tokens,
     usedSets = [],
     excludedSets = [],
-    options: TransformerOptions
+    options: TransformerOptions = {
+        expandTypography: true,
+    }
 ) {
     // Parse tokens into array structure
     const parsed = parseTokenValues(tokens);

--- a/src/utils/convertTokensObjectToResolved.ts
+++ b/src/utils/convertTokensObjectToResolved.ts
@@ -1,9 +1,15 @@
 import {mergeTokenGroups, resolveTokenValues} from '@/plugin/tokenHelpers';
+import {TransformerOptions} from './types';
 import convertTokensToGroupedObject from './convertTokensToGroupedObject';
 import parseTokenValues from './parseTokenValues';
 
 // Takes Figma Tokens input, resolves all aliases while respecting user's theme choice and outputs an object with resolved tokens, ready to be consumed by style dictionary.
-export default function convertTokensObjectToResolved(tokens, usedSets = [], excludedSets = []) {
+export default function convertTokensObjectToResolved(
+    tokens,
+    usedSets = [],
+    excludedSets = [],
+    options: TransformerOptions
+) {
     // Parse tokens into array structure
     const parsed = parseTokenValues(tokens);
     // Merge to one giant array
@@ -11,6 +17,6 @@ export default function convertTokensObjectToResolved(tokens, usedSets = [], exc
     // Resolve aliases
     const resolved = resolveTokenValues(merged);
     // Group back into one object
-    const object = convertTokensToGroupedObject(resolved, excludedSets);
+    const object = convertTokensToGroupedObject(resolved, excludedSets, options.expandTypography);
     return object;
 }

--- a/src/utils/convertTokensToGroupedObject.ts
+++ b/src/utils/convertTokensToGroupedObject.ts
@@ -1,7 +1,7 @@
 import {appendTypeToToken} from '@/app/components/createTokenObj';
 import set from 'set-value';
 
-export default function convertTokensToGroupedObject(tokens, excludedSets) {
+export default function convertTokensToGroupedObject(tokens, excludedSets, expandTypography = false) {
     let tokenObj = {};
     tokenObj = tokens.reduce((acc, token) => {
         if (excludedSets.includes(token.internal__Parent)) {
@@ -12,7 +12,7 @@ export default function convertTokensToGroupedObject(tokens, excludedSets) {
         delete tokenWithType.name;
         delete tokenWithType.rawValue;
         delete tokenWithType.internal__Parent;
-        if (tokenWithType.type === 'typography') {
+        if (expandTypography && tokenWithType.type === 'typography') {
             const expandedTypography = Object.entries(tokenWithType.value).reduce((acc, [key, val]) => {
                 acc[key] = {
                     value: val,

--- a/src/utils/test/github/input.json
+++ b/src/utils/test/github/input.json
@@ -28,6 +28,32 @@
         }
     },
     "options": {
+        "typography": {
+            "h1": {
+                "value": {
+                    "fontFamily": "Roboto",
+                    "fontSize": "96",
+                    "fontWeight": "Light"
+                },
+                "type": "typography"
+            },
+            "h2": {
+                "value": {
+                    "fontFamily": "Roboto",
+                    "fontSize": "60",
+                    "fontWeight": "Light"
+                },
+                "type": "typography"
+            },
+            "h3": {
+                "value": {
+                    "fontFamily": "Roboto",
+                    "fontSize": "48",
+                    "fontWeight": "Light"
+                },
+                "type": "typography"
+            }
+        },
         "sizing": {
             "base": {
                 "value": "4",

--- a/src/utils/test/github/output.json
+++ b/src/utils/test/github/output.json
@@ -29,6 +29,33 @@
     ],
     "options": [
         {
+            "name": "typography.h1",
+            "type": "typography",
+            "value": {
+                "fontFamily": "Roboto",
+                "fontSize": "96",
+                "fontWeight": "Light"
+            }
+        },
+        {
+            "name": "typography.h2",
+            "type": "typography",
+            "value": {
+                "fontFamily": "Roboto",
+                "fontSize": "60",
+                "fontWeight": "Light"
+            }
+        },
+        {
+            "name": "typography.h3",
+            "type": "typography",
+            "value": {
+                "fontFamily": "Roboto",
+                "fontSize": "48",
+                "fontWeight": "Light"
+            }
+        },
+        {
             "name": "sizing.base",
             "value": "4",
             "description": "Alias value",

--- a/src/utils/transform.ts
+++ b/src/utils/transform.ts
@@ -1,7 +1,8 @@
 import convertTokensObjectToResolved from './convertTokensObjectToResolved';
+import {TransformerOptions} from './types';
 
-function transform(input, sets, excludes) {
-    return convertTokensObjectToResolved(input, sets, excludes);
+function transform(input, sets, excludes, options: TransformerOptions) {
+    return convertTokensObjectToResolved(input, sets, excludes, options);
 }
 
 export default transform;

--- a/src/utils/types.d.ts
+++ b/src/utils/types.d.ts
@@ -1,0 +1,3 @@
+export interface TransformerOptions {
+    expandTypography: boolean;
+}

--- a/token-transformer/README.md
+++ b/token-transformer/README.md
@@ -3,6 +3,7 @@
 Converts tokens from Figma Tokens to something Style Dictionary can read, removing any math operations or aliases, only resulting in raw values.
 
 ## How to use
+
 Install (either globally or local)
 `npm install token-transformer -g`
 
@@ -11,6 +12,7 @@ Install (either globally or local)
 `node token-transformer input.json output.json global,dark,components global`
 
 ## Parameters
+
 Input: Filename of input
 
 Output: Filename of output

--- a/token-transformer/README.md
+++ b/token-transformer/README.md
@@ -23,4 +23,4 @@ Sets: Sets to be used, comma-seperated
 
 Excludes: Sets that should not be part of the export (e.g. a global color scale)
 
---expandTypography: true|false in order to opt-out of automatic expansion of typography types
+--expandTypography: true|false in order to opt-out of automatic expansion of typography types (default: true)

--- a/token-transformer/README.md
+++ b/token-transformer/README.md
@@ -11,6 +11,8 @@ Install (either globally or local)
 
 `node token-transformer input.json output.json global,dark,components global`
 
+`node token-transformer input.json output.json --expandTypography=false`
+
 ## Parameters
 
 Input: Filename of input
@@ -20,3 +22,5 @@ Output: Filename of output
 Sets: Sets to be used, comma-seperated
 
 Excludes: Sets that should not be part of the export (e.g. a global color scale)
+
+--expandTypography: true|false in order to opt-out of automatic expansion of typography types

--- a/token-transformer/README.md
+++ b/token-transformer/README.md
@@ -23,4 +23,4 @@ Sets: Sets to be used, comma-seperated
 
 Excludes: Sets that should not be part of the export (e.g. a global color scale)
 
---expandTypography: true|false in order to opt-out of automatic expansion of typography types (default: true)
+--expandTypography: true|false to enable/disable automatic expansion of typography types (default: false)

--- a/token-transformer/index.js
+++ b/token-transformer/index.js
@@ -40,7 +40,7 @@ const argv = yargs(hideBin(process.argv))
             .option('expandTypography', {
                 type: 'boolean',
                 describe: 'Expands typography in the output tokens',
-                default: true,
+                default: false,
             });
     })
 
@@ -48,6 +48,9 @@ const argv = yargs(hideBin(process.argv))
     .version()
     .parse();
 
+/**
+ * Utility functions
+ */
 const writeFile = (path, contents, cb) => {
     fs.mkdir(getDirName(path), {recursive: true}, (err) => {
         if (err) return cb(err);
@@ -58,6 +61,11 @@ const writeFile = (path, contents, cb) => {
 
 const log = (message) => process.stdout.write(`[token-transformer] ${message}`);
 
+/**
+ * Transformation
+ *
+ * Reads the given input file, transforms all tokens and writes them to the output file
+ */
 const transform = () => {
     const {input, output, sets, excludes, expandTypography} = argv;
 

--- a/token-transformer/index.js
+++ b/token-transformer/index.js
@@ -1,8 +1,50 @@
 #!/usr/bin/env node
 
+const yargs = require('yargs/yargs');
+const {hideBin} = require('yargs/helpers');
 const fs = require('fs');
 const getDirName = require('path').dirname;
 const transformTokens = require('./dist/transform').default;
+
+/**
+ * Command line arguments
+ */
+const argv = yargs(hideBin(process.argv))
+    .usage('token-transformer input output sets excludes')
+    .example('token-transformer input.json output.json global,dark,components global')
+
+    .command('$0 <input> <output> [sets] [excludes]', 'transforms given tokens', (_yargs) => {
+        _yargs
+            .positional('input', {
+                description: 'Input file containing the tokens',
+                type: 'string',
+                array: true,
+                demandOption: 'ERROR: Specify an input first (e.g. tokens.json)',
+            })
+            .positional('output', {
+                description: 'Output file to write the transformed tokens to',
+                type: 'string',
+                array: true,
+                demandOption: 'ERROR: Specify an output first (e.g. transformed.json)',
+            })
+            .positional('sets', {
+                description: 'Sets to be used, comma separated',
+                type: 'string',
+            })
+            .positional('excludes', {
+                description: 'Sets that should not be part of the export (e.g. a global color scale)',
+                type: 'string',
+            })
+            .option('expandTypography', {
+                type: 'boolean',
+                describe: 'Expands typography in the output tokens',
+                default: false,
+            });
+    })
+
+    .help()
+    .version()
+    .parse();
 
 function writeFile(path, contents, cb) {
     fs.mkdir(getDirName(path), {recursive: true}, function (err) {
@@ -13,25 +55,16 @@ function writeFile(path, contents, cb) {
 }
 
 function transform() {
-    const [input, output, rawSets, rawExcludes] = process.argv.slice(2);
-    const sets = rawSets ? rawSets.split(',') : [];
-    const excludes = rawExcludes ? rawExcludes.split(',') : [];
-    if (!input) {
-        process.stdout.write(`ERROR: Specify an input first (e.g. tokens.json)`);
+    const {input, output, sets, excludes, expandTypography} = argv;
 
-        return;
-    }
-
-    if (!output) {
-        process.stdout.write(`ERROR: Specify an output first (e.g. transformed.json)`);
-
-        return;
-    }
-
-    if (fs.existsSync(input)) {
+    if (fs.existsSync(argv.input)) {
         const tokens = fs.readFileSync(input, {encoding: 'utf8', flag: 'r'});
         const parsed = JSON.parse(tokens);
-        const transformed = transformTokens(parsed, sets, excludes);
+        const options = {
+            expandTypography,
+        };
+        const transformed = transformTokens(parsed, sets, excludes, options);
+
         writeFile(output, JSON.stringify(transformed, null, 2), () => {
             process.stdout.write(
                 `Transformed tokens from ${input} to ${output}, using sets ${sets.join(', ')}${

--- a/token-transformer/input.json
+++ b/token-transformer/input.json
@@ -28,6 +28,32 @@
         }
     },
     "options": {
+        "typography": {
+            "h1": {
+                "value": {
+                    "fontFamily": "Roboto",
+                    "fontSize": "96",
+                    "fontWeight": "Light"
+                },
+                "type": "typography"
+            },
+            "h2": {
+                "value": {
+                    "fontFamily": "Roboto",
+                    "fontSize": "60",
+                    "fontWeight": "Light"
+                },
+                "type": "typography"
+            },
+            "h3": {
+                "value": {
+                    "fontFamily": "Roboto",
+                    "fontSize": "48",
+                    "fontWeight": "Light"
+                },
+                "type": "typography"
+            }
+        },
         "sizing": {
             "base": {
                 "value": "4",

--- a/token-transformer/output.json
+++ b/token-transformer/output.json
@@ -1,0 +1,735 @@
+{
+  "typography": {
+    "h1": {
+      "value": {
+        "fontFamily": "Roboto",
+        "fontSize": 96,
+        "fontWeight": "Light"
+      },
+      "type": "typography"
+    },
+    "h2": {
+      "value": {
+        "fontFamily": "Roboto",
+        "fontSize": 60,
+        "fontWeight": "Light"
+      },
+      "type": "typography"
+    },
+    "h3": {
+      "value": {
+        "fontFamily": "Roboto",
+        "fontSize": 48,
+        "fontWeight": "Light"
+      },
+      "type": "typography"
+    }
+  },
+  "sizing": {
+    "base": {
+      "value": 4,
+      "description": "Alias value",
+      "type": "sizing"
+    },
+    "default": {
+      "value": 8,
+      "description": "Math value",
+      "type": "sizing"
+    }
+  },
+  "Light-Theme-Colorscale": {
+    "Gray": {
+      "00": {
+        "value": "#FAFBFC",
+        "description": "Gray 00",
+        "type": "color"
+      },
+      "01": {
+        "value": "#EAEEF2",
+        "description": "Gray 01",
+        "type": "color"
+      },
+      "02": {
+        "value": "#D4DAE0",
+        "description": "Gray 02",
+        "type": "color"
+      },
+      "03": {
+        "value": "#B7BFC7",
+        "description": "Gray 03",
+        "type": "color"
+      },
+      "04": {
+        "value": "#949DA7",
+        "description": "Gray 04",
+        "type": "color"
+      },
+      "05": {
+        "value": "#707A84",
+        "description": "Gray 05",
+        "type": "color"
+      },
+      "06": {
+        "value": "#57606A",
+        "description": "Gray 06",
+        "type": "color"
+      },
+      "07": {
+        "value": "#424A53",
+        "description": "Gray 07",
+        "type": "color"
+      },
+      "08": {
+        "value": "#32383F",
+        "description": "Gray 08",
+        "type": "color"
+      },
+      "09": {
+        "value": "#24292F",
+        "description": "Gray 09",
+        "type": "color"
+      },
+      "Black": {
+        "value": "#1B1F24",
+        "description": "Gray 10 or Black",
+        "type": "color"
+      }
+    },
+    "Coral": {
+      "00": {
+        "value": "#FFF0EB",
+        "description": "Coral 00",
+        "type": "color"
+      },
+      "01": {
+        "value": "#FFD6CC",
+        "description": "Coral 01",
+        "type": "color"
+      },
+      "02": {
+        "value": "#FFB4A1",
+        "description": "Coral 02",
+        "type": "color"
+      },
+      "03": {
+        "value": "#FD8C73",
+        "description": "Coral 03",
+        "type": "color"
+      },
+      "04": {
+        "value": "#EC6547",
+        "description": "Coral 04",
+        "type": "color"
+      },
+      "05": {
+        "value": "#C4432B",
+        "description": "Coral 05",
+        "type": "color"
+      },
+      "06": {
+        "value": "#9E2F1C",
+        "description": "Coral 06",
+        "type": "color"
+      },
+      "07": {
+        "value": "#801F0F",
+        "description": "Coral 07",
+        "type": "color"
+      },
+      "08": {
+        "value": "#691105",
+        "description": "Coral 08",
+        "type": "color"
+      },
+      "09": {
+        "value": "#510901",
+        "description": "Coral 09",
+        "type": "color"
+      }
+    },
+    "Blue": {
+      "00": {
+        "value": "#E4F6FF",
+        "description": "Blue 00",
+        "type": "color"
+      },
+      "01": {
+        "value": "#BCE5FF",
+        "description": "Blue 01",
+        "type": "color"
+      },
+      "02": {
+        "value": "#89CDFF",
+        "description": "Blue 02",
+        "type": "color"
+      },
+      "03": {
+        "value": "#58B1FF",
+        "description": "Blue 03",
+        "type": "color"
+      },
+      "04": {
+        "value": "#298FFF",
+        "description": "Blue 04",
+        "type": "color"
+      },
+      "05": {
+        "value": "#096BDE",
+        "description": "Blue 05",
+        "type": "color"
+      },
+      "06": {
+        "value": "#0552B2",
+        "description": "Blue 06",
+        "type": "color"
+      },
+      "07": {
+        "value": "#033F8F",
+        "description": "Blue 07",
+        "type": "color"
+      },
+      "08": {
+        "value": "#0B326D",
+        "description": "Blue 08",
+        "type": "color"
+      },
+      "09": {
+        "value": "#052455",
+        "description": "Blue 09",
+        "type": "color"
+      }
+    },
+    "Pink": {
+      "00": {
+        "value": "#FFEFF7",
+        "description": "Pink 00",
+        "type": "color"
+      },
+      "01": {
+        "value": "#FFD3EB",
+        "description": "Pink 01",
+        "type": "color"
+      },
+      "02": {
+        "value": "#FFADDA",
+        "description": "Pink 02",
+        "type": "color"
+      },
+      "03": {
+        "value": "#FF80C8",
+        "description": "Pink 03",
+        "type": "color"
+      },
+      "04": {
+        "value": "#E85AAD",
+        "description": "Pink 04",
+        "type": "color"
+      },
+      "05": {
+        "value": "#BF3989",
+        "description": "Pink 05",
+        "type": "color"
+      },
+      "06": {
+        "value": "#99286E",
+        "description": "Pink 06",
+        "type": "color"
+      },
+      "07": {
+        "value": "#772057",
+        "description": "Pink 07",
+        "type": "color"
+      },
+      "08": {
+        "value": "#611347",
+        "description": "Pink 08",
+        "type": "color"
+      },
+      "09": {
+        "value": "#4D0336",
+        "description": "Pink 09",
+        "type": "color"
+      }
+    },
+    "Orange": {
+      "00": {
+        "value": "#FFF1E5",
+        "description": "Orange 00",
+        "type": "color"
+      },
+      "01": {
+        "value": "#FFD8B5",
+        "description": "Orange 01",
+        "type": "color"
+      },
+      "02": {
+        "value": "#FFB77C",
+        "description": "Orange 2",
+        "type": "color"
+      },
+      "03": {
+        "value": "#FB8F44",
+        "description": "Orange 03",
+        "type": "color"
+      },
+      "04": {
+        "value": "#E16F24",
+        "description": "Orange 04",
+        "type": "color"
+      },
+      "05": {
+        "value": "#BC4C00",
+        "description": "Orange 05",
+        "type": "color"
+      },
+      "06": {
+        "value": "#953800",
+        "description": "Orange 06",
+        "type": "color"
+      },
+      "07": {
+        "value": "#762C00",
+        "description": "Orange 07",
+        "type": "color"
+      },
+      "08": {
+        "value": "#5C2200",
+        "description": "Orange 08",
+        "type": "color"
+      },
+      "09": {
+        "value": "#471700",
+        "description": "Orange 09",
+        "type": "color"
+      }
+    },
+    "Red": {
+      "00": {
+        "value": "#FFEFEE",
+        "description": "Red 00",
+        "type": "color"
+      },
+      "01": {
+        "value": "#FFD5D3",
+        "description": "Red 01",
+        "type": "color"
+      },
+      "02": {
+        "value": "#FFB2B0",
+        "description": "Red 02",
+        "type": "color"
+      },
+      "03": {
+        "value": "#FF8987",
+        "description": "Red 03",
+        "type": "color"
+      },
+      "04": {
+        "value": "#FB5254",
+        "description": "Red 04",
+        "type": "color"
+      },
+      "05": {
+        "value": "#D42A32",
+        "description": "Red 05",
+        "type": "color"
+      },
+      "06": {
+        "value": "#A81C26",
+        "description": "Red 06",
+        "type": "color"
+      },
+      "07": {
+        "value": "#84161F",
+        "description": "Red 07",
+        "type": "color"
+      },
+      "08": {
+        "value": "#691019",
+        "description": "Red 08",
+        "type": "color"
+      },
+      "09": {
+        "value": "#52040F",
+        "description": "Red 09",
+        "type": "color"
+      }
+    },
+    "Indigo": {
+      "00": {
+        "value": "#EFF2FF",
+        "description": "Indigo 00",
+        "type": "color"
+      },
+      "01": {
+        "value": "#D7DDFF",
+        "description": "Indigo 01",
+        "type": "color"
+      },
+      "02": {
+        "value": "#B9C2FF",
+        "description": "Indigo 02",
+        "type": "color"
+      },
+      "03": {
+        "value": "#9AA4FF",
+        "description": "Indigo 03",
+        "type": "color"
+      },
+      "04": {
+        "value": "#7683FF",
+        "description": "Indigo 04",
+        "type": "color"
+      },
+      "05": {
+        "value": "#545DF0",
+        "description": "Indigo 05",
+        "type": "color"
+      },
+      "06": {
+        "value": "#3C42D0",
+        "description": "Indigo 06",
+        "type": "color"
+      },
+      "07": {
+        "value": "#2C33A5",
+        "description": "Indigo 07",
+        "type": "color"
+      },
+      "08": {
+        "value": "#22297F",
+        "description": "Indigo 08",
+        "type": "color"
+      },
+      "09": {
+        "value": "#191F5C",
+        "description": "Indigo 09",
+        "type": "color"
+      }
+    },
+    "Purple": {
+      "00": {
+        "value": "#FBEFFF",
+        "description": "Purple 00",
+        "type": "color"
+      },
+      "01": {
+        "value": "#ECD8FF",
+        "description": "Purple 01",
+        "type": "color"
+      },
+      "02": {
+        "value": "#D8B9FF",
+        "description": "Purple 02",
+        "type": "color"
+      },
+      "03": {
+        "value": "#C297FF",
+        "description": "Purple 03",
+        "type": "color"
+      },
+      "04": {
+        "value": "#A475F9",
+        "description": "Purple 04",
+        "type": "color"
+      },
+      "05": {
+        "value": "#8250DF",
+        "description": "Purple 05",
+        "type": "color"
+      },
+      "06": {
+        "value": "#6639BA",
+        "description": "Purple 06",
+        "type": "color"
+      },
+      "07": {
+        "value": "#512A97",
+        "description": "Purple 07",
+        "type": "color"
+      },
+      "08": {
+        "value": "#3E1F79",
+        "description": "Purple 08",
+        "type": "color"
+      },
+      "09": {
+        "value": "#2E1461",
+        "description": "Purple 09",
+        "type": "color"
+      }
+    },
+    "Green": {
+      "00": {
+        "value": "#DAFBE1",
+        "description": "Green 00",
+        "type": "color"
+      },
+      "01": {
+        "value": "#ACEEBB",
+        "description": "Green 01",
+        "type": "color"
+      },
+      "02": {
+        "value": "#6FDD8B",
+        "description": "Green 02",
+        "type": "color"
+      },
+      "03": {
+        "value": "#4AC26B",
+        "description": "Green 03",
+        "type": "color"
+      },
+      "04": {
+        "value": "#2DA44E",
+        "description": "Green 04",
+        "type": "color"
+      },
+      "05": {
+        "value": "#1A7F37",
+        "description": "Green 05",
+        "type": "color"
+      },
+      "06": {
+        "value": "#116329",
+        "description": "Green 06",
+        "type": "color"
+      },
+      "07": {
+        "value": "#044F1E",
+        "description": "Green 07",
+        "type": "color"
+      },
+      "08": {
+        "value": "#003D16",
+        "description": "Green 08",
+        "type": "color"
+      },
+      "09": {
+        "value": "#002D11",
+        "description": "Green 09",
+        "type": "color"
+      }
+    },
+    "Yellow": {
+      "00": {
+        "value": "#FCF4CA",
+        "description": "Yellow 00",
+        "type": "color"
+      },
+      "01": {
+        "value": "#F6DE7C",
+        "description": "Yellow 01",
+        "type": "color"
+      },
+      "02": {
+        "value": "#E6C24A",
+        "description": "Yellow 02",
+        "type": "color"
+      },
+      "03": {
+        "value": "#D2A52D",
+        "description": "Yellow 03",
+        "type": "color"
+      },
+      "04": {
+        "value": "#BB8400",
+        "description": "Yellow 04",
+        "type": "color"
+      },
+      "05": {
+        "value": "#976500",
+        "description": "Yellow 05",
+        "type": "color"
+      },
+      "06": {
+        "value": "#7A4C00",
+        "description": "Yellow 06",
+        "type": "color"
+      },
+      "07": {
+        "value": "#613B01",
+        "description": "Yellow 07",
+        "type": "color"
+      },
+      "08": {
+        "value": "#4D2D00",
+        "description": "Yellow 08",
+        "type": "color"
+      },
+      "09": {
+        "value": "#382103",
+        "description": "Yellow 09",
+        "type": "color"
+      }
+    },
+    "Lemon": {
+      "00": {
+        "value": "#FDF5B3",
+        "description": "Lemon 00",
+        "type": "color"
+      },
+      "01": {
+        "value": "#F4E162",
+        "description": "Lemon 01",
+        "type": "color"
+      },
+      "02": {
+        "value": "#DEC741",
+        "description": "Lemon 02",
+        "type": "color"
+      },
+      "03": {
+        "value": "#C5AA20",
+        "description": "Lemon 03",
+        "type": "color"
+      },
+      "04": {
+        "value": "#A88D02",
+        "description": "Lemon 04",
+        "type": "color"
+      },
+      "05": {
+        "value": "#866D00",
+        "description": "Lemon 05",
+        "type": "color"
+      },
+      "06": {
+        "value": "#685400",
+        "description": "Lemon 06",
+        "type": "color"
+      },
+      "07": {
+        "value": "#534100",
+        "description": "Lemon 07",
+        "type": "color"
+      },
+      "08": {
+        "value": "#413200",
+        "description": "Lemon 08",
+        "type": "color"
+      },
+      "09": {
+        "value": "#322400",
+        "description": "Lemon 09",
+        "type": "color"
+      }
+    },
+    "Lime": {
+      "00": {
+        "value": "#EAFABA",
+        "description": "Lime 00",
+        "type": "color"
+      },
+      "01": {
+        "value": "#CDEC78",
+        "description": "Lime 01",
+        "type": "color"
+      },
+      "02": {
+        "value": "#B1D353",
+        "description": "Lime 02",
+        "type": "color"
+      },
+      "03": {
+        "value": "#94B83B",
+        "description": "Lime 03",
+        "type": "color"
+      },
+      "04": {
+        "value": "#799A2A",
+        "description": "Lime 04",
+        "type": "color"
+      },
+      "05": {
+        "value": "#5A791B",
+        "description": "Lime 05",
+        "type": "color"
+      },
+      "06": {
+        "value": "#425E13",
+        "description": "Lime 06",
+        "type": "color"
+      },
+      "07": {
+        "value": "#2F4A06",
+        "description": "Lime 07",
+        "type": "color"
+      },
+      "08": {
+        "value": "#233B03",
+        "description": "Lime 08",
+        "type": "color"
+      },
+      "09": {
+        "value": "#182C01",
+        "description": "Lime 09",
+        "type": "color"
+      }
+    },
+    "Teal": {
+      "00": {
+        "value": "#DAF9F5",
+        "description": "Teal 00",
+        "type": "color"
+      },
+      "01": {
+        "value": "#B0EAE3",
+        "description": "Teal 01",
+        "type": "color"
+      },
+      "02": {
+        "value": "#6BD6D0",
+        "description": "Teal 02",
+        "type": "color"
+      },
+      "03": {
+        "value": "#49BCB7",
+        "description": "Teal 03",
+        "type": "color"
+      },
+      "04": {
+        "value": "#339D9B",
+        "description": "Teal 04",
+        "type": "color"
+      },
+      "05": {
+        "value": "#197B7B",
+        "description": "Teal 05",
+        "type": "color"
+      },
+      "06": {
+        "value": "#136061",
+        "description": "Teal 06",
+        "type": "color"
+      },
+      "07": {
+        "value": "#024B4D",
+        "description": "Teal 07",
+        "type": "color"
+      },
+      "08": {
+        "value": "#063A3C",
+        "description": "Teal 08",
+        "type": "color"
+      },
+      "09": {
+        "value": "#052B2C",
+        "description": "Teal 09",
+        "type": "color"
+      }
+    }
+  },
+  "colors": {
+    "Background": {
+      "value": "#1B1F24",
+      "description": "Alias value",
+      "type": "color"
+    },
+    "Background50": {
+      "value": "#1b1f2480",
+      "description": "Nested color value",
+      "type": "color"
+    }
+  }
+}

--- a/webpack-transform.config.js
+++ b/webpack-transform.config.js
@@ -29,6 +29,11 @@ module.exports = (env, argv) => ({
             '@types': path.resolve(__dirname, 'types'),
             '@': path.resolve(__dirname, 'src'),
         },
+        fallback: {
+            assert: require.resolve('assert'),
+            fs: false,
+            path: require.resolve('path-browserify'),
+        },
         extensions: ['.tsx', '.ts', '.jsx', '.js'],
     },
 

--- a/webpack-transform.config.js
+++ b/webpack-transform.config.js
@@ -29,11 +29,6 @@ module.exports = (env, argv) => ({
             '@types': path.resolve(__dirname, 'types'),
             '@': path.resolve(__dirname, 'src'),
         },
-        fallback: {
-            assert: require.resolve('assert'),
-            fs: false,
-            path: require.resolve('path-browserify'),
-        },
         extensions: ['.tsx', '.ts', '.jsx', '.js'],
     },
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2457,6 +2457,13 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@types/yargs@^17.0.8":
+  version "17.0.8"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.8.tgz#d23a3476fd3da8a0ea44b5494ca7fa677b9dad4c"
+  integrity sha512-wDeUwiUmem9FzsyysEwRukaEdDNcwbROvQ9QGRKaLI6t+IltNzbn4/i4asmB10auvZGQCzSQ6t0GSczEThlUXw==
+  dependencies:
+    "@types/yargs-parser" "*"
+
 "@typescript-eslint/eslint-plugin@^2.1.0":
   version "2.34.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.34.0.tgz#6f8ce8a46c7dea4a6f1d171d2bb8fbae6dac2be9"
@@ -2807,6 +2814,11 @@ ansi-regex@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
@@ -2974,6 +2986,16 @@ assert@^1.1.1:
     object-assign "^4.1.1"
     util "0.10.3"
 
+assert@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/assert/-/assert-2.0.0.tgz#95fc1c616d48713510680f2eaf2d10dd22e02d32"
+  integrity sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==
+  dependencies:
+    es6-object-assign "^1.1.0"
+    is-nan "^1.2.1"
+    object-is "^1.0.1"
+    util "^0.12.0"
+
 assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
@@ -3025,6 +3047,11 @@ autoprefixer@^10.2.5:
     fraction.js "^4.0.13"
     normalize-range "^0.1.2"
     postcss-value-parser "^4.1.0"
+
+available-typed-arrays@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
+  integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
 aws-sign2@~0.7.0:
   version "0.7.0"
@@ -4775,6 +4802,32 @@ es-abstract@^1.17.2, es-abstract@^1.18.0-next.1, es-abstract@^1.18.0-next.2:
     string.prototype.trimstart "^1.0.4"
     unbox-primitive "^1.0.0"
 
+es-abstract@^1.18.5:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.19.1.tgz#d4885796876916959de78edaa0df456627115ec3"
+  integrity sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==
+  dependencies:
+    call-bind "^1.0.2"
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    get-intrinsic "^1.1.1"
+    get-symbol-description "^1.0.0"
+    has "^1.0.3"
+    has-symbols "^1.0.2"
+    internal-slot "^1.0.3"
+    is-callable "^1.2.4"
+    is-negative-zero "^2.0.1"
+    is-regex "^1.1.4"
+    is-shared-array-buffer "^1.0.1"
+    is-string "^1.0.7"
+    is-weakref "^1.0.1"
+    object-inspect "^1.11.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.2"
+    string.prototype.trimend "^1.0.4"
+    string.prototype.trimstart "^1.0.4"
+    unbox-primitive "^1.0.1"
+
 es-to-primitive@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a"
@@ -4783,6 +4836,11 @@ es-to-primitive@^1.2.1:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
+
+es6-object-assign@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
+  integrity sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -5464,6 +5522,11 @@ for-in@^1.0.2:
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
   integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
 
+foreach@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
+  integrity sha1-C+4AUBiusmDQo6865ljdATbsG5k=
+
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
@@ -5613,6 +5676,14 @@ get-stream@^5.0.0:
   integrity sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==
   dependencies:
     pump "^3.0.0"
+
+get-symbol-description@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/get-symbol-description/-/get-symbol-description-1.0.0.tgz#7fdb81c900101fbd564dd5f1a30af5aadc1e58d6"
+  integrity sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.1"
 
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
@@ -5771,7 +5842,7 @@ has-ansi@^2.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
-has-bigints@^1.0.0:
+has-bigints@^1.0.0, has-bigints@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.1.tgz#64fe6acb020673e3b78db035a5af69aa9d07b113"
   integrity sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==
@@ -5790,6 +5861,13 @@ has-symbols@^1.0.0, has-symbols@^1.0.1, has-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
   integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
+
+has-tostringtag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.0.tgz#7e133818a7d394734f941e73c3d3f9291e658b25"
+  integrity sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==
+  dependencies:
+    has-symbols "^1.0.2"
 
 has-value@^0.3.1:
   version "0.3.1"
@@ -6157,6 +6235,14 @@ is-accessor-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
+is-arguments@^1.0.4:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.1.tgz#15b3f88fda01f2a97fec84ca761a560f123efa9b"
+  integrity sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==
+  dependencies:
+    call-bind "^1.0.2"
+    has-tostringtag "^1.0.0"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -6202,6 +6288,11 @@ is-callable@^1.1.4, is-callable@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.3.tgz#8b1e0500b73a1d76c70487636f368e519de8db8e"
   integrity sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==
+
+is-callable@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.4.tgz#47301d58dd0259407865547853df6d61fe471945"
+  integrity sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==
 
 is-ci@^2.0.0:
   version "2.0.0"
@@ -6303,6 +6394,13 @@ is-generator-fn@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
+is-generator-function@^1.0.7:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.0.10.tgz#f1558baf1ac17e0deea7c0415c438351ff2b3c72"
+  integrity sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==
+  dependencies:
+    has-tostringtag "^1.0.0"
+
 is-glob@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
@@ -6324,6 +6422,14 @@ is-installed-globally@^0.3.2:
   dependencies:
     global-dirs "^2.0.1"
     is-path-inside "^3.0.1"
+
+is-nan@^1.2.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/is-nan/-/is-nan-1.3.2.tgz#043a54adea31748b55b6cd4e09aadafa69bd9e1d"
+  integrity sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
 
 is-negative-zero@^2.0.1:
   version "2.0.1"
@@ -6399,10 +6505,23 @@ is-regex@^1.1.2:
     call-bind "^1.0.2"
     has-symbols "^1.0.1"
 
+is-regex@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958"
+  integrity sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==
+  dependencies:
+    call-bind "^1.0.2"
+    has-tostringtag "^1.0.0"
+
 is-regexp@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
   integrity sha1-/S2INUXEa6xaYz57mgnof6LLUGk=
+
+is-shared-array-buffer@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz#97b0c85fbdacb59c9c446fe653b82cf2b5b7cfe6"
+  integrity sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==
 
 is-stream@^1.1.0:
   version "1.1.0"
@@ -6419,6 +6538,13 @@ is-string@^1.0.5:
   resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.5.tgz#40493ed198ef3ff477b8c7f92f644ec82a5cd3a6"
   integrity sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==
 
+is-string@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.7.tgz#0dd12bf2006f255bb58f695110eff7491eebc0fd"
+  integrity sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==
+  dependencies:
+    has-tostringtag "^1.0.0"
+
 is-symbol@^1.0.2, is-symbol@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.3.tgz#38e1014b9e6329be0de9d24a414fd7441ec61937"
@@ -6426,10 +6552,28 @@ is-symbol@^1.0.2, is-symbol@^1.0.3:
   dependencies:
     has-symbols "^1.0.1"
 
+is-typed-array@^1.1.3, is-typed-array@^1.1.7:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.8.tgz#cbaa6585dc7db43318bc5b89523ea384a6f65e79"
+  integrity sha512-HqH41TNZq2fgtGT8WHVFVJhBVGuY3AnP3Q36K8JKXUxSxRgk/d+7NjmwG2vo2mYmXK8UYZKu0qH8bVP5gEisjA==
+  dependencies:
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.2"
+    es-abstract "^1.18.5"
+    foreach "^2.0.5"
+    has-tostringtag "^1.0.0"
+
 is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
+
+is-weakref@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.0.2.tgz#9529f383a9338205e89765e0392efc2f100f06f2"
+  integrity sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==
+  dependencies:
+    call-bind "^1.0.2"
 
 is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
@@ -7876,10 +8020,23 @@ object-hash@^2.1.1:
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.1.1.tgz#9447d0279b4fcf80cff3259bf66a1dc73afabe09"
   integrity sha512-VOJmgmS+7wvXf8CjbQmimtCnEx3IAoLxI3fp2fbWehxrWBcAQFbk+vcwb6vzR0VZv/eNCJ/27j151ZTwqW/JeQ==
 
+object-inspect@^1.11.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.0.tgz#6e2c120e868fd1fd18cb4f18c31741d0d6e776f0"
+  integrity sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==
+
 object-inspect@^1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.9.0.tgz#c90521d74e1127b67266ded3394ad6116986533a"
   integrity sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==
+
+object-is@^1.0.1:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.5.tgz#b9deeaa5fc7f1846a0faecdceec138e5778f53ac"
+  integrity sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
 
 object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
@@ -8186,6 +8343,11 @@ path-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.1.tgz#e6c4ddd7ed3aa27c68a20cc4e50e1a4ee83bbc4a"
   integrity sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==
+
+path-browserify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-1.0.1.tgz#d98454a9c3753d5790860f16f68867b9e46be1fd"
+  integrity sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==
 
 path-dirname@^1.0.0:
   version "1.0.2"
@@ -9804,6 +9966,15 @@ string-width@^4.1.0, string-width@^4.2.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
 
+string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
 string.prototype.matchall@^4.0.2:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.4.tgz#608f255e93e072107f5de066f81a2dfb78cf6b29"
@@ -9892,6 +10063,13 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
+
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-bom@^3.0.0:
   version "3.0.0"
@@ -10390,6 +10568,16 @@ unbox-primitive@^1.0.0:
     has-symbols "^1.0.0"
     which-boxed-primitive "^1.0.1"
 
+unbox-primitive@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.1.tgz#085e215625ec3162574dc8859abee78a59b14471"
+  integrity sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==
+  dependencies:
+    function-bind "^1.1.1"
+    has-bigints "^1.0.1"
+    has-symbols "^1.0.2"
+    which-boxed-primitive "^1.0.2"
+
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz#2619800c4c825800efdd8343af7dd9933cbe2818"
@@ -10582,6 +10770,18 @@ util@^0.11.0:
   dependencies:
     inherits "2.0.3"
 
+util@^0.12.0:
+  version "0.12.4"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.12.4.tgz#66121a31420df8f01ca0c464be15dfa1d1850253"
+  integrity sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==
+  dependencies:
+    inherits "^2.0.3"
+    is-arguments "^1.0.4"
+    is-generator-function "^1.0.7"
+    is-typed-array "^1.1.3"
+    safe-buffer "^5.1.2"
+    which-typed-array "^1.1.2"
+
 utila@~0.4:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
@@ -10769,7 +10969,7 @@ whatwg-url@^8.0.0:
     tr46 "^2.0.2"
     webidl-conversions "^6.1.0"
 
-which-boxed-primitive@^1.0.1:
+which-boxed-primitive@^1.0.1, which-boxed-primitive@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz#13757bc89b209b049fe5d86430e21cf40a89a8e6"
   integrity sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==
@@ -10784,6 +10984,18 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
+
+which-typed-array@^1.1.2:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.7.tgz#2761799b9a22d4b8660b3c1b40abaa7739691793"
+  integrity sha512-vjxaB4nfDqwKI0ws7wZpxIlde1XrLX5uB0ZjpfshgmapJMD7jJWhZI+yToJTqaFByF0eNBcYxbjmCzoRP7CfEw==
+  dependencies:
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.2"
+    es-abstract "^1.18.5"
+    foreach "^2.0.5"
+    has-tostringtag "^1.0.0"
+    is-typed-array "^1.1.7"
 
 which@^1.2.14, which@^1.2.9, which@^1.3.1:
   version "1.3.1"
@@ -10939,6 +11151,11 @@ yargs-parser@^20.2.2:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.7.tgz#61df85c113edfb5a7a4e36eb8aa60ef423cbc90a"
   integrity sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==
 
+yargs-parser@^21.0.0:
+  version "21.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.0.0.tgz#a485d3966be4317426dd56bdb6a30131b281dc55"
+  integrity sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==
+
 yargs@^13.3.0, yargs@^13.3.2:
   version "13.3.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.2.tgz#ad7ffefec1aa59565ac915f82dccb38a9c31a2dd"
@@ -10984,6 +11201,19 @@ yargs@^16.0.0:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
+
+yargs@^17.3.1:
+  version "17.3.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.3.1.tgz#da56b28f32e2fd45aefb402ed9c26f42be4c07b9"
+  integrity sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.0.0"
 
 yauzl@^2.10.0:
   version "2.10.0"


### PR DESCRIPTION
Currently the **token-transformer** CLI automatically expands typography types to:

```
"typographyName": {
  "fontFamily": {
    "value": "Roboto"
  },
  "fontSize": {
    "value": 18
  }
}
```
For style-dictionary compatibility it would be easier to have the following format (especially for custom formats):
```
"typographyName": {
  "type": "typography",
  "value": {
    "fontFamily": "Roboto",
    "fontSize": 18
  }
}
```
so we can use the **type** to group/filter typographies together.

This PR adds:
* yargs set-up for token-transformer inputs & validation
* possibility to add options for transformations (here I introduced expandTypography so users can opt-out of this auto expansion)