### PR TITLE
1216 update button loses unsaved local changes

### DIFF
--- a/src/app/store/models/tokenState.test.ts
+++ b/src/app/store/models/tokenState.test.ts
@@ -815,4 +815,10 @@ describe('editToken', () => {
       },
     ]);
   });
+
+  it('should be able to update checkForChanges', () => {
+    store.dispatch.tokenState.updateCheckForChanges(true);
+    const { checkForChanges } = store.getState().tokenState;
+    expect(checkForChanges).toEqual(true);
+  });
 });

--- a/src/app/store/models/tokenState.tsx
+++ b/src/app/store/models/tokenState.tsx
@@ -48,7 +48,8 @@ export interface TokenState {
   editProhibited: boolean;
   hasUnsavedChanges: boolean;
   collapsedTokenSets: string[];
-  collapsedTokenTypeObj: Record<TokenTypes, boolean>
+  collapsedTokenTypeObj: Record<TokenTypes, boolean>;
+  checkForChanges: boolean;
 }
 
 export const tokenState = createModel<RootModel>()({
@@ -74,6 +75,7 @@ export const tokenState = createModel<RootModel>()({
       acc[tokenType as TokenTypes] = false;
       return acc;
     }, {}),
+    checkForChanges: false,
   } as unknown as TokenState,
   reducers: {
     setEditProhibited(state, payload: boolean) {
@@ -398,6 +400,10 @@ export const tokenState = createModel<RootModel>()({
       ...state,
       collapsedTokenTypeObj: data,
     }),
+    updateCheckForChanges: (state, data: boolean) => ({
+      ...state,
+      checkForChanges: data,
+    }),
     ...tokenStateReducers,
   },
   effects: (dispatch) => ({
@@ -458,8 +464,8 @@ export const tokenState = createModel<RootModel>()({
         dispatch.tokenState.updateDocument();
       }
     },
-    updateCheckForChanges(checkForChanges: boolean) {
-      dispatch.tokenState.updateDocument({ checkForChanges, shouldUpdateNodes: false });
+    updateCheckForChanges() {
+      dispatch.tokenState.updateDocument({ shouldUpdateNodes: false });
     },
     updateDocument(options?: UpdateDocumentPayload, rootState?) {
       const defaults = { shouldUpdateNodes: true, updateRemote: true };
@@ -479,7 +485,7 @@ export const tokenState = createModel<RootModel>()({
           api: rootState.uiState.api,
           storageType: rootState.uiState.storageType,
           shouldUpdateRemote: params.updateRemote && rootState.settings.updateRemote,
-          checkForChanges: params.checkForChanges || false,
+          checkForChanges: rootState.tokenState.checkForChanges,
         });
       } catch (e) {
         console.error('Error updating document', e);


### PR DESCRIPTION
Unsaved local changes are lost when update button is clicked and plugin is re-opened