### PR TITLE
1065-documentation-tokens-doesnt-work-within-the-composition

### DIFF
--- a/src/app/components/TokenButton/TokenButton.tsx
+++ b/src/app/components/TokenButton/TokenButton.tsx
@@ -115,7 +115,7 @@ export const TokenButton: React.FC<Props> = ({
     };
     if (propsToSet[0].clear) propsToSet[0].clear.map((item) => Object.assign(newProps, { [item]: 'delete' }));
 
-    if (type === 'composition' && value === 'delete') {
+    if (type === 'composition' && isActive && !propsToSet[0].clear) {
       // distructure composition token when it is unselected
       const compositionToken = tokensContext.resolvedTokens.find((token) => token.name === tokenValue);
       const tokensInCompositionToken: NodeTokenRefMap = {};


### PR DESCRIPTION
Documentation Token in Composition token doesn't work
<img width="841" alt="179482057-7e94c91a-83db-4121-b646-71c2b75cb06c" src="https://user-images.githubusercontent.com/25951419/186359794-e10dc2b4-ee5e-4f7b-bf54-4f1721a9b076.png">
.