### PR TITLE
1135 allow bulk remap

### DIFF
--- a/src/app/components/Initiator.tsx
+++ b/src/app/components/Initiator.tsx
@@ -30,7 +30,6 @@ export function Initiator() {
         switch (pluginMessage.type) {
           case MessageFromPluginTypes.SELECTION: {
             const { selectionValues, mainNodeSelectionValues, selectedNodes } = pluginMessage;
-            console.log("main", pluginMessage)
             dispatch.uiState.setSelectedLayers(selectedNodes);
             dispatch.uiState.setDisabled(false);
             if (mainNodeSelectionValues.length > 1) {

--- a/src/app/components/Initiator.tsx
+++ b/src/app/components/Initiator.tsx
@@ -30,6 +30,7 @@ export function Initiator() {
         switch (pluginMessage.type) {
           case MessageFromPluginTypes.SELECTION: {
             const { selectionValues, mainNodeSelectionValues, selectedNodes } = pluginMessage;
+            console.log("main", pluginMessage)
             dispatch.uiState.setSelectedLayers(selectedNodes);
             dispatch.uiState.setDisabled(false);
             if (mainNodeSelectionValues.length > 1) {

--- a/src/app/components/InspectorMultiView.tsx
+++ b/src/app/components/InspectorMultiView.tsx
@@ -15,12 +15,13 @@ import { TokenTypes } from '@/constants/TokenTypes';
 import { Properties } from '@/constants/Properties';
 import { SelectionGroup } from '@/types';
 import { NodeInfo } from '@/types/NodeInfo';
+import BulkRemapModal from './modals/BulkRemapModal';
 
 export default function InspectorMultiView({ resolvedTokens }: { resolvedTokens: SingleToken[] }) {
   const inspectState = useSelector(inspectStateSelector, isEqual);
   const uiState = useSelector(uiStateSelector, isEqual);
   const { removeTokensByValue } = useTokens();
-
+  const [bulkRemapModalVisible, setShowBulkRemapModalVisible] = React.useState(false);
   const dispatch = useDispatch<Dispatch>();
 
   React.useEffect(() => {
@@ -59,6 +60,14 @@ export default function InspectorMultiView({ resolvedTokens }: { resolvedTokens:
     removeTokensByValue(valuesToRemove);
   }, [inspectState.selectedTokens, removeTokensByValue, uiState.selectionValues]);
 
+  const handleShowBulkRemap = React.useCallback(() => {
+    setShowBulkRemapModalVisible(true);
+  }, [bulkRemapModalVisible]);
+
+  const handleHideBulkRemap = React.useCallback(() => {
+    setShowBulkRemapModalVisible(false);
+  }, [bulkRemapModalVisible]);
+
   return (
     <Box
       css={{
@@ -91,11 +100,21 @@ export default function InspectorMultiView({ resolvedTokens }: { resolvedTokens:
                 Select all
               </Label>
             </Box>
+            <Button onClick={handleShowBulkRemap} variant="secondary">
+              Bulk remap
+            </Button>
             <Button onClick={() => removeTokens()} disabled={inspectState.selectedTokens.length === 0} variant="secondary">
               Remove selected
             </Button>
           </Box>
           {Object.entries(groupedSelectionValues).map((group) => <InspectorTokenGroup key={`inspect-group-${group[0]}`} group={group as [Properties, SelectionGroup[]]} resolvedTokens={resolvedTokens} />)}
+          {bulkRemapModalVisible && (
+            <BulkRemapModal
+              isOpen={bulkRemapModalVisible}
+              onClose={handleHideBulkRemap}
+            />
+          )}
+
         </Box>
       ) : (
         <Blankslate title={uiState.selectedLayers > 0 ? 'No tokens found' : 'No layers selected'} text={uiState.selectedLayers > 0 ? 'None of the selected layers contain any tokens' : 'Select a layer to see applied tokens'} />

--- a/src/app/components/InspectorMultiView.tsx
+++ b/src/app/components/InspectorMultiView.tsx
@@ -100,12 +100,14 @@ export default function InspectorMultiView({ resolvedTokens }: { resolvedTokens:
                 Select all
               </Label>
             </Box>
-            <Button onClick={handleShowBulkRemap} variant="secondary">
-              Bulk remap
-            </Button>
-            <Button onClick={() => removeTokens()} disabled={inspectState.selectedTokens.length === 0} variant="secondary">
-              Remove selected
-            </Button>
+            <Box css={{ display: 'flex', flexDirection: 'row', gap: '$1' }}>
+              <Button onClick={handleShowBulkRemap} variant="secondary">
+                Bulk remap
+              </Button>
+              <Button onClick={() => removeTokens()} disabled={inspectState.selectedTokens.length === 0} variant="secondary">
+                Remove selected
+              </Button>
+            </Box>
           </Box>
           {Object.entries(groupedSelectionValues).map((group) => <InspectorTokenGroup key={`inspect-group-${group[0]}`} group={group as [Properties, SelectionGroup[]]} resolvedTokens={resolvedTokens} />)}
           {bulkRemapModalVisible && (

--- a/src/app/components/modals/BulkRemapModal.tsx
+++ b/src/app/components/modals/BulkRemapModal.tsx
@@ -20,20 +20,22 @@ export default function BulkRemapModal({ isOpen, onClose }: Props) {
     onClose();
   }, [onClose]);
 
-  const onConfirm = React.useCallback(() => {
-    handleBulkRemap(newToken, matchingToken);
+  const onConfirm = React.useCallback(async () => {
+    await handleBulkRemap(newToken, matchingToken);
     onClose();
-  }, []);
+  }, [handleBulkRemap, onClose, newToken, matchingToken]);
 
-  const handleMatchingTokenChange = React.useCallback<React.ChangeEventHandler<HTMLInputElement>>((e) => {
-    e.persist();
-    setMatchingToken(e.target.value);
-  }, [matchingToken]);
+  const handleMatchingTokenChange = React.useCallback<React.ChangeEventHandler<HTMLInputElement>>(
+    (e) => {
+      e.persist();
+      setMatchingToken(e.target.value);
+    }, [matchingToken]);
 
-  const handleNewTokenChange = React.useCallback<React.ChangeEventHandler<HTMLInputElement>>((e) => {
-    e.persist();
-    setNewToken(e.target.value);
-  }, [newToken]);
+  const handleNewTokenChange = React.useCallback<React.ChangeEventHandler<HTMLInputElement>>(
+    (e) => {
+      e.persist();
+      setNewToken(e.target.value);
+    }, [newToken]);
 
   return (
     <Modal large isOpen={isOpen} close={handleClose}>
@@ -49,6 +51,7 @@ export default function BulkRemapModal({ isOpen, onClose }: Props) {
           </Stack>
           <Input
             full
+            required
             autofocus
             type="text"
             label="Match"
@@ -60,7 +63,6 @@ export default function BulkRemapModal({ isOpen, onClose }: Props) {
           <Input
             required
             full
-            autofocus
             type="text"
             label="Remap"
             value={newToken}

--- a/src/app/components/modals/BulkRemapModal.tsx
+++ b/src/app/components/modals/BulkRemapModal.tsx
@@ -43,7 +43,6 @@ export default function BulkRemapModal({ isOpen, onClose }: Props) {
 
           </Stack>
           <Input
-            required
             full
             autofocus
             type="text"

--- a/src/app/components/modals/BulkRemapModal.tsx
+++ b/src/app/components/modals/BulkRemapModal.tsx
@@ -12,8 +12,8 @@ type Props = {
 };
 
 export default function BulkRemapModal({ isOpen, onClose }: Props) {
-  const [matchingToken, setMatchingToken] = React.useState('');
-  const [newToken, setNewToken] = React.useState('');
+  const [oldName, setOldName] = React.useState('');
+  const [newName, setNewName] = React.useState('');
   const { handleBulkRemap } = useTokens();
 
   const handleClose = React.useCallback(() => {
@@ -21,21 +21,19 @@ export default function BulkRemapModal({ isOpen, onClose }: Props) {
   }, [onClose]);
 
   const onConfirm = React.useCallback(async () => {
-    await handleBulkRemap(newToken, matchingToken);
+    await handleBulkRemap(newName, oldName);
     onClose();
-  }, [handleBulkRemap, onClose, newToken, matchingToken]);
+  }, [handleBulkRemap, onClose, newName, oldName]);
 
-  const handleMatchingTokenChange = React.useCallback<React.ChangeEventHandler<HTMLInputElement>>(
-    (e) => {
-      e.persist();
-      setMatchingToken(e.target.value);
-    }, [matchingToken]);
+  const handleOldNameChange = React.useCallback<React.ChangeEventHandler<HTMLInputElement>>((e) => {
+    e.persist();
+    setOldName(e.target.value);
+  }, [oldName]);
 
-  const handleNewTokenChange = React.useCallback<React.ChangeEventHandler<HTMLInputElement>>(
-    (e) => {
-      e.persist();
-      setNewToken(e.target.value);
-    }, [newToken]);
+  const handleNewNameChange = React.useCallback<React.ChangeEventHandler<HTMLInputElement>>((e) => {
+    e.persist();
+    setNewName(e.target.value);
+  }, [newName]);
 
   return (
     <Modal large isOpen={isOpen} close={handleClose}>
@@ -47,7 +45,6 @@ export default function BulkRemapModal({ isOpen, onClose }: Props) {
             <Heading>
               Choose a new token for
             </Heading>
-
           </Stack>
           <Input
             full
@@ -55,20 +52,20 @@ export default function BulkRemapModal({ isOpen, onClose }: Props) {
             autofocus
             type="text"
             label="Match"
-            value={matchingToken}
+            value={oldName}
             placeholder=""
-            onChange={handleMatchingTokenChange}
-            name="matchingToken"
+            onChange={handleOldNameChange}
+            name="oldName"
           />
           <Input
             required
             full
             type="text"
             label="Remap"
-            value={newToken}
+            value={newName}
             placeholder=""
-            onChange={handleNewTokenChange}
-            name="newToken"
+            onChange={handleNewNameChange}
+            name="newName"
           />
           <Stack direction="row" gap={4} justify="between">
             <Button variant="secondary" onClick={onClose}>

--- a/src/app/components/modals/BulkRemapModal.tsx
+++ b/src/app/components/modals/BulkRemapModal.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import Modal from '../Modal';
+import Heading from '../Heading';
+import Button from '../Button';
+import Stack from '../Stack';
+import Input from '../Input';
+
+type Props = {
+  isOpen: boolean
+  onClose: () => void;
+};
+
+export default function BulkRemapModal({ isOpen, onClose }: Props) {
+  const [matchingToken, setMatchingToken] = React.useState('');
+  const [newToken, setNewToken] = React.useState('');
+  const handleClose = React.useCallback(() => {
+    onClose();
+  }, [onClose]);
+
+  const onConfirm = React.useCallback(() => {
+  }, []);
+
+  const handleMatchingTokenChange = React.useCallback<React.ChangeEventHandler<HTMLInputElement>>((e) => {
+    e.persist();
+    setMatchingToken(e.target.value);
+  }, [matchingToken]);
+
+  const handleNewTokenChange = React.useCallback<React.ChangeEventHandler<HTMLInputElement>>((e) => {
+    e.persist();
+    setNewToken(e.target.value);
+  }, [newToken]);
+
+  return (
+    <Modal large isOpen={isOpen} close={handleClose}>
+      <form
+        onSubmit={onConfirm}
+      >
+        <Stack direction="column" gap={4} css={{ minHeight: '215px', justifyContent: 'center' }}>
+          <Stack direction="column" gap={2}>
+            <Heading>
+              Choose a new token for
+            </Heading>
+
+          </Stack>
+          <Input
+            required
+            full
+            autofocus
+            type="text"
+            label="Match"
+            value={matchingToken}
+            placeholder=""
+            onChange={handleMatchingTokenChange}
+            name="matchingToken"
+          />
+          <Input
+            required
+            full
+            autofocus
+            type="text"
+            label="Remap"
+            value={newToken}
+            placeholder=""
+            onChange={handleNewTokenChange}
+            name="newToken"
+          />
+          <Stack direction="row" gap={4} justify="between">
+            <Button variant="secondary" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="submit" variant="primary">
+              Remap
+            </Button>
+          </Stack>
+        </Stack>
+      </form>
+    </Modal>
+  );
+}

--- a/src/app/components/modals/BulkRemapModal.tsx
+++ b/src/app/components/modals/BulkRemapModal.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import Modal from '../Modal';
-import Heading from '../Heading';
 import Button from '../Button';
 import Stack from '../Stack';
 import Input from '../Input';
@@ -28,24 +27,19 @@ export default function BulkRemapModal({ isOpen, onClose }: Props) {
   const handleOldNameChange = React.useCallback<React.ChangeEventHandler<HTMLInputElement>>((e) => {
     e.persist();
     setOldName(e.target.value);
-  }, [oldName]);
+  }, []);
 
   const handleNewNameChange = React.useCallback<React.ChangeEventHandler<HTMLInputElement>>((e) => {
     e.persist();
     setNewName(e.target.value);
-  }, [newName]);
+  }, []);
 
   return (
-    <Modal large isOpen={isOpen} close={handleClose}>
+    <Modal large showClose isOpen={isOpen} close={handleClose} title="Choose a new token for">
       <form
         onSubmit={onConfirm}
       >
-        <Stack direction="column" gap={4} css={{ minHeight: '215px', justifyContent: 'center' }}>
-          <Stack direction="column" gap={2}>
-            <Heading>
-              Choose a new token for
-            </Heading>
-          </Stack>
+        <Stack direction="column" gap={4}>
           <Input
             full
             required

--- a/src/app/components/modals/BulkRemapModal.tsx
+++ b/src/app/components/modals/BulkRemapModal.tsx
@@ -4,6 +4,7 @@ import Heading from '../Heading';
 import Button from '../Button';
 import Stack from '../Stack';
 import Input from '../Input';
+import useTokens from '../../store/useTokens';
 
 type Props = {
   isOpen: boolean
@@ -13,11 +14,15 @@ type Props = {
 export default function BulkRemapModal({ isOpen, onClose }: Props) {
   const [matchingToken, setMatchingToken] = React.useState('');
   const [newToken, setNewToken] = React.useState('');
+  const { handleBulkRemap } = useTokens();
+
   const handleClose = React.useCallback(() => {
     onClose();
   }, [onClose]);
 
   const onConfirm = React.useCallback(() => {
+    handleBulkRemap(newToken, matchingToken);
+    onClose();
   }, []);
 
   const handleMatchingTokenChange = React.useCallback<React.ChangeEventHandler<HTMLInputElement>>((e) => {

--- a/src/app/store/useTokens.test.tsx
+++ b/src/app/store/useTokens.test.tsx
@@ -373,5 +373,18 @@ describe('useToken test', () => {
         settings: store.getState().settings,
       });
     });
+
+    it('should remap all tokens', async () => {
+      await act(async () => {
+        await result.current.handleBulkRemap('newName', 'oldName');
+      });
+
+      expect(messageSpy).toBeCalledWith({
+        type: AsyncMessageTypes.BULK_REMAP_TOKENS,
+        oldName: 'oldName',
+        newName: 'newName',
+      });
+    });
   });
+
 });

--- a/src/app/store/useTokens.tsx
+++ b/src/app/store/useTokens.tsx
@@ -131,6 +131,16 @@ export default function useTokens() {
     });
   }, [confirm]);
 
+  const handleBulkRemap = useCallback(async (newToken: string, matchingToken?: string) => {
+    const settings = settingsStateSelector(store.getState());
+    track('bulkRemapToken', { fromInspect: true });
+    AsyncMessageChannel.ReactInstance.message({
+      type: AsyncMessageTypes.BULK_REMAP_TOKENS,
+      matchingToken,
+      newToken,
+    });
+  }, [confirm]);
+
   // Calls Figma with an old name and new name and asks it to update all tokens that use the old name
   const remapToken = useCallback(async (oldName: string, newName: string, updateMode?: UpdateMode) => {
     track('remapToken', { fromRename: true });
@@ -199,6 +209,7 @@ export default function useTokens() {
     remapToken,
     removeTokensByValue,
     handleRemap,
+    handleBulkRemap,
   }), [
     isAlias,
     getTokenValue,
@@ -209,5 +220,6 @@ export default function useTokens() {
     remapToken,
     removeTokensByValue,
     handleRemap,
+    handleBulkRemap,
   ]);
 }

--- a/src/app/store/useTokens.tsx
+++ b/src/app/store/useTokens.tsx
@@ -131,15 +131,14 @@ export default function useTokens() {
     });
   }, [confirm]);
 
-  const handleBulkRemap = useCallback(async (newToken: string, matchingToken: string) => {
-    const settings = settingsStateSelector(store.getState());
+  const handleBulkRemap = useCallback(async (newName: string, oldName: string) => {
     track('bulkRemapToken', { fromInspect: true });
     AsyncMessageChannel.ReactInstance.message({
       type: AsyncMessageTypes.BULK_REMAP_TOKENS,
-      matchingToken,
-      newToken,
+      oldName,
+      newName,
     });
-  }, [confirm]);
+  }, []);
 
   // Calls Figma with an old name and new name and asks it to update all tokens that use the old name
   const remapToken = useCallback(async (oldName: string, newName: string, updateMode?: UpdateMode) => {

--- a/src/app/store/useTokens.tsx
+++ b/src/app/store/useTokens.tsx
@@ -131,7 +131,7 @@ export default function useTokens() {
     });
   }, [confirm]);
 
-  const handleBulkRemap = useCallback(async (newToken: string, matchingToken?: string) => {
+  const handleBulkRemap = useCallback(async (newToken: string, matchingToken: string) => {
     const settings = settingsStateSelector(store.getState());
     track('bulkRemapToken', { fromInspect: true });
     AsyncMessageChannel.ReactInstance.message({

--- a/src/plugin/asyncMessageHandlers/__tests__/bulkRemapTokens.test.ts
+++ b/src/plugin/asyncMessageHandlers/__tests__/bulkRemapTokens.test.ts
@@ -3,12 +3,12 @@ import { bulkRemapTokens } from '../bulkRemapTokens';
 import { defaultNodeManager } from '../../NodeManager';
 import { updatePluginData } from '@/plugin/pluginData';
 
+jest.mock('@/plugin/pluginData', (() => ({
+  updatePluginData: jest.fn(),
+})));
+
 describe('bulkRemapTokens', () => {
   const findNodesSpy = jest.spyOn(defaultNodeManager, 'findNodesWithData');
-  jest.mock('../../pluginData', (() => ({
-    updatePluginData: jest.fn(),
-  })));
-
   it('should work', async () => {
     findNodesSpy.mockImplementationOnce(() => Promise.resolve([
       {
@@ -50,6 +50,7 @@ describe('bulkRemapTokens', () => {
       oldName: 'old',
       newName: 'new'
     });
+
     expect(updatePluginData).toBeCalledWith({
       entries: [{
         hash: '9c7e97584a40179e12c9e2c75d34f80e66fe6f64',

--- a/src/plugin/asyncMessageHandlers/__tests__/bulkRemapTokens.test.ts
+++ b/src/plugin/asyncMessageHandlers/__tests__/bulkRemapTokens.test.ts
@@ -1,0 +1,91 @@
+import { AsyncMessageTypes } from '@/types/AsyncMessages';
+import { bulkRemapTokens } from '../bulkRemapTokens';
+import { defaultNodeManager } from '../../NodeManager';
+import { updatePluginData } from '@/plugin/pluginData';
+
+describe('bulkRemapTokens', () => {
+  const findNodesSpy = jest.spyOn(defaultNodeManager, 'findNodesWithData');
+  jest.mock('../../pluginData', (() => ({
+    updatePluginData: jest.fn(),
+  })));
+
+  it('should work', async () => {
+    findNodesSpy.mockImplementationOnce(() => Promise.resolve([
+      {
+        hash: '9c7e97584a40179e12c9e2c75d34f80e66fe6f64',
+        id: '295:3',
+        node: {
+          id: '295:3',
+        } as RectangleNode,
+        tokens: {
+          borderRadius: 'old.border-radius',
+          fill: 'old.slate.400',
+          sizing: 'old-size.450',
+        }
+      },
+      {
+        hash: '9c7e97584a40179e12c9e2c75d34f80e66fe6f64',
+        id: '295:4',
+        node: {
+          id: '295:4',
+        } as RectangleNode,
+        tokens: {
+          fill: 'old.red.500',
+          sizing: 'old-size.1600'
+        }
+      },
+      {
+        hash: '9c7e97584a40179e12c9e2c75d34f80e66fe6f64',
+        id: '295:5',
+        node: {
+          id: '295:5',
+        } as TextNode,
+        tokens: {
+          fill: 'old-color.gray.300'
+        }
+      }
+    ]));
+    await bulkRemapTokens({
+      type: AsyncMessageTypes.BULK_REMAP_TOKENS,
+      oldName: 'old',
+      newName: 'new'
+    });
+    expect(updatePluginData).toBeCalledWith({
+      entries: [{
+        hash: '9c7e97584a40179e12c9e2c75d34f80e66fe6f64',
+        id: '295:3',
+        node: {
+          id: '295:3',
+        } as RectangleNode,
+        tokens: {
+          borderRadius: 'new.border-radius',
+          fill: 'new.slate.400',
+          sizing: 'new-size.450',
+        }
+      },
+      {
+        hash: '9c7e97584a40179e12c9e2c75d34f80e66fe6f64',
+        id: '295:4',
+        node: {
+          id: '295:4',
+        } as RectangleNode,
+        tokens: {
+          fill: 'new.red.500',
+          sizing: 'new-size.1600'
+        }
+      },
+      {
+        hash: '9c7e97584a40179e12c9e2c75d34f80e66fe6f64',
+        id: '295:5',
+        node: {
+          id: '295:5',
+        } as TextNode,
+        tokens: {
+          fill: 'new-color.gray.300'
+        }
+      }],
+      values: {},
+      shouldOverride: true
+    })
+  });
+});

--- a/src/plugin/asyncMessageHandlers/__tests__/bulkRemapTokens.test.ts
+++ b/src/plugin/asyncMessageHandlers/__tests__/bulkRemapTokens.test.ts
@@ -9,7 +9,7 @@ jest.mock('@/plugin/pluginData', (() => ({
 
 describe('bulkRemapTokens', () => {
   const findNodesSpy = jest.spyOn(defaultNodeManager, 'findNodesWithData');
-  it('should work', async () => {
+  it('should be able to replace all matching token names with new token name', async () => {
     findNodesSpy.mockImplementationOnce(() => Promise.resolve([
       {
         hash: '9c7e97584a40179e12c9e2c75d34f80e66fe6f64',

--- a/src/plugin/asyncMessageHandlers/bulkRemapTokens.ts
+++ b/src/plugin/asyncMessageHandlers/bulkRemapTokens.ts
@@ -6,32 +6,26 @@ import { sendSelectionChange } from '../sendSelectionChange';
 
 export const bulkRemapTokens: AsyncMessageChannelHandlers[AsyncMessageTypes.BULK_REMAP_TOKENS] = async (msg) => {
   try {
-    const {
-      matchingToken, newToken
-    } = msg;
+    const { oldName, newName } = msg;
     const allWithData = await defaultNodeManager.findNodesWithData({});
-    console.log("all", allWithData)
-
     const updatedNodes: NodeManagerNode[] = [];
-    console.log("matching", matchingToken)
 
     allWithData.forEach((node) => {
       const { tokens } = node;
       const updatedTokens = Object.entries(tokens).reduce<Record<string, string>>((acc, [key, val]) => {
-        if (val.startsWith(matchingToken)) {
-          acc[key] = val.replace(matchingToken, newToken);
+        if (val.startsWith(oldName)) {
+          acc[key] = val.replace(oldName, newName);
         } else {
           acc[key] = val;
         }
         return acc;
       }, {});
-      console.log("updated", updatedTokens)
       updatedNodes.push({
         ...node,
         tokens: updatedTokens,
       });
     });
-    console.log("updated", updatedNodes)
+
     await updatePluginData({ entries: updatedNodes, values: {}, shouldOverride: true });
     await sendSelectionChange();
   } catch (e) {

--- a/src/plugin/asyncMessageHandlers/bulkRemapTokens.ts
+++ b/src/plugin/asyncMessageHandlers/bulkRemapTokens.ts
@@ -1,16 +1,39 @@
 import { AsyncMessageChannelHandlers } from '@/AsyncMessageChannel';
-import { UpdateMode } from '@/constants/UpdateMode';
 import { AsyncMessageTypes } from '@/types/AsyncMessages';
-import { tokenArrayGroupToMap } from '@/utils/tokenArrayGroupToMap';
-import { updateNodes } from '../node';
 import { defaultNodeManager, NodeManagerNode } from '../NodeManager';
 import { updatePluginData } from '../pluginData';
 import { sendSelectionChange } from '../sendSelectionChange';
-import { TokenTypes } from '@/constants/TokenTypes';
 
 export const bulkRemapTokens: AsyncMessageChannelHandlers[AsyncMessageTypes.BULK_REMAP_TOKENS] = async (msg) => {
   try {
+    const {
+      matchingToken, newToken
+    } = msg;
+    const allWithData = await defaultNodeManager.findNodesWithData({});
+    console.log("all", allWithData)
 
+    const updatedNodes: NodeManagerNode[] = [];
+    console.log("matching", matchingToken)
+
+    allWithData.forEach((node) => {
+      const { tokens } = node;
+      const updatedTokens = Object.entries(tokens).reduce<Record<string, string>>((acc, [key, val]) => {
+        if (val.startsWith(matchingToken)) {
+          acc[key] = val.replace(matchingToken, newToken);
+        } else {
+          acc[key] = val;
+        }
+        return acc;
+      }, {});
+      console.log("updated", updatedTokens)
+      updatedNodes.push({
+        ...node,
+        tokens: updatedTokens,
+      });
+    });
+    console.log("updated", updatedNodes)
+    await updatePluginData({ entries: updatedNodes, values: {}, shouldOverride: true });
+    await sendSelectionChange();
   } catch (e) {
     console.error(e);
   }

--- a/src/plugin/asyncMessageHandlers/bulkRemapTokens.ts
+++ b/src/plugin/asyncMessageHandlers/bulkRemapTokens.ts
@@ -1,0 +1,17 @@
+import { AsyncMessageChannelHandlers } from '@/AsyncMessageChannel';
+import { UpdateMode } from '@/constants/UpdateMode';
+import { AsyncMessageTypes } from '@/types/AsyncMessages';
+import { tokenArrayGroupToMap } from '@/utils/tokenArrayGroupToMap';
+import { updateNodes } from '../node';
+import { defaultNodeManager, NodeManagerNode } from '../NodeManager';
+import { updatePluginData } from '../pluginData';
+import { sendSelectionChange } from '../sendSelectionChange';
+import { TokenTypes } from '@/constants/TokenTypes';
+
+export const bulkRemapTokens: AsyncMessageChannelHandlers[AsyncMessageTypes.BULK_REMAP_TOKENS] = async (msg) => {
+  try {
+
+  } catch (e) {
+    console.error(e);
+  }
+};

--- a/src/plugin/asyncMessageHandlers/index.ts
+++ b/src/plugin/asyncMessageHandlers/index.ts
@@ -19,3 +19,4 @@ export * from './update';
 export * from './setLicenseKey';
 export * from './attachLocalStylesToTheme';
 export * from './resolveStyleInfo';
+export * from './bulkRemapTokens';

--- a/src/plugin/asyncMessageHandlers/remapTokens.ts
+++ b/src/plugin/asyncMessageHandlers/remapTokens.ts
@@ -38,6 +38,7 @@ export const remapTokens: AsyncMessageChannelHandlers[AsyncMessageTypes.REMAP_TO
         }
         return acc;
       }, {});
+      
       if (shouldBeRemapped) {
         updatedNodes.push({
           ...node,

--- a/src/plugin/controller.ts
+++ b/src/plugin/controller.ts
@@ -18,6 +18,7 @@ AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.SET_STORAGE_TYPE, as
 AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.SET_NODE_DATA, asyncHandlers.setNodeData);
 AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.REMOVE_TOKENS_BY_VALUE, asyncHandlers.removeTokensByValue);
 AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.REMAP_TOKENS, asyncHandlers.remapTokens);
+AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.BULK_REMAP_TOKENS, asyncHandlers.bulkRemapTokens);
 AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.GOTO_NODE, asyncHandlers.gotoNode);
 AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.SELECT_NODES, asyncHandlers.selectNodes);
 AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.PULL_STYLES, asyncHandlers.pullStyles);

--- a/src/types/AsyncMessages.ts
+++ b/src/types/AsyncMessages.ts
@@ -78,8 +78,8 @@ export type RemapTokensAsyncMessage = AsyncMessage<AsyncMessageTypes.REMAP_TOKEN
 export type RemapTokensMessageAsyncResult = AsyncMessage<AsyncMessageTypes.REMAP_TOKENS>;
 
 export type BulkRemapTokensAsyncMessage = AsyncMessage<AsyncMessageTypes.BULK_REMAP_TOKENS, {
-  matchingToken: string;
-  newToken: string;
+  oldName: string;
+  newName: string;
 }>;
 export type BulkRemapTokensMessageAsyncResult = AsyncMessage<AsyncMessageTypes.BULK_REMAP_TOKENS>;
 

--- a/src/types/AsyncMessages.ts
+++ b/src/types/AsyncMessages.ts
@@ -78,7 +78,7 @@ export type RemapTokensAsyncMessage = AsyncMessage<AsyncMessageTypes.REMAP_TOKEN
 export type RemapTokensMessageAsyncResult = AsyncMessage<AsyncMessageTypes.REMAP_TOKENS>;
 
 export type BulkRemapTokensAsyncMessage = AsyncMessage<AsyncMessageTypes.BULK_REMAP_TOKENS, {
-  matchingToken?: string;
+  matchingToken: string;
   newToken: string;
 }>;
 export type BulkRemapTokensMessageAsyncResult = AsyncMessage<AsyncMessageTypes.BULK_REMAP_TOKENS>;

--- a/src/types/AsyncMessages.ts
+++ b/src/types/AsyncMessages.ts
@@ -24,6 +24,7 @@ export enum AsyncMessageTypes {
   SET_NODE_DATA = 'async/set-node-data',
   REMOVE_TOKENS_BY_VALUE = 'async/remove-tokens-by-value',
   REMAP_TOKENS = 'async/remap-tokens',
+  BULK_REMAP_TOKENS = 'async/bulk-remap-tokens',
   GOTO_NODE = 'async/goto-node',
   SELECT_NODES = 'async/select-nodes',
   PULL_STYLES = 'async/pull-styles',
@@ -75,6 +76,12 @@ export type RemapTokensAsyncMessage = AsyncMessage<AsyncMessageTypes.REMAP_TOKEN
   settings?: SettingsState;
 }>;
 export type RemapTokensMessageAsyncResult = AsyncMessage<AsyncMessageTypes.REMAP_TOKENS>;
+
+export type BulkRemapTokensAsyncMessage = AsyncMessage<AsyncMessageTypes.BULK_REMAP_TOKENS, {
+  matchingToken?: string;
+  newToken: string;
+}>;
+export type BulkRemapTokensMessageAsyncResult = AsyncMessage<AsyncMessageTypes.BULK_REMAP_TOKENS>;
 
 export type GotoNodeAsyncMessage = AsyncMessage<AsyncMessageTypes.GOTO_NODE, {
   id: string;
@@ -180,6 +187,7 @@ export type AsyncMessages =
   | SetNodeDataAsyncMessage
   | RemoveTokensByValueAsyncMessage
   | RemapTokensAsyncMessage
+  | BulkRemapTokensAsyncMessage
   | GotoNodeAsyncMessage
   | SelectNodesAsyncMessage
   | PullStylesAsyncMessage
@@ -205,6 +213,7 @@ export type AsyncMessageResults =
   | SetNodeDataAsyncMessageResult
   | RemoveTokensByValueAsyncMessageResult
   | RemapTokensMessageAsyncResult
+  | BulkRemapTokensMessageAsyncResult
   | GotoNodeMessageAsyncResult
   | SelectNodesMessageAsyncResult
   | PullStylesAsyncMessageResult


### PR DESCRIPTION
Users can remap several tokens at once.
Users can click bulk remap button in Inspect Tab and type part of the old name and new name.
Then all tokens are remaped with new name
![image](https://user-images.githubusercontent.com/25951419/187370308-677f83fb-3d61-4669-9352-a72d60964862.png)
