### PR TITLE
1125 suggestion dropdown doesnt appear for documentation tokens while changing to another token on the inspect tab

### DIFF
--- a/src/app/components/DownshiftInput/DownShiftInput.test.tsx
+++ b/src/app/components/DownshiftInput/DownShiftInput.test.tsx
@@ -91,7 +91,7 @@ describe('DownShiftInput', () => {
     });
   });
 
-  it('should return matching tokens', () => {
+  it('should return color tokens when type is color', () => {
     const result = render(
       <DownshiftInput
         type="color"
@@ -105,5 +105,20 @@ describe('DownShiftInput', () => {
     result.getByTestId('downshift-input-suffix-button').click();
     expect(result.getByText('#e2e8f0')).toBeInTheDocument();
     expect(result.getByText('#cbd5e1')).toBeInTheDocument();
+  });
+
+  it('should return all tokens when type is documentation type', () => {
+    const result = render(
+      <DownshiftInput
+        type="tokenName"
+        resolvedTokens={resolvedTokens}
+        setInputValue={mockSetInputValue}
+        handleChange={mockHandleChange}
+        value="{"
+        suffix
+      />,
+    );
+    result.getByTestId('downshift-input-suffix-button').click();
+    expect(result.getAllByTestId('downshift-input-item')).toHaveLength(7);
   });
 });

--- a/src/app/components/DownshiftInput/DownshiftInput.tsx
+++ b/src/app/components/DownshiftInput/DownshiftInput.tsx
@@ -10,6 +10,8 @@ import { TokenTypes } from '@/constants/TokenTypes';
 import { styled } from '@/stitches.config';
 import { StyledDownshiftInput } from './StyledDownshiftInput';
 import Tooltip from '../Tooltip';
+import { Properties } from '@/constants/Properties';
+import { isDocumentationType } from '@/utils/is/isDocumentationType';
 
 const StyledDropdown = styled('div', {
   position: 'absolute',
@@ -135,14 +137,25 @@ export const DownshiftInput: React.FunctionComponent<DownShiftProps> = ({
   }, []);
 
   const filteredTokenItems = useMemo(
-    () => resolvedTokens
-      .filter(
-        (token: SingleToken) => !filteredValue || token.name.toLowerCase().includes(filteredValue.toLowerCase()),
-      )
-      .filter((token: SingleToken) => token?.type === type && token.name !== initialName).sort((a, b) => (
-        a.name.localeCompare(b.name)
-      )),
-    [resolvedTokens, filteredValue, type],
+    () => {
+      if (isDocumentationType(type as Properties)) {
+        return resolvedTokens
+          .filter(
+            (token: SingleToken) => !filteredValue || token.name.toLowerCase().includes(filteredValue.toLowerCase()),
+          )
+          .filter((token: SingleToken) => token.name !== initialName).sort((a, b) => (
+            a.name.localeCompare(b.name)
+          ));
+      }
+      return resolvedTokens
+        .filter(
+          (token: SingleToken) => !filteredValue || token.name.toLowerCase().includes(filteredValue.toLowerCase()),
+        )
+        .filter((token: SingleToken) => token?.type === type && token.name !== initialName).sort((a, b) => (
+          a.name.localeCompare(b.name)
+        ));
+    },
+    [resolvedTokens, filteredValue, type, isDocumentationType],
   );
 
   const resolveValue = useCallback((token: SingleToken) => {

--- a/src/app/components/DownshiftInput/DownshiftInput.tsx
+++ b/src/app/components/DownshiftInput/DownshiftInput.tsx
@@ -234,6 +234,7 @@ export const DownshiftInput: React.FunctionComponent<DownShiftProps> = ({
                 {filteredTokenItems.map((token: SingleToken, index: number) => (
                   <StyledItem
                     data-cy="downshift-input-item"
+                    data-testid="downshift-input-item"
                     className="dropdown-item"
                     {...getItemProps({ key: token.name, index, item: token })}
                     css={{

--- a/src/utils/is/__tests__/isDocumentationType.test.ts
+++ b/src/utils/is/__tests__/isDocumentationType.test.ts
@@ -1,0 +1,18 @@
+import { Properties } from '@/constants/Properties';
+import { isDocumentationType } from '../isDocumentationType';
+
+describe('isDocumentationType', () => {
+  const documentationTypes = ['tokenValue', 'value', 'tokenName', 'description'];
+  const nonDocumentationTypes = ['composition', 'sizing', 'opacity', 'color'];
+  it('should return true for documentation types', () => {
+    documentationTypes.forEach((type) => {
+      expect(isDocumentationType(type as Properties)).toBe(true);
+    });
+  });
+
+  it('should return false for non documentation types', () => {
+    nonDocumentationTypes.forEach((type) => {
+      expect(isDocumentationType(type as Properties)).toBe(false);
+    });
+  });
+});

--- a/src/utils/is/isDocumentationType.ts
+++ b/src/utils/is/isDocumentationType.ts
@@ -1,0 +1,5 @@
+import { Properties } from '@/constants/Properties';
+
+export function isDocumentationType(type: Properties): boolean {
+  return [Properties.tokenValue, Properties.value, Properties.tokenName, Properties.description].includes(type);
+}


### PR DESCRIPTION
When trying to remap in the Inspect and the token you're trying to remap is on either of the Documentation properties (tokenName, value, rawValue, description) the modal that appears to give you suggestions doesn't show anythng.

After fixing: It shows all tokens when type is documentation type