### PR TITLE
1068-after-pushing-to-a-repo-the-plugin-doesnt-remember-the-tokenset-you-were-on-and-shows-the-tokenset-on-top-of-the-list

### DIFF
--- a/src/app/store/models/reducers/tokenState/setTokenData.ts
+++ b/src/app/store/models/reducers/tokenState/setTokenData.ts
@@ -26,7 +26,9 @@ export function setTokenData(state: TokenState, payload: SetTokenDataPayload): T
       ),
     })),
     activeTheme: payload.activeTheme ?? null,
-    activeTokenSet: Array.isArray(payload.values) ? 'global' : Object.keys(payload.values)[0],
+    ...(Object.keys(payload.values).includes(state.activeTokenSet) ? {} : {
+      activeTokenSet: Array.isArray(payload.values) ? 'global' : Object.keys(payload.values)[0],
+    }),
     usedTokenSet: Array.isArray(payload.values)
       ? { global: TokenSetStatus.ENABLED }
       : usedTokenSets,


### PR DESCRIPTION
After pushing to a repo, the plugin doesn't remember the tokenset you were on and shows the tokenset on top of the list.

After fixing: tokenset is kept after syncing with remote storage(github, gitlab, etc)