### PR TITLE
fix: eslint no object

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,6 +27,14 @@ module.exports = {
     "no-prototype-builtins": 0,
     "no-async-promise-executor": 0,
     "no-restricted-syntax": ["error", "ForInStatement", "LabeledStatement", "WithStatement"],
+    "@typescript-eslint/ban-types": [2, {
+      "types": {
+        "object": {
+          "message": "The `Object` type actually means \"any non-nullish value\", so it is marginally better than `unknown`.\n- If you want a type meaning \"any object\", you probably want `Record<string, unknown>` instead.\n- If you want a type meaning \"any value\", you probably want `unknown` instead."
+        }
+      },
+      "extendDefaults": true
+    }],
     "react/jsx-no-bind": [2, {
       ignoreDOMComponents: false,
       ignoreRefs: false,

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "dbaeumer.vscode-eslint"
+  ]
+}


### PR DESCRIPTION
This rule disallows some types such as `Object`, `object`, `{}`, etc... these are considered too vague and should not be used.

In this commit I also added eslint as a workspace recommendation for VSCode.