### PR TITLE
841-auto-complete-in-token-picker-on-inspect-tab-does-not-work-correctly

### DIFF
--- a/src/app/components/InspectorTokenSingle.tsx
+++ b/src/app/components/InspectorTokenSingle.tsx
@@ -43,9 +43,7 @@ export default function InspectorTokenSingle({
   }, [inspectState.selectedTokens, token]);
 
   const handleDownShiftInputChange = React.useCallback((newInputValue: string) => {
-    if (newInputValue.charAt(0) === '$') setNewTokenName(newInputValue.slice(1, newInputValue.length));
-    if (newInputValue.charAt(0) === '{') setNewTokenName(newInputValue.slice(1, newInputValue.length - 1));
-    else setNewTokenName(newInputValue);
+    setNewTokenName(newInputValue.replace(/[{}$]/g, ''));
   }, []);
 
   const handleChange = React.useCallback<React.ChangeEventHandler<HTMLInputElement>>((e) => {


### PR DESCRIPTION
When remapping a token, if we type $ and select a token from a list doesn't work.

Before fixing: 
Start to type: $
![172659805-5414b6d3-0dac-4c40-b6cf-f322f3b6d7ea](https://user-images.githubusercontent.com/25951419/185896043-469b6e72-5fc2-415e-9ace-e6f7f4a33c2c.png)
and then select "gray" from the list but doesn't work.
![172659757-01e4599a-4c59-4387-bee5-5935975ac49a](https://user-images.githubusercontent.com/25951419/185896128-74b3623b-a40b-4f55-9a2a-79485bbe3c97.png)

Right now: it works.
