### PR TITLE
Add ability to use units in math expressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "octokit-commit-multiple-files": "^3.2.1",
     "polished": "^4.1.3",
     "postcss": "^8.2.13",
+    "postcss-calc-ast-parser": "^0.1.4",
     "react": "17.0.0",
     "react-colorful": "^5.5.1",
     "react-devtools": "^4.24.3",

--- a/src/utils/math/__tests__/checkAndEvaluateMath.test.ts
+++ b/src/utils/math/__tests__/checkAndEvaluateMath.test.ts
@@ -1,0 +1,25 @@
+import { checkAndEvaluateMath } from '../checkAndEvaluateMath';
+
+describe('checkAndEvaluateMath', () => {
+  it('solves simple unit-less expressions', () => {
+    expect(checkAndEvaluateMath('10 + 20 * 3')).toEqual('70');
+  });
+
+  it('solves simple expressions with units', () => {
+    expect(checkAndEvaluateMath('10px + 20px * 3')).toEqual('70px');
+    expect(checkAndEvaluateMath('1rem + 2rem * 3')).toEqual('7rem');
+    expect(checkAndEvaluateMath('60px / 2')).toEqual('30px');
+  });
+
+  it('solves complex expressions with units', () => {
+    expect(checkAndEvaluateMath('5px * (2 + 3)')).toEqual('25px');
+    expect(checkAndEvaluateMath('(5rem + 10rem * 2) / 2')).toEqual('12.5rem');
+    expect(checkAndEvaluateMath('5% - 2% * 2')).toEqual('1%');
+  });
+
+  it('does not solve expressions with mismatched units', () => {
+    expect(checkAndEvaluateMath('1rem + 1px')).toEqual('1rem + 1px');
+    expect(checkAndEvaluateMath('2px * 2px')).toEqual('2px * 2px');
+    expect(checkAndEvaluateMath('2px + 10%')).toEqual('2px + 10%');
+  });
+});

--- a/src/utils/math/__tests__/checkAndEvaluateMath.test.ts
+++ b/src/utils/math/__tests__/checkAndEvaluateMath.test.ts
@@ -2,7 +2,7 @@ import { checkAndEvaluateMath } from '../checkAndEvaluateMath';
 
 describe('checkAndEvaluateMath', () => {
   it('solves simple unit-less expressions', () => {
-    expect(checkAndEvaluateMath('10 + 20 * 3')).toEqual('70');
+    expect(checkAndEvaluateMath('10 + 20 * 3')).toEqual(70);
   });
 
   it('solves simple expressions with units', () => {

--- a/src/utils/math/checkAndEvaluateMath.ts
+++ b/src/utils/math/checkAndEvaluateMath.ts
@@ -1,11 +1,26 @@
 import { Parser } from 'expr-eval';
+import calcAstParser from 'postcss-calc-ast-parser';
 
 const parser = new Parser();
 
 export function checkAndEvaluateMath(expr: string) {
+  const calcParsed = calcAstParser.parse(expr);
+  const calcReduced = calcAstParser.reduceExpression(calcParsed);
+
+  if (!calcReduced) {
+    return expr;
+  }
+
+  let unitlessExpr = expr;
+  let unit = '';
+
+  if (calcReduced.type !== 'Number') {
+    unitlessExpr = expr.replace(new RegExp(calcReduced.unit, 'ig'), '');
+    unit = calcReduced.unit;
+  }
+
   try {
-    parser.evaluate(expr);
-    return +parser.evaluate(expr).toFixed(3);
+    return +parser.evaluate(unitlessExpr).toFixed(3) + unit;
   } catch (ex) {
     return expr;
   }

--- a/src/utils/math/checkAndEvaluateMath.ts
+++ b/src/utils/math/checkAndEvaluateMath.ts
@@ -1,27 +1,34 @@
 import { Parser } from 'expr-eval';
 import calcAstParser from 'postcss-calc-ast-parser';
+import { Root } from 'postcss-calc-ast-parser/dist/types/ast';
 
 const parser = new Parser();
 
 export function checkAndEvaluateMath(expr: string) {
-  const calcParsed = calcAstParser.parse(expr);
-  const calcReduced = calcAstParser.reduceExpression(calcParsed);
+  let calcParsed: Root;
 
-  if (!calcReduced) {
+  try {
+    calcParsed = calcAstParser.parse(expr);
+  } catch (ex) {
     return expr;
   }
 
+  const calcReduced = calcAstParser.reduceExpression(calcParsed);
   let unitlessExpr = expr;
   let unit = '';
 
-  if (calcReduced.type !== 'Number') {
+  if (calcReduced && calcReduced.type !== 'Number') {
     unitlessExpr = expr.replace(new RegExp(calcReduced.unit, 'ig'), '');
     unit = calcReduced.unit;
   }
 
+  let evaluated: number;
+
   try {
-    return +parser.evaluate(unitlessExpr).toFixed(3) + unit;
+    evaluated = parser.evaluate(unitlessExpr);
   } catch (ex) {
     return expr;
   }
+
+  return unit ? `${evaluated}${unit}` : Number.parseFloat(evaluated.toFixed(3));
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13804,6 +13804,13 @@ posix-character-classes@^0.1.0:
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
+postcss-calc-ast-parser@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/postcss-calc-ast-parser/-/postcss-calc-ast-parser-0.1.4.tgz#9aeee3650a91c0b2902789689bc044c9f83bc447"
+  integrity sha512-CebpbHc96zgFjGgdQ6BqBy6XIUgRx1xXWCAAk6oke02RZ5nxwo9KQejTg8y7uYEeI9kv8jKQPYjoe6REsY23vw==
+  dependencies:
+    postcss-value-parser "^3.3.1"
+
 postcss-cli@^8.3.1:
   version "8.3.1"
   resolved "https://registry.yarnpkg.com/postcss-cli/-/postcss-cli-8.3.1.tgz#865dad08300ac59ae9cecb7066780aa81c767a77"
@@ -13934,6 +13941,11 @@ postcss-selector-parser@^6.0.6, postcss-selector-parser@^6.0.7:
   dependencies:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
+
+postcss-value-parser@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281"
+  integrity sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
 
 postcss-value-parser@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION
This allows expressions with units to be interpreted, which in turn solves the issue of not being able to use tokens with units in aliases. For instance, this will now work:
```
t1 = 10px
t2 = {t1} * 2
```
All the hard work is done by the `post-calc-at-parser` package by @ota-meshi, so most of the credit should go to them.