### PR TITLE
fix: respect setting of shadow behind node for effects

### DIFF
--- a/src/plugin/figmaUtils/getShadowBehindNodeFromEffect.test.ts
+++ b/src/plugin/figmaUtils/getShadowBehindNodeFromEffect.test.ts
@@ -1,0 +1,24 @@
+import { getShadowBehindNodeFromEffect } from './getShadowBehindNodeFromEffect';
+
+describe('getShadowBehindNodeFromEffect', () => {
+  const dropShadowWithTrue: Effect = {
+    type: 'DROP_SHADOW',
+    showShadowBehindNode: true,
+  };
+  const dropShadowWithFalse: Effect = {
+    type: 'DROP_SHADOW',
+    showShadowBehindNode: false,
+  };
+  const innerShadow: Effect = {
+    type: 'INNER_SHADOW',
+  };
+  it('returns the correct values for effects', () => {
+    expect(getShadowBehindNodeFromEffect(dropShadowWithTrue)).toBeTruthy();
+    expect(getShadowBehindNodeFromEffect(dropShadowWithFalse)).toBeFalsy();
+    expect(getShadowBehindNodeFromEffect(innerShadow)).toBeFalsy();
+  });
+  it('returns false when no effect was given', () => {
+    const effectArray = [dropShadowWithTrue, dropShadowWithFalse, innerShadow];
+    expect(getShadowBehindNodeFromEffect(effectArray[3])).toBeFalsy();
+  });
+});

--- a/src/plugin/figmaUtils/getShadowBehindNodeFromEffect.ts
+++ b/src/plugin/figmaUtils/getShadowBehindNodeFromEffect.ts
@@ -1,0 +1,7 @@
+export function getShadowBehindNodeFromEffect(effect: Effect) {
+  if (!effect) return false;
+  if (effect.type === 'DROP_SHADOW') {
+    return effect.showShadowBehindNode;
+  }
+  return false;
+}

--- a/src/plugin/setEffectValuesOnTarget.test.ts
+++ b/src/plugin/setEffectValuesOnTarget.test.ts
@@ -87,7 +87,21 @@ describe('setEffectValuesOnTarget', () => {
     rectangleNodeMock = {
       type: 'RECTANGLE',
       fills: [],
-      effects: [],
+      effects: [{
+        type: 'DROP_SHADOW',
+        blendMode: 'NORMAL',
+        visible: true,
+        color: {
+          a: 0.5,
+          r: 0,
+          g: 0,
+          b: 0,
+        },
+        offset: { x: 0, y: 0 },
+        radius: 2,
+        spread: 4,
+        showShadowBehindNode: true,
+      }],
     } as unknown as RectangleNode;
   });
 
@@ -109,6 +123,7 @@ describe('setEffectValuesOnTarget', () => {
           offset: { x: 0, y: 0 },
           radius: 10,
           spread: 0,
+          showShadowBehindNode: true,
         },
       ],
     });
