### PR TITLE
Fixes Create styles removing previously attached styles

### DIFF
--- a/src/app/store/models/reducers/__tests__/assignStyleIdsToTheme.test.ts
+++ b/src/app/store/models/reducers/__tests__/assignStyleIdsToTheme.test.ts
@@ -30,4 +30,69 @@ describe('assignStyleIdsToTheme', () => {
       },
     ]);
   });
+
+  it('keeps previously stored styleIds intact', () => {
+    const mockState = {
+      themes: [
+        {
+          id: 'light',
+          name: 'Light',
+          selectedTokenSets: {},
+          $figmaStyleReferences: {
+            'colors.brand.primary': 'S:1234',
+          },
+        },
+      ],
+    } as unknown as TokenState;
+
+    expect(assignStyleIdsToTheme(mockState, {
+      id: 'light',
+      styleIds: {
+        'colors.brand.secondary': 'S:2345',
+      },
+    }).themes).toEqual([
+      {
+        id: 'light',
+        name: 'Light',
+        selectedTokenSets: {},
+        $figmaStyleReferences: {
+          'colors.brand.primary': 'S:1234',
+          'colors.brand.secondary': 'S:2345',
+        },
+      },
+    ]);
+  });
+
+  it('overwrites existing styleids', () => {
+    const mockState = {
+      themes: [
+        {
+          id: 'light',
+          name: 'Light',
+          selectedTokenSets: {},
+          $figmaStyleReferences: {
+            'colors.brand.primary': 'S:1234',
+          },
+        },
+      ],
+    } as unknown as TokenState;
+
+    expect(assignStyleIdsToTheme(mockState, {
+      id: 'light',
+      styleIds: {
+        'colors.brand.primary': 'S:9999',
+        'colors.brand.secondary': 'S:2345',
+      },
+    }).themes).toEqual([
+      {
+        id: 'light',
+        name: 'Light',
+        selectedTokenSets: {},
+        $figmaStyleReferences: {
+          'colors.brand.primary': 'S:9999',
+          'colors.brand.secondary': 'S:2345',
+        },
+      },
+    ]);
+  });
 });

--- a/src/app/store/models/reducers/tokenState/assignStyleIdsToCurrentTheme.ts
+++ b/src/app/store/models/reducers/tokenState/assignStyleIdsToCurrentTheme.ts
@@ -15,7 +15,7 @@ export function assignStyleIdsToCurrentTheme(state: TokenState, styleIds: Record
   const updatedThemes = [...state.themes];
   updatedThemes.splice(themeObjectIndex, 1, {
     ...state.themes[themeObjectIndex],
-    $figmaStyleReferences: { ...styleIds },
+    $figmaStyleReferences: { ...state.themes[themeObjectIndex].$figmaStyleReferences, ...styleIds },
   });
 
   return {

--- a/src/app/store/models/reducers/tokenState/assignStyleIdsToTheme.ts
+++ b/src/app/store/models/reducers/tokenState/assignStyleIdsToTheme.ts
@@ -17,7 +17,7 @@ export function assignStyleIdsToTheme(state: TokenState, data: Payload): TokenSt
   const updatedThemes = [...state.themes];
   updatedThemes.splice(themeObjectIndex, 1, {
     ...state.themes[themeObjectIndex],
-    $figmaStyleReferences: { ...data.styleIds },
+    $figmaStyleReferences: { ...state.themes[themeObjectIndex].$figmaStyleReferences, ...data.styleIds },
   });
 
   return {


### PR DESCRIPTION
This PR fixes a bug with `Create styles` which would detach any existing styles to our $themes object.

In `assignStyleIdsToTheme` I spread the existing `$figmaStyleReferences` before we spread the new object.

## Before:
https://user-images.githubusercontent.com/4548309/185566427-7aaa3918-c470-47a3-938a-c414e6e70d25.mp4


## After:
https://user-images.githubusercontent.com/4548309/185566418-b7f8a48e-39e1-41bf-84fa-0b2cd48aea8f.mp4