### PR TITLE
Fix numerical font weights

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "figma-tokens",
     "version": "1.0.0",
-    "plugin_version": "94",
+    "plugin_version": "95",
     "description": "Figma Tokens",
     "license": "MIT",
     "scripts": {

--- a/src/plugin/setTextValuesOnTarget.ts
+++ b/src/plugin/setTextValuesOnTarget.ts
@@ -14,8 +14,8 @@ export default async function setTextValuesOnTarget(target, token) {
       textCase,
       textDecoration,
     } = value.value || value;
-    const family = fontFamily || target.fontName.family;
-    const style = fontWeight || target.fontName.style;
+    const family = fontFamily?.toString() || target.fontName.family;
+    const style = fontWeight?.toString() || target.fontName.style;
     await figma.loadFontAsync({ family, style });
 
     if (fontFamily || fontWeight) {


### PR DESCRIPTION
Fixes a bug that prevented users form using numerical font weights.

For example, a user that had `Museo Sans` that had a font weight of `500` could not use that combination. As Figma expects a string for `fontWeight`, but we returned `fontWeight` as we received it, in that case a number.

