### PR TITLE
1188-typograhy-token-→-ignoresreorders-key-value-for-textcase-paragraphspacing-textdecoration

### DIFF
--- a/src/app/components/ResolvedTypograhpyValueDisplay.tsx
+++ b/src/app/components/ResolvedTypograhpyValueDisplay.tsx
@@ -44,7 +44,7 @@ export const ResolvedTypograhpyValueDisplay: React.FC<Props> = ({ value }) => {
       </Box>
       <Box>
         {Object.keys(properties).map((key) => (
-          <StyledValueItem key={seed(key)}>{value[key as keyof typeof value]}</StyledValueItem>
+          <StyledValueItem key={seed(key)}>{value[key as keyof typeof value]}&nbsp;</StyledValueItem>
         ))}
       </Box>
     </Box>


### PR DESCRIPTION
When you reference a semantic typography token that doesn't have a value for all three of the following tokens → textCase, paragraphSpacing and textDecoration, it doesn't keep the order or basically ignores empty fields.
![185393134-7ecfb4aa-5c81-4626-a416-b886e5576d80](https://user-images.githubusercontent.com/25951419/187163111-397cd766-4866-4914-850f-fd9e269701f7.jpg)
