### PR TITLE
fix: token sets show as list for free users even when using multi file sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "figma-tokens",
   "version": "1.0.0",
-  "plugin_version": "112.rc-2",
+  "plugin_version": "112.rc-3",
   "description": "Figma Tokens",
   "license": "MIT",
   "scripts": {

--- a/src/app/hooks/useIsGitMultiFileEnabled.ts
+++ b/src/app/hooks/useIsGitMultiFileEnabled.ts
@@ -1,18 +1,15 @@
 import { useSelector } from 'react-redux';
 import { useMemo } from 'react';
-import { useFlags } from 'launchdarkly-react-client-sdk';
 import { apiSelector } from '@/selectors';
 import { StorageProviderType } from '@/constants/StorageProviderType';
 
 export function useIsGitMultiFileEnabled() {
   const api = useSelector(apiSelector);
-  const { multiFileSync } = useFlags();
 
   return useMemo(() => (
     Boolean(
-      multiFileSync
-      && (api?.provider === StorageProviderType.GITHUB || api?.provider === StorageProviderType.GITLAB || api?.provider === StorageProviderType.ADO)
+      (api?.provider === StorageProviderType.GITHUB || api?.provider === StorageProviderType.GITLAB || api?.provider === StorageProviderType.ADO)
       && !api?.filePath?.endsWith('.json'),
     )
-  ), [api, multiFileSync]);
+  ), [api]);
 }


### PR DESCRIPTION
Free users should be able to see token sets stored on a multi file sync as a tree, just like Pro users.

Before:
![image](https://user-images.githubusercontent.com/4548309/177658604-a14d1e55-d75f-436e-b4ca-8e5e4c748a7f.png)

After:
![image](https://user-images.githubusercontent.com/4548309/177658611-ee0e8553-e0dc-457e-950f-5bdefabb48c7.png)
