### PR TITLE
FT-261 Fix read only on github

### DIFF
--- a/src/storage/GithubTokenStorage.ts
+++ b/src/storage/GithubTokenStorage.ts
@@ -80,15 +80,19 @@ export class GithubTokenStorage extends GitTokenStorage {
     }
   }
 
-  public async canWrite() {
+  public async canWrite(): Promise<boolean> {
     const currentUser = await this.octokitClient.rest.users.getAuthenticated();
     if (!currentUser.data.login) return false;
-
-    return !!(await this.octokitClient.rest.repos.getCollaboratorPermissionLevel({
-      owner: this.owner,
-      repo: this.repository,
-      username: currentUser.data.login,
-    })).data;
+    try {
+      const canWrite = await this.octokitClient.rest.repos.getCollaboratorPermissionLevel({
+        owner: this.owner,
+        repo: this.repository,
+        username: currentUser.data.login,
+      });
+      return !!canWrite;
+    } catch (e) {
+      return false;
+    }
   }
 
   public async read(): Promise<RemoteTokenStorageFile<GitStorageMetadata>[]> {
@@ -217,6 +221,6 @@ export class GithubTokenStorage extends GitTokenStorage {
         },
       ],
     });
-    return !!response.data.content;
+    return !!response;
   }
 }

--- a/src/storage/GithubTokenStorage.ts
+++ b/src/storage/GithubTokenStorage.ts
@@ -221,6 +221,6 @@ export class GithubTokenStorage extends GitTokenStorage {
         },
       ],
     });
-    return !!response;
+    return !!response.data.content;
   }
 }

--- a/src/storage/__tests__/GithubTokenStorage.test.ts
+++ b/src/storage/__tests__/GithubTokenStorage.test.ts
@@ -129,6 +129,25 @@ describe('GithubTokenStorage', () => {
     });
   });
 
+  it('canWrite should return false if it wasnt possible to fetch collaboration level', async () => {
+    mockGetAuthenticated.mockImplementationOnce(() => (
+      Promise.resolve({
+        data: {
+          login: 'six7',
+        },
+      })
+    ));
+    mockGetCollaboratorPermissionLevel.mockImplementationOnce(() => {
+      throw new Error('Could not fetch collaboration level');
+    });
+    expect(await storageProvider.canWrite()).toBe(false);
+    expect(mockGetCollaboratorPermissionLevel).toBeCalledWith({
+      owner: 'six7',
+      repo: 'figma-tokens',
+      username: 'six7',
+    });
+  });
+
   it('canWrite should return true if a collaborator', async () => {
     mockGetAuthenticated.mockImplementationOnce(() => (
       Promise.resolve({

--- a/src/storage/__tests__/GithubTokenStorage.test.ts
+++ b/src/storage/__tests__/GithubTokenStorage.test.ts
@@ -119,7 +119,7 @@ describe('GithubTokenStorage', () => {
       })
     ));
     mockGetCollaboratorPermissionLevel.mockImplementationOnce(() => (
-      Promise.resolve({ data: null })
+      Promise.resolve(null)
     ));
     expect(await storageProvider.canWrite()).toBe(false);
     expect(mockGetCollaboratorPermissionLevel).toBeCalledWith({


### PR DESCRIPTION
fixes setting collaborator permissions correctly when a user is part of an organization and has read-only mode set. github returns a 404 if you query permissions for a read only user, no data at all.

for user-based projects (where there are no permissions, but only collaborator or not) the user wouldn't even have access to the project.