### PR TITLE
fix: token tooltip is missing alias value

### DIFF
--- a/src/app/components/TokenTooltip/SingleShadowValueDisplay.tsx
+++ b/src/app/components/TokenTooltip/SingleShadowValueDisplay.tsx
@@ -6,6 +6,8 @@ type Props = {
   shadow: TokenBoxshadowValue
 };
 
+// @TODO: Figure out how to display resolved shadow value without seeming duplicative / like we do for typography a shorthand
+
 export const SingleShadowValueDisplay: React.FC<Props> = ({ shadow }) => (
   <Box css={{
     display: 'flex', flexDirection: 'column', marginBottom: '$2', color: '$fgToolTipMuted',

--- a/src/app/components/TokenTooltip/SingleTypograhpyValueDisplay.tsx
+++ b/src/app/components/TokenTooltip/SingleTypograhpyValueDisplay.tsx
@@ -10,7 +10,17 @@ type Props = {
   shouldResolve: boolean
 };
 
-export const SingleTypographyValueDisplay: React.FC<Props> = ({ value, shouldResolve }) => (
+export const SingleTypographyValueDisplay: React.FC<Props> = ({ value, shouldResolve }) => (shouldResolve ? (
+  <Box css={{ color: '$fgToolTipMuted' }}>
+    {value.fontFamily}
+    {' '}
+    {value.fontWeight}
+    {' '}
+    /
+    {' '}
+    {value.fontSize}
+  </Box>
+) : (
   <Box css={{ color: '$fgToolTipMuted' }}>
     <div>
       Font:
@@ -52,18 +62,5 @@ export const SingleTypographyValueDisplay: React.FC<Props> = ({ value, shouldRes
       {' '}
       {value.textDecoration?.value || value.textDecoration}
     </div>
-    {
-        shouldResolve && (
-        <Box css={{ color: '$fgToolTipMuted' }}>
-          {value.fontFamily}
-          {' '}
-          {value.fontWeight}
-          {' '}
-          /
-          {' '}
-          {value.fontSize}
-        </Box>
-        )
-      }
   </Box>
-);
+));

--- a/src/app/components/TokenTooltip/TokenTooltipContent.tsx
+++ b/src/app/components/TokenTooltip/TokenTooltipContent.tsx
@@ -16,10 +16,11 @@ export const TokenTooltipContent: React.FC<Props> = ({ token }) => {
   const tokenIsAlias = React.useMemo(() => (
     isAlias(token, tokensContext.resolvedTokens)
   ), [token, isAlias, tokensContext.resolvedTokens]);
-  const tokenIsShadowOrTypographyAlias = React.useMemo(() => (
-    token.type === TokenTypes.TYPOGRAPHY || token.type === TokenTypes.BOX_SHADOW) && 
-    typeof token.value === 'string'
-    , [token, tokensContext.resolvedTokens]
+  const tokenIsShadowOrTypographyAlias = React.useMemo(
+    () => (
+      token.type === TokenTypes.TYPOGRAPHY || token.type === TokenTypes.BOX_SHADOW)
+    && typeof token.value === 'string',
+    [token],
   );
 
   return (
@@ -27,13 +28,20 @@ export const TokenTooltipContent: React.FC<Props> = ({ token }) => {
       <Box css={{ fontSize: '$0', fontWeight: '$bold', color: '$fgToolTip' }}>
         {token.name.split('.')[token.name.split('.').length - 1]}
       </Box>
-      <Box css={{ color: '$fgToolTipMuted' }}>
-        <TokenTooltipContentValue
-          token={token}
-          shouldResolve={tokenIsAlias}
-          tokenIsShadowOrTypographyAlias={tokenIsShadowOrTypographyAlias}
-        />
-      </Box>
+      <TokenTooltipContentValue
+        token={token}
+        shouldResolve={false}
+        tokenIsShadowOrTypographyAlias={tokenIsShadowOrTypographyAlias}
+      />
+      {tokenIsAlias && (
+        <Box css={{ color: '$fgToolTipMuted' }}>
+          <TokenTooltipContentValue
+            token={token}
+            shouldResolve
+            tokenIsShadowOrTypographyAlias={tokenIsShadowOrTypographyAlias}
+          />
+        </Box>
+      )}
       {token.description && <Box css={{ color: '$fgToolTipMuted' }}>{token.description}</Box>}
     </div>
   );

--- a/src/app/components/TokenTooltip/TokenTooltipContentValue.tsx
+++ b/src/app/components/TokenTooltip/TokenTooltipContentValue.tsx
@@ -43,7 +43,7 @@ export const TokenTooltipContentValue: React.FC<Props> = ({ token, shouldResolve
       />
     );
   }
-  
+
   if (isSingleCompositionToken(token)) {
     if (Array.isArray(valueToCheck)) {
       return (


### PR DESCRIPTION
In our token listing performance effort we introduced a regression which caused tokens that used an alias to no longer show the alias, instead we only showed the resolved value.

Fixes https://github.com/six7/figma-tokens/issues/718

This PR reintroduces this.

We should still add tests for tooltips in a followup.