### PR TITLE
1224 plugin seems to reset window size when using deep inspect

### DIFF
--- a/src/app/components/AppContainer/startupProcessSteps/savePluginDataFactory.ts
+++ b/src/app/components/AppContainer/startupProcessSteps/savePluginDataFactory.ts
@@ -1,4 +1,4 @@
-import type { Dispatch } from '@/app/store';
+import { Dispatch } from '@/app/store';
 import type { StartupMessage } from '@/types/AsyncMessages';
 import { identify } from '@/utils/analytics';
 
@@ -6,9 +6,6 @@ export function savePluginDataFactory(dispatch: Dispatch, params: StartupMessage
   return async () => {
     const { user } = params;
     if (user) {
-      dispatch.userState.setUserId(user.figmaId);
-      dispatch.userState.setUserName(user.name);
-      dispatch.uiState.setLastOpened(params.lastOpened);
       const {
         width, height, showEmptyGroups, ...rest
       } = params.settings;
@@ -20,6 +17,9 @@ export function savePluginDataFactory(dispatch: Dispatch, params: StartupMessage
         },
         ...rest,
       };
+      dispatch.userState.setUserId(user.figmaId);
+      dispatch.userState.setUserName(user.name);
+      dispatch.uiState.setLastOpened(params.lastOpened);
       dispatch.settings.setUISettings(settings);
       identify(user);
     } else {

--- a/src/app/components/AppContainer/startupProcessSteps/savePluginDataFactory.ts
+++ b/src/app/components/AppContainer/startupProcessSteps/savePluginDataFactory.ts
@@ -9,7 +9,18 @@ export function savePluginDataFactory(dispatch: Dispatch, params: StartupMessage
       dispatch.userState.setUserId(user.figmaId);
       dispatch.userState.setUserName(user.name);
       dispatch.uiState.setLastOpened(params.lastOpened);
-      dispatch.settings.setUISettings(params.settings);
+      const {
+        width, height, showEmptyGroups, ...rest
+      } = params.settings;
+      const settings = {
+        uiWindow: {
+          width,
+          height,
+          isMinimized: false,
+        },
+        ...rest,
+      };
+      dispatch.settings.setUISettings(settings);
       identify(user);
     } else {
       throw new Error('User not found');

--- a/src/app/components/AppContainer/startupProcessSteps/savePluginDataFactory.ts
+++ b/src/app/components/AppContainer/startupProcessSteps/savePluginDataFactory.ts
@@ -1,4 +1,4 @@
-import { Dispatch } from '@/app/store';
+import type { Dispatch } from '@/app/store';
 import type { StartupMessage } from '@/types/AsyncMessages';
 import { identify } from '@/utils/analytics';
 

--- a/src/app/store/models/settings.tsx
+++ b/src/app/store/models/settings.tsx
@@ -164,6 +164,9 @@ export const settings = createModel<RootModel>()({
     setInspectDeep: (payload, rootState) => {
       setUI(rootState.settings);
     },
+    setUISettings: (payload, rootState) => {
+      setUI(rootState.settings);
+    },
     ...Object.fromEntries(
       (Object.entries(settingsStateEffects).map(([key, factory]) => (
         [key, factory()]


### PR DESCRIPTION
Fixed two issue.
https://github.com/six7/figma-tokens/issues/1223
https://github.com/six7/figma-tokens/issues/1224

The plugin seems to reset the window size when the user has

1. Changed window size
2. Then restarted the plugin
3. Then - without changing window size - changing Deep inspect
Notice how the plugin then resets the window size.



We seem to have caused a regression with Deep inspect:

To reproduce:

1. Activate deep inspect
2. Restart the plugin
3. Select a layer
4. Go to Inspect
5. Notice how even though it says Deep inspect is on, it only shows values of that current layer, not of children.
6. Turn Deep inspect off and on again
Notice that it now works

After fixing: Plugin keeps the window size and all children tokens are displayed after restarting the plugin.