@@ -132,6 +147,7 @@ describe('setEffectValuesOnTarget', () => {
           offset: { x: 0, y: 0 },
           radius: 2,
           spread: 4,
+          showShadowBehindNode: true,
         },
         {
           type: 'DROP_SHADOW',
@@ -146,6 +162,7 @@ describe('setEffectValuesOnTarget', () => {
           offset: { x: 0, y: 4 },
           radius: 4,
           spread: 4,
+          showShadowBehindNode: false,
         },
         {
           type: 'DROP_SHADOW',
@@ -160,15 +177,17 @@ describe('setEffectValuesOnTarget', () => {
           offset: { x: 0, y: 8 },
           radius: 16,
           spread: 4,
+          showShadowBehindNode: false,
         },
       ],
     });
   });
 
   it('sets mixed shadow tokens', async () => {
+    const rectangleNodeMockOriginal = rectangleNodeMock;
     await setEffectValuesOnTarget(rectangleNodeMock, mixedShadowToken);
     expect(rectangleNodeMock).toEqual({
-      ...rectangleNodeMock,
+      ...rectangleNodeMockOriginal,
       effects: [
         {
           type: 'INNER_SHADOW',
@@ -197,6 +216,7 @@ describe('setEffectValuesOnTarget', () => {
           offset: { x: 0, y: 4 },
           radius: 4,
           spread: 4,
+          showShadowBehindNode: false,
         },
         {
           type: 'DROP_SHADOW',
@@ -211,6 +231,61 @@ describe('setEffectValuesOnTarget', () => {
           offset: { x: 0, y: 8 },
           radius: 16,
           spread: 4,
+          showShadowBehindNode: false,
+        },
+      ],
+    });
+  });
+
+  it('respects set show behind setting for mixed shadow tokens', async () => {
+    const rectangleNodeMockOriginal = rectangleNodeMock;
+    await setEffectValuesOnTarget(rectangleNodeMock, mixedShadowToken);
+    expect(rectangleNodeMock).toEqual({
+      ...rectangleNodeMockOriginal,
+      effects: [
+        {
+          type: 'INNER_SHADOW',
+          blendMode: 'NORMAL',
+          visible: true,
+          color: {
+            a: 0.5,
+            r: 0,
+            g: 0,
+            b: 0,
+          },
+          offset: { x: 0, y: 0 },
+          radius: 2,
+          spread: 4,
+        },
+        {
+          type: 'DROP_SHADOW',
+          blendMode: 'NORMAL',
+          visible: true,
+          color: {
+            a: 1,
+            r: 0,
+            g: 0,
+            b: 0,
+          },
+          offset: { x: 0, y: 4 },
+          radius: 4,
+          spread: 4,
+          showShadowBehindNode: false,
+        },
+        {
+          type: 'DROP_SHADOW',
+          blendMode: 'NORMAL',
+          visible: true,
+          color: {
+            a: 1,
+            r: 0,
+            g: 0,
+            b: 0,
+          },
+          offset: { x: 0, y: 8 },
+          radius: 16,
+          spread: 4,
+          showShadowBehindNode: false,
         },
       ],
     });

--- a/src/plugin/setEffectValuesOnTarget.ts
+++ b/src/plugin/setEffectValuesOnTarget.ts
@@ -4,6 +4,7 @@ import { convertBoxShadowTypeToFigma } from './figmaTransforms/boxShadow';
 import { convertToFigmaColor } from './figmaTransforms/colors';
 import { convertTypographyNumberToFigma } from './figmaTransforms/generic';
 import convertOffsetToFigma from './figmaTransforms/offset';
+import { getShadowBehindNodeFromEffect } from './figmaUtils/getShadowBehindNodeFromEffect';
 
 export default function setEffectValuesOnTarget(
   // @TODO update this typing
@@ -15,7 +16,7 @@ export default function setEffectValuesOnTarget(
     const { description, value } = token;
 
     if (Array.isArray(value)) {
-      const effectsArray = value.map((v) => {
+      const effectsArray = value.map((v, index) => {
         const { color, opacity: a } = convertToFigmaColor(v.color);
         const { r, g, b } = color;
         return {
@@ -31,6 +32,7 @@ export default function setEffectValuesOnTarget(
           offset: convertOffsetToFigma(convertTypographyNumberToFigma(v.x.toString()), convertTypographyNumberToFigma(v.y.toString())),
           blendMode: v.blendMode || 'NORMAL' as BlendMode,
           visible: true,
+          ...v.type === 'dropShadow' && 'effects' in target ? { showShadowBehindNode: getShadowBehindNodeFromEffect(target.effects[index]) } : {},
         };
       }) as Effect[];
 
@@ -53,6 +55,7 @@ export default function setEffectValuesOnTarget(
             offset: convertOffsetToFigma(convertTypographyNumberToFigma(value.x.toString()), convertTypographyNumberToFigma(value.y.toString())),
             blendMode: (value.blendMode || 'NORMAL') as BlendMode,
             visible: true,
+            ...value.type === 'dropShadow' && 'effects' in target ? { showShadowBehindNode: getShadowBehindNodeFromEffect(target.effects[0]) } : {},
           },
         ];
       }


### PR DESCRIPTION
This PR introduces behavior that respects the layer / effect styles setting of `Show behind transparent areas`.

To try:

- Create a shadow token (with multiple layers using `Drop Shadow type`).
- Creatye styles
- Change the `Show behind transparent areas` setting in the Figma Styles / properties panel.
- Hit Update in the plugin and notice that the setting in the Style / properties panel didn't change.

Previous behavior: We always set that setting to `true`.