### PR TITLE
filter the list of token files to be transformed when using multifile

### DIFF
--- a/token-transformer/index.js
+++ b/token-transformer/index.js
@@ -100,7 +100,7 @@ const getAllFiles = function(dirPath, arrayOfFiles) {
     }
   })
 
-  return arrayOfFiles
+  return arrayOfFiles.filter(file => file.endsWith('.json'))
 }
 
 const getTokens = async (input) => {


### PR DESCRIPTION
Currently token-transformer crashes when there are other files present (such as for example a `.DS_Store` file). This mitigates this, but there may be a better solution.