### PR TITLE
Add the ability to preserve rawValue on token transform

### DIFF
--- a/src/utils/__snapshots__/convertTokensObjectToResolved.test.ts.snap
+++ b/src/utils/__snapshots__/convertTokensObjectToResolved.test.ts.snap
@@ -68,6 +68,28 @@ Object {
 }
 `;
 
+exports[`convertTokensObjectToResolved preserves rawValue when requested 1`] = `
+Object {
+  "colors": Object {
+    "background": Object {
+      "rawValue": "$colors.black",
+      "type": "color",
+      "value": "#000000",
+    },
+    "black": Object {
+      "rawValue": "#000000",
+      "type": "color",
+      "value": "#000000",
+    },
+    "white": Object {
+      "rawValue": "#ffffff",
+      "type": "color",
+      "value": "#ffffff",
+    },
+  },
+}
+`;
+
 exports[`convertTokensObjectToResolved respects used sets 1`] = `
 Object {
   "colors": Object {

--- a/src/utils/convertTokensObjectToResolved.test.ts
+++ b/src/utils/convertTokensObjectToResolved.test.ts
@@ -114,6 +114,41 @@ describe('convertTokensObjectToResolved', () => {
       ],
     };
 
-    expect(convertTokensObjectToResolved(tokens, [], [], { expandTypography: false })).toMatchSnapshot();
+    expect(convertTokensObjectToResolved(tokens, [], [], { expandTypography: false, preserveRawValue: false })).toMatchSnapshot();
+  });
+
+  it('preserves rawValue when requested', () => {
+    const tokens = {
+      global: {
+        colors: {
+          white: {
+            value: '#ffffff',
+            type: 'color',
+          },
+          black: {
+            value: '#000000',
+            type: 'color',
+          },
+        },
+      },
+      light: {
+        colors: {
+          background: {
+            value: '$colors.white',
+            type: 'color',
+          },
+        },
+      },
+      dark: {
+        colors: {
+          background: {
+            value: '$colors.black',
+            type: 'color',
+          },
+        },
+      },
+    };
+
+    expect(convertTokensObjectToResolved(tokens, [], [], { expandTypography: false, preserveRawValue: true })).toMatchSnapshot();
   });
 });

--- a/src/utils/convertTokensObjectToResolved.ts
+++ b/src/utils/convertTokensObjectToResolved.ts
@@ -10,6 +10,7 @@ export default function convertTokensObjectToResolved(
   excludedSets = [],
   options: TransformerOptions = {
     expandTypography: false,
+    preserveRawValue: false,
   },
 ) {
   // Parse tokens into array structure
@@ -19,6 +20,6 @@ export default function convertTokensObjectToResolved(
   // Resolve aliases
   const resolved = resolveTokenValues(merged);
   // Group back into one object
-  const object = convertTokensToGroupedObject(resolved, excludedSets, options.expandTypography);
+  const object = convertTokensToGroupedObject(resolved, excludedSets, options);
   return object;
 }

--- a/src/utils/convertTokensToGroupedObject.ts
+++ b/src/utils/convertTokensToGroupedObject.ts
@@ -1,7 +1,8 @@
 import set from 'set-value';
 import { appendTypeToToken } from '@/app/components/createTokenObj';
+import { TransformerOptions } from './types';
 
-export default function convertTokensToGroupedObject(tokens, excludedSets, expandTypography = false) {
+export default function convertTokensToGroupedObject(tokens, excludedSets, options: TransformerOptions) {
   let tokenObj = {};
   tokenObj = tokens.reduce((acc, token) => {
     if (excludedSets.includes(token.internal__Parent)) {
@@ -10,9 +11,11 @@ export default function convertTokensToGroupedObject(tokens, excludedSets, expan
     const obj = acc || {};
     const tokenWithType = appendTypeToToken(token);
     delete tokenWithType.name;
-    delete tokenWithType.rawValue;
+    if (!options.preserveRawValue) {
+      delete tokenWithType.rawValue;
+    }
     delete tokenWithType.internal__Parent;
-    if (!!expandTypography && tokenWithType.type === 'typography') {
+    if (!!options.expandTypography && tokenWithType.type === 'typography') {
       const expandedTypography = Object.entries(tokenWithType.value).reduce((acc, [key, val]) => {
         acc[key] = {
           value: val,

--- a/src/utils/types.d.ts
+++ b/src/utils/types.d.ts
@@ -1,3 +1,4 @@
 export interface TransformerOptions {
   expandTypography: boolean;
+  preserveRawValue: boolean;
 }

--- a/token-transformer/index.js
+++ b/token-transformer/index.js
@@ -41,6 +41,11 @@ const argv = yargs(hideBin(process.argv))
                 type: 'boolean',
                 describe: 'Expands typography in the output tokens',
                 default: false,
+            })
+            .option('preserveRawValue', {
+                type: 'boolean',
+                describe: 'Preserve the raw, unprocessed value in the output tokens',
+                default: false
             });
     })
 
@@ -67,19 +72,20 @@ const log = (message) => process.stdout.write(`[token-transformer] ${message}\n`
  * Reads the given input file, transforms all tokens and writes them to the output file
  */
 const transform = () => {
-    const {input, output, sets, excludes, expandTypography} = argv;
+    const {input, output, sets, excludes, expandTypography, preserveRawValue} = argv;
 
     if (fs.existsSync(argv.input)) {
         const tokens = fs.readFileSync(input, {encoding: 'utf8', flag: 'r'});
         const parsed = JSON.parse(tokens);
         const options = {
             expandTypography,
+            preserveRawValue
         };
 
         log(`transforming tokens from input: ${input}`);
         log(`using sets: ${sets.length > 0 ? sets : '[]'}`);
         log(`using excludes: ${excludes.length > 0 ? excludes : '[]'}`);
-        log(`using options: { expandTypography: ${expandTypography} }`);
+        log(`using options: { expandTypography: ${expandTypography}, preserveRawValue: ${preserveRawValue} }`);
 
         const transformed = transformTokens(parsed, sets, excludes, options);
 


### PR DESCRIPTION
This PR adds the option `--preserveRawValue` to `token-transformer` which does as it suggests... preserves the `rawValue` field in the token output. This value is very useful when theming because it preserves the context of what a given value referenced which can be useful in custom formatters.

As a use-case example, image you had this token config

```js
colors: {
  base: {
    green: {
      '500': {
        value: '#48d597',
        type: 'color',
      },
    },
  },
},
main: {
  theme: {
    accent: {
      "1": {
        value: "{base.green.500}",
        type: "color"
      }
    }
  },
  content: {
    accent: {
      default: {
        value: "{theme.accent.1}",
        type: "color"
      },
    }
  }
}
```

It's fairly clear from looking at the config that there's a relationship between `content-accent`, `theme-accent-1`, and `base-green-500`. If you're building a theming setup, preserving that relationship via css-variables maximizes the flexibility you have to make broad changes by touching the fewest points. That's essentially what I wanted to do. 