### PR TITLE
[token-transformer]: Adds type to each item when expandTypography is true

### DIFF
--- a/src/utils/convertTokensToGroupedObject.ts
+++ b/src/utils/convertTokensToGroupedObject.ts
@@ -19,6 +19,7 @@ export default function convertTokensToGroupedObject(tokens, excludedSets, optio
       const expandedTypography = Object.entries(tokenWithType.value).reduce((acc, [key, val]) => {
         acc[key] = {
           value: val,
+          type: key,
         };
         return acc;
       }, {});

--- a/src/utils/formatTokens.test.ts
+++ b/src/utils/formatTokens.test.ts
@@ -44,23 +44,29 @@ describe('formatTokens', () => {
                 h1: {
                   fontFamily: {
                     value: 'Inter',
+                    type: 'fontFamily',
                   },
                   fontWeight: {
                     value: 'Bold',
+                    type: 'fontWeight',
                   },
                   fontSize: {
                     value: 36,
+                    type: 'fontSize',
                   },
                 },
                 h2: {
                   fontFamily: {
                     value: 'Inter',
+                    type: 'fontFamily',
                   },
                   fontWeight: {
                     value: 'Regular',
+                    type: 'fontWeight',
                   },
                   fontSize: {
                     value: 24,
+                    type: 'fontSize',
                   },
                 },
               },

--- a/src/utils/formatTokens.ts
+++ b/src/utils/formatTokens.ts
@@ -17,6 +17,7 @@ export default function formatTokens({
         const expandedTypography = Object.entries(tokenWithoutName.value).reduce((acc, [key, val]) => {
           acc[key] = {
             value: val,
+            type: key,
           };
           return acc;
         }, {});

--- a/token-transformer/CHANGELOG.md
+++ b/token-transformer/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.0.19 (2022-02-24)
+
+Changed expandTypography to include the key as a token type so users could transform these accordingly with style dictionary.
+
 ## v0.0.18 (2022-02-20)
 
 Adds --preserveRawValue: true|false which allows you to add a `rawValue` prop on each token containing the unresolved value. Thanks @zephraph!

--- a/token-transformer/package.json
+++ b/token-transformer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "token-transformer",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "A utility that transforms tokens from Figma Tokens to a format that is readable by Style Dictionary.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Before, with expandTypography set to true we'd get these tokens:

```
"base": {
      "fontFamily": {
        "value": "Inter",
      },
      "fontWeight": {
        "value": "Regular",
      },
      "lineHeight": {
        "value": "AUTO",
      },
      "fontSize": {
        "value": 18,
      },
      "letterSpacing": {
        "value": "0%",
      },
      "paragraphSpacing": {
        "value": 0,
      },
      "textDecoration": {
        "value": "none",
      },
      "textCase": {
        "value": "none",
      }
```

After this PR, we add the key as a type, so users could work with that in style dictionary.

```
"base": {
      "fontFamily": {
        "value": "Inter",
        "type": "fontFamily"
      },
      "fontWeight": {
        "value": "Regular",
        "type": "fontWeight"
      },
      "lineHeight": {
        "value": "AUTO",
        "type": "lineHeight"
      },
      "fontSize": {
        "value": 18,
        "type": "fontSize"
      },
      "letterSpacing": {
        "value": "0%",
        "type": "letterSpacing"
      },
      "paragraphSpacing": {
        "value": 0,
        "type": "paragraphSpacing"
      },
      "textDecoration": {
        "value": "none",
        "type": "textDecoration"
      },
      "textCase": {
        "value": "none",
        "type": "textCase"
      }
```