### PR TITLE
fix sort for single file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "figma-tokens",
   "version": "1.0.0",
-  "plugin_version": "114",
+  "plugin_version": "115",
   "description": "Figma Tokens",
   "license": "MIT",
   "scripts": {

--- a/src/app/components/ExportProvider/MultiFilesExport.tsx
+++ b/src/app/components/ExportProvider/MultiFilesExport.tsx
@@ -9,6 +9,7 @@ import Stack from '../Stack';
 import Heading from '../Heading';
 import { IconFile } from '@/icons';
 import { tokensSelector, themesListSelector } from '@/selectors';
+import { track } from '@/utils/analytics';
 
 type Props = {
   onClose: () => void;
@@ -37,6 +38,8 @@ export default function MultiFilesExport({ onClose }: Props) {
       .then((content) => {
         saveAs(content, 'tokens.zip');
       });
+    track('Export directory');
+
     onClose();
   }, [filesChangeset, onClose]);
 

--- a/src/app/components/ExportProvider/SingleFileExport.tsx
+++ b/src/app/components/ExportProvider/SingleFileExport.tsx
@@ -7,6 +7,7 @@ import Checkbox from '../Checkbox';
 import Label from '../Label';
 import Box from '../Box';
 import Stack from '../Stack';
+import { track } from '@/utils/analytics';
 
 type Props = {
   onClose: () => void
@@ -39,6 +40,12 @@ export default function SingleFileExport({ onClose }: Props) {
   const handleToggleExpandComposition = React.useCallback(() => {
     setExpandComposition(!expandComposition);
   }, [expandComposition]);
+
+  const handleClickExport = React.useCallback(() => {
+    track('Export file', {
+      includeParent, includeAllTokens, expandComposition, expandShadow, expandTypography,
+    });
+  }, [expandComposition, expandShadow, expandTypography, includeAllTokens, includeParent]);
 
   const formattedTokens = React.useMemo(() => getFormattedTokens({
     includeAllTokens, includeParent, expandTypography, expandShadow, expandComposition,
@@ -111,6 +118,7 @@ export default function SingleFileExport({ onClose }: Props) {
           href={`data:text/json;charset=utf-8,${encodeURIComponent(formattedTokens)}`}
           download="tokens.json"
           variant="primary"
+          onClick={handleClickExport}
         >
           Export
         </Button>

--- a/src/app/components/PresetProvider/DefaultPreset.tsx
+++ b/src/app/components/PresetProvider/DefaultPreset.tsx
@@ -5,6 +5,7 @@ import Button from '../Button';
 import Stack from '../Stack';
 import Heading from '../Heading';
 import Text from '../Text';
+import { track } from '@/utils/analytics';
 
 type Props = {
   onCancel: () => void;
@@ -13,6 +14,7 @@ type Props = {
 export default function DefaultPreset({ onCancel }: Props) {
   const dispatch = useDispatch<Dispatch>();
   const handleSetDefault = React.useCallback(() => {
+    track('Load preset');
     dispatch.tokenState.setDefaultTokens();
     onCancel();
   }, [dispatch, onCancel]);

--- a/src/app/components/PresetProvider/FilePreset.tsx
+++ b/src/app/components/PresetProvider/FilePreset.tsx
@@ -6,6 +6,7 @@ import Button from '../Button';
 import Stack from '../Stack';
 import Heading from '../Heading';
 import Text from '../Text';
+import { track } from '@/utils/analytics';
 
 declare module 'react' {
   interface InputHTMLAttributes<T> extends HTMLAttributes<T> {
@@ -31,15 +32,18 @@ export default function FilePreset({ onCancel }: Props) {
   const { fetchTokensFromFileOrDirectory } = useRemoteTokens();
 
   const handleFileButtonClick = React.useCallback(() => {
+    track('Import', { type: 'file' });
     hiddenFileInput.current?.click();
   }, [hiddenFileInput]);
 
   const handleDirectoryButtonClick = React.useCallback(() => {
+    track('Import', { type: 'directory' });
     hiddenDirectoryInput.current?.click();
   }, [hiddenDirectoryInput]);
 
   const handleFileOrDirectoryChange = React.useCallback(async (event: React.ChangeEvent<HTMLInputElement>) => {
     const { files } = event.target;
+
     await fetchTokensFromFileOrDirectory(files);
     onCancel();
   }, [fetchTokensFromFileOrDirectory, onCancel]);

--- a/src/app/store/providers/ado/ado.tsx
+++ b/src/app/store/providers/ado/ado.tsx
@@ -159,7 +159,8 @@ export const useADO = () => {
         };
       }
       if (content) {
-        const sortedTokens = applyTokenSetOrder(content.tokens, content.metadata?.tokenSetOrder ?? []);
+        // If we didn't get a tokenSetOrder from metadata, use the order of the token sets as they appeared
+        const sortedTokens = applyTokenSetOrder(content.tokens, content.metadata?.tokenSetOrder ?? Object.keys(content.tokens));
         return {
           ...content,
           tokens: sortedTokens,

--- a/src/app/store/providers/github/github.tsx
+++ b/src/app/store/providers/github/github.tsx
@@ -167,7 +167,9 @@ export function useGitHub() {
         };
       }
       if (content) {
-        const sortedTokens = applyTokenSetOrder(content.tokens, content.metadata?.tokenSetOrder ?? []);
+        // If we didn't get a tokenSetOrder from metadata, use the order of the token sets as they appeared
+        const sortedTokens = applyTokenSetOrder(content.tokens, content.metadata?.tokenSetOrder ?? Object.keys(content.tokens));
+
         return {
           ...content,
           tokens: sortedTokens,

--- a/src/app/store/providers/gitlab/gitlab.tsx
+++ b/src/app/store/providers/gitlab/gitlab.tsx
@@ -175,7 +175,8 @@ export function useGitLab() {
       }
 
       if (content) {
-        const sortedTokens = applyTokenSetOrder(content.tokens, content.metadata?.tokenSetOrder ?? []);
+        // If we didn't get a tokenSetOrder from metadata, use the order of the token sets as they appeared
+        const sortedTokens = applyTokenSetOrder(content.tokens, content.metadata?.tokenSetOrder ?? Object.keys(content.tokens));
         return {
           ...content,
           tokens: sortedTokens,


### PR DESCRIPTION
Changes behaviour introduced in 114 for single file sort where we no longer respected the order of keys in the JSON. This does not fix the underlying problem that we so far do not respect the $metadata property in the json, I created https://github.com/six7/figma-tokens/issues/1162 to tackle that.

This PR changes it so if no $metadata is present (all the time currently), we use the order of keys in the JSON (behaviour pre-114)