### PR TITLE
Fix tooltips lineHeight and letterSpacing

### DIFF
--- a/src/app/components/TokenTooltip.tsx
+++ b/src/app/components/TokenTooltip.tsx
@@ -47,19 +47,23 @@ export default function TokenTooltip({ token, resolvedTokens, shouldResolve = fa
         <div>
           <div>
             Font:
+            {' '}
             {valueToCheck.fontFamily?.value || valueToCheck.fontFamily}
           </div>
           <div>
             Weight:
+            {' '}
             {valueToCheck.fontWeight?.value || valueToCheck.fontWeight}
           </div>
           <div>
             Leading:
+            {' '}
             {valueToCheck.lineHeight?.value || valueToCheck.lineHeight}
           </div>
           <div>
             Tracking:
-            {valueToCheck.lineHeight?.value || valueToCheck.lineHeight}
+            {' '}
+            {valueToCheck.letterSpacing?.value || valueToCheck.letterSpacing}
           </div>
           <div>
             Paragraph Spacing:
@@ -68,10 +72,12 @@ export default function TokenTooltip({ token, resolvedTokens, shouldResolve = fa
           </div>
           <div>
             Text Case:
+            {' '}
             {valueToCheck.textCase?.value || valueToCheck.textCase}
           </div>
           <div>
             Text Decoration:
+            {' '}
             {valueToCheck.textDecoration?.value || valueToCheck.textDecoration}
           </div>
         </div>


### PR DESCRIPTION
Fixes line heights being shown twice, letterspacing wasn't visible and spaces were seemingly wrong.