### PR TITLE
1202-when-editing-a-token-of-a-custom-type-dont-overwrite-with-other

### DIFF
--- a/src/app/components/TokenListing.tsx
+++ b/src/app/components/TokenListing.tsx
@@ -48,7 +48,7 @@ const TokenListing: React.FC<Props> = ({
     dispatch.uiState.setShowEditForm(true);
     dispatch.uiState.setEditToken({
       ...token,
-      type: schema.type,
+      type: token?.type || schema.type,
       schema,
       status,
       initialName: name,


### PR DESCRIPTION
Sometimes users want to use custom types of tokens, they can do so by specifying this in the JSON by just adding something custom to the "type" field. The plugin respects that, and will show that type as the category name.

However, when you edit that token in the UI, we overwrite that token type and reset it to "other".

After fixing: Token type is kept as it was.