### PR TITLE
docs(token-transformer): add repository field to package.json

### DIFF
--- a/token-transformer/package.json
+++ b/token-transformer/package.json
@@ -2,6 +2,11 @@
   "name": "token-transformer",
   "version": "0.0.24",
   "description": "A utility that transforms tokens from Figma Tokens to a format that is readable by Style Dictionary.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/six7/figma-tokens.git",
+    "directory": "token-transformer"
+  },
   "main": "index.js",
   "scripts": {
     "build-typography-test": "node index.js tokens.json temp/typography.json base/options,base/sizing,core/typography base/options,base/sizing",


### PR DESCRIPTION
This change provides npm package pages to display reference links to GitHub repositories.

# motivation

I learned about Token Transformer from [here](https://docs.tokens.studio/sync/github#7-how-to-use-tokens-stored-in-github-in-development) in the documentation and wanted to read the source code to learn more about its behavior.
However, I could not find it by googling and it took me a while to realize that it is located in a subdirectory of figma-tokens.

Therefore, I thought it would be easier for others to reference if a link was posted on the npm page.
