### PR TITLE
Fix box shadows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "figma-tokens",
     "version": "1.0.0",
-    "plugin_version": "89",
+    "plugin_version": "90",
     "description": "Figma Tokens",
     "license": "MIT",
     "scripts": {

--- a/src/plugin/setValuesOnNode.ts
+++ b/src/plugin/setValuesOnNode.ts
@@ -1,6 +1,6 @@
 import { Properties } from '@/constants/Properties';
+import { TokenTypes } from '@/constants/TokenTypes';
 import { getAllFigmaStyleMaps } from '@/utils/getAllFigmaStyleMaps';
-import { convertToFigmaColor } from './figmaTransforms/colors';
 import { transformValue } from './helpers';
 import setColorValuesOnTarget from './setColorValuesOnTarget';
 import setEffectValuesOnTarget from './setEffectValuesOnTarget';
@@ -45,7 +45,7 @@ export default async function setValuesOnNode(
         if (matchingStyle) {
           node.effectStyleId = matchingStyle.id;
         } else {
-          setEffectValuesOnTarget(node, { value: values.boxShadow });
+          setEffectValuesOnTarget(node, { value: values.boxShadow, type: TokenTypes.BOX_SHADOW });
         }
       }
 


### PR DESCRIPTION
Fixes a bug that was introduced in V89 where we expected type: boxShadow to be passed but turns out we didnt 🤷‍♂️

fixes #567 