### PR TITLE
fix behavior when starting and pulling from remote with themes

### DIFF
--- a/src/app/components/AppContainer/startupProcessSteps/pullTokensFactory.ts
+++ b/src/app/components/AppContainer/startupProcessSteps/pullTokensFactory.ts
@@ -67,7 +67,8 @@ export function pullTokensFactory(
 
           dispatch.uiState.setApiData(matchingSet);
           dispatch.uiState.setLocalApiState(matchingSet);
-          dispatch.tokenState.setActiveTheme(params.activeTheme || null);
+          // we don't want to update nodes if we're pulling from remote
+          dispatch.tokenState.setActiveTheme({ themeId: params.activeTheme || null, shouldUpdateNodes: false });
 
           if (shouldPull) {
             const remoteData = await useRemoteTokensResult.pullTokens({

--- a/src/app/components/ManageThemesModal/SingleThemeEntry.tsx
+++ b/src/app/components/ManageThemesModal/SingleThemeEntry.tsx
@@ -35,7 +35,7 @@ export const SingleThemeEntry: React.FC<Props> = ({ theme, isActive, onOpen }) =
 
   const handleToggle = useCallback(() => {
     const nextValue = isActive ? null : theme.id;
-    dispatch.tokenState.setActiveTheme(nextValue);
+    dispatch.tokenState.setActiveTheme({ themeId: nextValue, shouldUpdateNodes: true });
   }, [dispatch, theme.id, isActive]);
 
   return (

--- a/src/app/components/ThemeSelector/ThemeSelector.tsx
+++ b/src/app/components/ThemeSelector/ThemeSelector.tsx
@@ -32,7 +32,7 @@ export const ThemeSelector: React.FC = () => {
   const availableThemes = useSelector(themeOptionsSelector);
 
   const handleClearTheme = useCallback(() => {
-    dispatch.tokenState.setActiveTheme(null);
+    dispatch.tokenState.setActiveTheme({ themeId: null, shouldUpdateNodes: true });
   }, [dispatch]);
 
   const handleSelectTheme = useCallback((themeId: string) => {
@@ -42,7 +42,7 @@ export const ThemeSelector: React.FC = () => {
     } else {
       track('Reset theme');
     }
-    dispatch.tokenState.setActiveTheme(nextTheme);
+    dispatch.tokenState.setActiveTheme({ themeId: nextTheme, shouldUpdateNodes: true });
   }, [dispatch, activeTheme]);
 
   const handleManageThemes = useCallback(() => {

--- a/src/app/store/models/effects/tokenState/setActiveTheme.ts
+++ b/src/app/store/models/effects/tokenState/setActiveTheme.ts
@@ -2,7 +2,7 @@ import type { RematchDispatch } from '@rematch/core';
 import type { RootModel } from '@/types/RootModel';
 
 export function setActiveTheme(dispatch: RematchDispatch<RootModel>) {
-  return (): void => {
-    dispatch.tokenState.updateDocument({ updateRemote: false });
+  return (payload: { themeId: string, shouldUpdateNodes?: boolean }): void => {
+    dispatch.tokenState.updateDocument({ updateRemote: false, shouldUpdateNodes: payload.shouldUpdateNodes });
   };
 }

--- a/src/app/store/models/reducers/tokenState/saveTheme.ts
+++ b/src/app/store/models/reducers/tokenState/saveTheme.ts
@@ -30,7 +30,8 @@ export function saveTheme(state: TokenState, data: Payload): TokenState {
     // @README if this theme is currently active or if it's a new theme
     // we will also run the setActiveTheme reducer
     // to update the usedTokenSets
-    return setActiveTheme(nextState, themeId);
+    // we don't want to update nodes or styles though.
+    return setActiveTheme(nextState, { themeId, shouldUpdateNodes: false });
   }
 
   return nextState;

--- a/src/app/store/models/reducers/tokenState/setActiveTheme.ts
+++ b/src/app/store/models/reducers/tokenState/setActiveTheme.ts
@@ -1,7 +1,9 @@
 import { TokenSetStatus } from '@/constants/TokenSetStatus';
 import type { TokenState } from '../../tokenState';
 
-export function setActiveTheme(state: TokenState, themeId: string | null): TokenState {
+// Needed to add a flag if all nodes should be updated, as otherwise all nodes are updated when we launch the plugin which we dont want to do. Feel free to refactor this.
+// This flag is only needed in the effects file, but we're declaring properties here
+export function setActiveTheme(state: TokenState, { themeId }: { themeId: string | null, shouldUpdateNodes?: boolean }): TokenState {
   const themeObject = themeId ? state.themes.find((theme) => theme.id === themeId) : null;
   const usedTokenSetsMap = themeObject
     ? Object.fromEntries(


### PR DESCRIPTION
This fixes the recently introduced behavior that the plugin tried to automatically update all nodes when starting the plugin, a remote storage was setup, themes were present and an active theme was trying to be set.

To clarify: We don't want to update nodes or styles everytime we set a theme. Initially when launching the plugin, there should not be an update, as it would mean users have to wait minutes until they can start using (eg when set to Update document or Update page)

This fixes that so that we're only updating nodes when required (eg toggling a theme)