### PR TITLE
807 cannot set a number fontweight in typography

### DIFF
--- a/src/plugin/figmaTransforms/fontWeight.ts
+++ b/src/plugin/figmaTransforms/fontWeight.ts
@@ -1,10 +1,9 @@
 export function convertFontWeightToFigma(value: string) {
-  console.log('ttttvalue', value, typeof value, value === '600');
   switch (value) {
     case '100':
       return 'Thin';
     case '200':
-      return 'Ultralight';
+      return 'ExtraLight';
     case '300':
       return 'Light';
     case '400':
@@ -16,34 +15,9 @@ export function convertFontWeightToFigma(value: string) {
     case '700':
       return 'Bold';
     case '800':
-      return 'Ultrabold';
+      return 'ExtraBold';
     case '900':
       return 'Black';
-    default:
-      return value;
-  }
-}
-
-export function convertFigmaToFontWeight(value: string) {
-  switch (value) {
-    case 'Thin':
-      return '100';
-    case 'Ultralight':
-      return '200';
-    case 'Light':
-      return '300';
-    case 'Regular':
-      return '400';
-    case 'Medium':
-      return '500';
-    case 'SemiBold':
-      return '600';
-    case 'Bold':
-      return '700';
-    case 'Ultrabold':
-      return '800';
-    case 'Black':
-      return '900';
     default:
       return value;
   }

--- a/src/plugin/figmaTransforms/fontWeight.ts
+++ b/src/plugin/figmaTransforms/fontWeight.ts
@@ -1,0 +1,50 @@
+export function convertFontWeightToFigma(value: string) {
+  console.log('ttttvalue', value, typeof value, value === '600');
+  switch (value) {
+    case '100':
+      return 'Thin';
+    case '200':
+      return 'Ultralight';
+    case '300':
+      return 'Light';
+    case '400':
+      return 'Regular';
+    case '500':
+      return 'Medium';
+    case '600':
+      return 'SemiBold';
+    case '700':
+      return 'Bold';
+    case '800':
+      return 'Ultrabold';
+    case '900':
+      return 'Black';
+    default:
+      return value;
+  }
+}
+
+export function convertFigmaToFontWeight(value: string) {
+  switch (value) {
+    case 'Thin':
+      return '100';
+    case 'Ultralight':
+      return '200';
+    case 'Light':
+      return '300';
+    case 'Regular':
+      return '400';
+    case 'Medium':
+      return '500';
+    case 'SemiBold':
+      return '600';
+    case 'Bold':
+      return '700';
+    case 'Ultrabold':
+      return '800';
+    case 'Black':
+      return '900';
+    default:
+      return value;
+  }
+}

--- a/src/plugin/figmaTransforms/fontWeight.ts
+++ b/src/plugin/figmaTransforms/fontWeight.ts
@@ -1,24 +1,24 @@
 export function convertFontWeightToFigma(value: string) {
   switch (value) {
     case '100':
-      return 'Thin';
+      return ['Thin', 'Hairline'];
     case '200':
-      return 'ExtraLight';
+      return ['ExtraLight', 'Extra Light', 'UltraLight', 'Ultra Light'];
     case '300':
-      return 'Light';
+      return ['Light'];
     case '400':
-      return 'Regular';
+      return ['Regular', 'Normal'];
     case '500':
-      return 'Medium';
+      return ['Medium'];
     case '600':
-      return 'SemiBold';
+      return ['SemiBold', 'Semi Bold', 'DemiBold', 'Demi Bold'];
     case '700':
-      return 'Bold';
+      return ['Bold'];
     case '800':
-      return 'ExtraBold';
+      return ['ExtraBold', 'Extra Bold', 'UltraBold', 'Ultra Bold'];
     case '900':
-      return 'Black';
+      return ['Black', 'Heavy'];
     default:
-      return value;
+      return [];
   }
 }

--- a/src/plugin/helpers.test.ts
+++ b/src/plugin/helpers.test.ts
@@ -67,6 +67,16 @@ describe('transformValue', () => {
       type: 'opacity',
       output: 0.6,
     },
+    {
+      input: '100',
+      type: 'fontWeights',
+      output: ['Thin', 'Hairline'],
+    },
+    {
+      input: 'bold',
+      type: 'fontWeights',
+      output: [],
+    },
   ];
   it('transforms non-conform values into their required formats', () => {
     tokens.forEach((token) => {

--- a/src/plugin/helpers.ts
+++ b/src/plugin/helpers.ts
@@ -5,6 +5,7 @@ import { convertLineHeightToFigma } from './figmaTransforms/lineHeight';
 import { convertBoxShadowTypeToFigma } from './figmaTransforms/boxShadow';
 import { convertTextCaseToFigma } from './figmaTransforms/textCase';
 import { convertTextDecorationToFigma } from './figmaTransforms/textDecoration';
+import { convertFontWeightToFigma } from './figmaTransforms/fontWeight';
 import { UserIdProperty } from '@/figmaStorage';
 import { generateId } from '@/utils/generateId';
 import { Properties } from '@/constants/Properties';
@@ -27,6 +28,7 @@ export async function getUserId() {
   return userId;
 }
 
+export function transformValue(value: string, type: 'fontWeights'): ReturnType<typeof convertFontWeightToFigma>;
 export function transformValue(value: string, type: 'letterSpacing'): LetterSpacing | null;
 export function transformValue(value: string, type: 'lineHeights'): LineHeight | null;
 export function transformValue(value: string, type: 'boxShadowType'): ReturnType<typeof convertBoxShadowTypeToFigma>;
@@ -60,6 +62,8 @@ export function transformValue(value: string, type: string) {
     case 'paragraphSpacing':
     case 'fontSizes':
       return convertTypographyNumberToFigma(value);
+    case 'fontWeights':
+      return convertFontWeightToFigma(value);
     case 'letterSpacing':
       return convertLetterSpacingToFigma(value);
     case 'lineHeights':

--- a/src/plugin/pullStyles.ts
+++ b/src/plugin/pullStyles.ts
@@ -15,6 +15,7 @@ import { PullStyleOptions } from '@/types';
 import { slugify } from '@/utils/string';
 import { TokenTypes } from '@/constants/TokenTypes';
 import { TokenBoxshadowValue } from '@/types/values';
+import { convertFontWeightToFigma } from './figmaTransforms/fontWeight';
 
 export default function pullStyles(styleTypes: PullStyleOptions): void {
   // @TODO should be specifically typed according to their type
@@ -113,7 +114,7 @@ export default function pullStyles(styleTypes: PullStyleOptions): void {
 
     fontWeights = uniqueFontCombinations.map((font, idx) => ({
       name: `fontWeights.${slugify(font.family)}-${idx}`,
-      value: font.style,
+      value: convertFontWeightToFigma(font.style),
       type: TokenTypes.FONT_WEIGHTS,
     }));
 

--- a/src/plugin/pullStyles.ts
+++ b/src/plugin/pullStyles.ts
@@ -15,7 +15,6 @@ import { PullStyleOptions } from '@/types';
 import { slugify } from '@/utils/string';
 import { TokenTypes } from '@/constants/TokenTypes';
 import { TokenBoxshadowValue } from '@/types/values';
-import { convertFontWeightToFigma } from './figmaTransforms/fontWeight';
 
 export default function pullStyles(styleTypes: PullStyleOptions): void {
   // @TODO should be specifically typed according to their type
@@ -114,7 +113,7 @@ export default function pullStyles(styleTypes: PullStyleOptions): void {
 
     fontWeights = uniqueFontCombinations.map((font, idx) => ({
       name: `fontWeights.${slugify(font.family)}-${idx}`,
-      value: convertFontWeightToFigma(font.style),
+      value: font.style,
       type: TokenTypes.FONT_WEIGHTS,
     }));
 

--- a/src/plugin/setTextValuesOnTarget.test.ts
+++ b/src/plugin/setTextValuesOnTarget.test.ts
@@ -67,4 +67,23 @@ describe('setTextValuesOnTarget', () => {
       textCase: 'TITLE',
     });
   });
+
+  it('it throws error, when there is no value in token', async () => {
+    await setTextValuesOnTarget(textNodeMock, {
+      description: 'Use with care',
+    });
+    expect(textNodeMock).toEqual({
+      ...textNodeMock,
+    });
+  });
+
+  it('it does nothing when the type of value is string', async () => {
+    await setTextValuesOnTarget(textNodeMock, {
+      description: 'Use with care',
+      value: 'string'
+    });
+    expect(textNodeMock).toEqual({
+      ...textNodeMock,
+    });
+  });
 });

--- a/src/plugin/setTextValuesOnTarget.test.ts
+++ b/src/plugin/setTextValuesOnTarget.test.ts
@@ -36,7 +36,7 @@ describe('setTextValuesOnTarget', () => {
     expect(textNodeMock).toEqual({ ...textNodeMock, fontName: { ...textNodeMock.fontName, style: 'Bold' } });
   });
 
-  it('convert number fontWeight and sets to the node', async () => {
+  it('converts a numerical fontWeight and sets to the node', async () => {
     loadFontAsyncSpy.mockImplementationOnce(() => (
       Promise.reject()
     ));
@@ -47,7 +47,7 @@ describe('setTextValuesOnTarget', () => {
     expect(textNodeMock).toEqual({ ...textNodeMock, fontName: { ...textNodeMock.fontName, style: 'Medium' } });
   });
 
-  it(`can't set number fontWeight to the node if there is no match fontWeight`, async () => {
+  it('can\'t set number fontWeight to the node if there is no matching fontWeight', async () => {
     loadFontAsyncSpy.mockImplementation(() => (
       Promise.reject()
     ));

--- a/src/plugin/setTextValuesOnTarget.test.ts
+++ b/src/plugin/setTextValuesOnTarget.test.ts
@@ -47,6 +47,14 @@ describe('setTextValuesOnTarget', () => {
     expect(textNodeMock).toEqual({ ...textNodeMock, fontName: { ...textNodeMock.fontName, style: 'Medium' } });
   });
 
+  it(`can't set number fontWeight to the node if there is no match fontWeight`, async () => {
+    loadFontAsyncSpy.mockImplementation(() => (
+      Promise.reject()
+    ));
+    await setTextValuesOnTarget(textNodeMock, { value: { fontWeight: '500' } });
+    expect(textNodeMock).toEqual({ ...textNodeMock, fontName: { ...textNodeMock.fontName } });
+  });
+
   it('sets textCase, textDecoration and description if those are given', async () => {
     await setTextValuesOnTarget(textNodeMock, {
       description: 'Use with care',

--- a/src/plugin/setTextValuesOnTarget.test.ts
+++ b/src/plugin/setTextValuesOnTarget.test.ts
@@ -2,6 +2,7 @@ import setTextValuesOnTarget from './setTextValuesOnTarget';
 
 describe('setTextValuesOnTarget', () => {
   let textNodeMock;
+  const loadFontAsyncSpy = jest.spyOn(figma, 'loadFontAsync');
 
   beforeEach(() => {
     textNodeMock = {
@@ -33,6 +34,17 @@ describe('setTextValuesOnTarget', () => {
   it('sets fontWeight if that is given', async () => {
     await setTextValuesOnTarget(textNodeMock, { value: { fontWeight: 'Bold' } });
     expect(textNodeMock).toEqual({ ...textNodeMock, fontName: { ...textNodeMock.fontName, style: 'Bold' } });
+  });
+
+  it('convert number fontWeight and sets to the node', async () => {
+    loadFontAsyncSpy.mockImplementationOnce(() => (
+      Promise.reject()
+    ));
+    loadFontAsyncSpy.mockImplementation(() => (
+      Promise.resolve()
+    ));
+    await setTextValuesOnTarget(textNodeMock, { value: { fontWeight: '500' } });
+    expect(textNodeMock).toEqual({ ...textNodeMock, fontName: { ...textNodeMock.fontName, style: 'Medium' } });
   });
 
   it('sets textCase, textDecoration and description if those are given', async () => {

--- a/src/plugin/setTextValuesOnTarget.ts
+++ b/src/plugin/setTextValuesOnTarget.ts
@@ -17,16 +17,14 @@ export default async function setTextValuesOnTarget(target: TextNode | TextStyle
         textCase,
         textDecoration,
       } = value;
-      console.log('fontwei', fontWeight);
-      const transformedValue = transformValue(String(fontWeight), 'fontWeights');
-      console.log('transfom', transformedValue);
       const family = fontFamily?.toString() || (target.fontName !== figma.mixed ? target.fontName.family : '');
-      const style = transformedValue || (target.fontName !== figma.mixed ? target.fontName.style : '');
-      await figma.loadFontAsync({ family, style });
+      const style = fontWeight?.toString() || (target.fontName !== figma.mixed ? target.fontName.style : '');
+      const transformedValue = transformValue(style, 'fontWeights');
+      await figma.loadFontAsync({ family, style: transformedValue });
       if (fontFamily || fontWeight) {
         target.fontName = {
           family,
-          style,
+          style: transformedValue,
         };
       }
 

--- a/src/plugin/setTextValuesOnTarget.ts
+++ b/src/plugin/setTextValuesOnTarget.ts
@@ -20,8 +20,8 @@ export default async function setTextValuesOnTarget(target: TextNode | TextStyle
       const style = fontWeight?.toString() || (target.fontName !== figma.mixed ? target.fontName.style : '');
 
       try {
-        await figma.loadFontAsync({ family, style });
         if (fontFamily || fontWeight) {
+          await figma.loadFontAsync({ family, style });
           target.fontName = {
             family,
             style,
@@ -31,9 +31,9 @@ export default async function setTextValuesOnTarget(target: TextNode | TextStyle
         const candidateStyles = transformValue(style, 'fontWeights');
         await Promise.all(
           candidateStyles.map(async (candidateStyle) => (
-            await figma.loadFontAsync({ family, style: candidateStyle })
+            figma.loadFontAsync({ family, style: candidateStyle })
               .then(() => {
-                if (fontFamily || fontWeight) {
+                if (fontFamily || candidateStyle) {
                   target.fontName = {
                     family,
                     style: candidateStyle,

--- a/src/plugin/setTextValuesOnTarget.ts
+++ b/src/plugin/setTextValuesOnTarget.ts
@@ -33,7 +33,7 @@ export default async function setTextValuesOnTarget(target: TextNode | TextStyle
           candidateStyles.map(async (candidateStyle) => (
             figma.loadFontAsync({ family, style: candidateStyle })
               .then(() => {
-                if (fontFamily || candidateStyle) {
+                if (candidateStyle) {
                   target.fontName = {
                     family,
                     style: candidateStyle,

--- a/src/plugin/setTextValuesOnTarget.ts
+++ b/src/plugin/setTextValuesOnTarget.ts
@@ -41,7 +41,7 @@ export default async function setTextValuesOnTarget(target: TextNode | TextStyle
                 }
               })
               .catch((e) => {
-                console.log('Error setting FontWeight on target', e);
+                console.log('Error setting fontWeight on target', e);
               })
           )),
         );

--- a/src/plugin/setTextValuesOnTarget.ts
+++ b/src/plugin/setTextValuesOnTarget.ts
@@ -30,8 +30,8 @@ export default async function setTextValuesOnTarget(target: TextNode | TextStyle
       } catch {
         const candidateStyles = transformValue(style, 'fontWeights');
         await Promise.all(
-          candidateStyles.map((candidateStyle) => (
-            figma.loadFontAsync({ family, style: candidateStyle })
+          candidateStyles.map(async (candidateStyle) => (
+            await figma.loadFontAsync({ family, style: candidateStyle })
               .then(() => {
                 if (fontFamily || fontWeight) {
                   target.fontName = {

--- a/src/plugin/setTextValuesOnTarget.ts
+++ b/src/plugin/setTextValuesOnTarget.ts
@@ -5,6 +5,7 @@ import { transformValue } from './helpers';
 export default async function setTextValuesOnTarget(target: TextNode | TextStyle, token: Pick<SingleTypographyToken, 'value' | 'description'>) {
   try {
     const { value, description } = token;
+    console.log('value', value);
     if (typeof value !== 'string') {
       const {
         fontFamily,
@@ -16,8 +17,11 @@ export default async function setTextValuesOnTarget(target: TextNode | TextStyle
         textCase,
         textDecoration,
       } = value;
+      console.log('fontwei', fontWeight);
+      const transformedValue = transformValue(String(fontWeight), 'fontWeights');
+      console.log('transfom', transformedValue);
       const family = fontFamily?.toString() || (target.fontName !== figma.mixed ? target.fontName.family : '');
-      const style = fontWeight?.toString() || (target.fontName !== figma.mixed ? target.fontName.style : '');
+      const style = transformedValue || (target.fontName !== figma.mixed ? target.fontName.style : '');
       await figma.loadFontAsync({ family, style });
       if (fontFamily || fontWeight) {
         target.fontName = {

--- a/src/plugin/setValuesOnNode.ts
+++ b/src/plugin/setValuesOnNode.ts
@@ -29,7 +29,7 @@ export default async function setValuesOnNode(
   const stylePathPrefix = prefixStylesWithThemeName && activeThemeObject
     ? activeThemeObject.name
     : null;
-
+  console.log('values', values);
   try {
     // BORDER RADIUS
     if (

--- a/src/plugin/setValuesOnNode.ts
+++ b/src/plugin/setValuesOnNode.ts
@@ -29,7 +29,6 @@ export default async function setValuesOnNode(
   const stylePathPrefix = prefixStylesWithThemeName && activeThemeObject
     ? activeThemeObject.name
     : null;
-  console.log('values', values);
   try {
     // BORDER RADIUS
     if (


### PR DESCRIPTION
We can't set fontWeight with a number between 100 to 900 which is the most common way to set it.

After fixing:
In Figma, there is a match rule between font family and font-weight, so every font weight doesn't work to every font family.
To test this, we can use `Montserrat` fontfamily which support all font weights from 100 to 900.