### PR TITLE
fix coverage action same comment

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -81,7 +81,10 @@ jobs:
         with:
           fullCoverageDiff: false
           runCommand: "npx jest --collectCoverageFrom='[\"src/**/*.{js,jsx,ts,tsx}\"]' --coverage --collectCoverage=true --coverageDirectory='./' --coverageReporters='json-summary' --forceExit --detectOpenHandles"
-          delta: 0.5
+          total_delta: 1
+          delta: 1
+          afterSwitchCommand: yarn --frozen-lockfile
+          useSameComment: true
   test-transform:
     name: Transformer Tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
Changes the test-coverage tests to update the same comment and introduces afterSwitchCommand which runs a yarn install after switching to base branch