### PR TITLE
1169 add error handling when a free user tries to save a repo with a multi file setup pro feature

### DIFF
--- a/src/app/components/AppContainer/startupProcessSteps/__tests__/getLdFlagsFactory.test.ts
+++ b/src/app/components/AppContainer/startupProcessSteps/__tests__/getLdFlagsFactory.test.ts
@@ -45,6 +45,31 @@ describe('getLdFlagsFactory', () => {
     });
   });
 
+  it('should set a free plan if there is no plan', async () => {
+    const mockStore = createMockStore({
+      userState: {
+        licenseKey: 'FIGMA-TOKENS',
+      },
+    });
+    const mockParams = {
+      user: {
+        userId: 'uid:1234',
+      },
+    } as unknown as StartupMessage;
+    const mockLdClient = {
+      identify: jest.fn(),
+    } as unknown as LDClient;
+
+    const fn = getLdFlagsFactory(mockStore, Promise.resolve(mockLdClient), mockParams);
+    await fn();
+
+    expect(setUserDataSpy).toBeCalledTimes(1);
+    expect(setUserDataSpy).toBeCalledWith({
+      plan: 'free',
+    });
+    expect(mockLdClient.identify).toBeCalledTimes(1);
+  });
+
   it('should set a free plan', async () => {
     const mockStore = createMockStore({});
     const mockParams = {

--- a/src/app/store/providers/ado/ado.tsx
+++ b/src/app/store/providers/ado/ado.tsx
@@ -114,9 +114,15 @@ export const useADO = () => {
       } catch (e) {
         closeDialog();
         console.log('Error pushing to ADO', e);
+        if (e instanceof Error) {
+          return {
+            status: 'failure',
+            errorMessage: e.message === ErrorMessages.GIT_MULTIFILE_PERMISSION_ERROR ? ErrorMessages.GIT_MULTIFILE_PERMISSION_ERROR : ErrorMessages.ADO_CREDENTIAL_ERROR,
+          };
+        }
         return {
           status: 'failure',
-          errorMessage: e === ErrorMessages.GIT_MULTIFILE_PERMISSION_ERROR ? ErrorMessages.GIT_MULTIFILE_PERMISSION_ERROR : ErrorMessages.ADO_CREDENTIAL_ERROR,
+          errorMessage: ErrorMessages.GITHUB_CREDENTIAL_ERROR,
         };
       }
     }
@@ -132,6 +138,7 @@ export const useADO = () => {
     tokens,
     themes,
     pushDialog,
+    closeDialog,
     localApiState,
   ]);
 

--- a/src/app/store/providers/ado/ado.tsx
+++ b/src/app/store/providers/ado/ado.tsx
@@ -32,7 +32,7 @@ export const useADO = () => {
   const dispatch = useDispatch<Dispatch>();
   const { multiFileSync } = useFlags();
   const { confirm } = useConfirm();
-  const { pushDialog } = usePushDialog();
+  const { pushDialog, closeDialog } = usePushDialog();
 
   const storageClientFactory = React.useCallback((context: AdoCredentials) => {
     const storageClient = new ADOTokenStorage(context);
@@ -112,10 +112,11 @@ export const useADO = () => {
           themes,
         };
       } catch (e) {
+        closeDialog();
         console.log('Error pushing to ADO', e);
         return {
           status: 'failure',
-          errorMessage: ErrorMessages.ADO_CREDENTIAL_ERROR,
+          errorMessage: e === ErrorMessages.GIT_MULTIFILE_PERMISSION_ERROR ? ErrorMessages.GIT_MULTIFILE_PERMISSION_ERROR : ErrorMessages.ADO_CREDENTIAL_ERROR,
         };
       }
     }

--- a/src/app/store/providers/bitbucket/bitbucket.tsx
+++ b/src/app/store/providers/bitbucket/bitbucket.tsx
@@ -121,9 +121,15 @@ export function useBitbucket() {
       } catch (e) {
         closeDialog();
         console.log('Error pushing to Bitbucket', e);
+        if (e instanceof Error) {
+          return {
+            status: 'failure',
+            errorMessage: e.message === ErrorMessages.GIT_MULTIFILE_PERMISSION_ERROR ? ErrorMessages.GIT_MULTIFILE_PERMISSION_ERROR : ErrorMessages.BITBUCKET_CREDENTIAL_ERROR,
+          };
+        }
         return {
           status: 'failure',
-          errorMessage: e === ErrorMessages.GIT_MULTIFILE_PERMISSION_ERROR ? ErrorMessages.GIT_MULTIFILE_PERMISSION_ERROR : ErrorMessages.BITBUCKET_CREDENTIAL_ERROR,
+          errorMessage: ErrorMessages.GITHUB_CREDENTIAL_ERROR,
         };
       }
     }
@@ -139,6 +145,7 @@ export function useBitbucket() {
     dispatch.uiState,
     dispatch.tokenState,
     pushDialog,
+    closeDialog,
     tokens,
     themes,
     localApiState,

--- a/src/app/store/providers/bitbucket/bitbucket.tsx
+++ b/src/app/store/providers/bitbucket/bitbucket.tsx
@@ -33,7 +33,7 @@ export function useBitbucket() {
   const { multiFileSync } = useFlags();
   const dispatch = useDispatch<Dispatch>();
   const { confirm } = useConfirm();
-  const { pushDialog } = usePushDialog();
+  const { pushDialog, closeDialog } = usePushDialog();
 
   const storageClientFactory = useCallback(
     (context: BitbucketCredentials, owner?: string, repo?: string) => {
@@ -119,10 +119,11 @@ export function useBitbucket() {
           themes,
         };
       } catch (e) {
+        closeDialog();
         console.log('Error pushing to Bitbucket', e);
         return {
           status: 'failure',
-          errorMessage: ErrorMessages.BITBUCKET_CREDENTIAL_ERROR,
+          errorMessage: e === ErrorMessages.GIT_MULTIFILE_PERMISSION_ERROR ? ErrorMessages.GIT_MULTIFILE_PERMISSION_ERROR : ErrorMessages.BITBUCKET_CREDENTIAL_ERROR,
         };
       }
     }

--- a/src/app/store/providers/github/github.tsx
+++ b/src/app/store/providers/github/github.tsx
@@ -117,11 +117,11 @@ export function useGitHub() {
           themes,
         };
       } catch (e) {
-        console.log('Error pushing to GitHub', e);
         closeDialog();
+        console.log('Error pushing to GitHub', e);
         return {
           status: 'failure',
-          errorMessage: ErrorMessages.GITHUB_CREDENTIAL_ERROR,
+          errorMessage: e === ErrorMessages.GIT_MULTIFILE_PERMISSION_ERROR ? ErrorMessages.GIT_MULTIFILE_PERMISSION_ERROR : ErrorMessages.GITHUB_CREDENTIAL_ERROR,
         };
       }
     }

--- a/src/app/store/providers/github/github.tsx
+++ b/src/app/store/providers/github/github.tsx
@@ -32,7 +32,7 @@ export function useGitHub() {
   const { multiFileSync } = useFlags();
   const dispatch = useDispatch<Dispatch>();
   const { confirm } = useConfirm();
-  const { pushDialog } = usePushDialog();
+  const { pushDialog, closeDialog } = usePushDialog();
 
   const storageClientFactory = useCallback((context: GithubCredentials, owner?: string, repo?: string) => {
     const splitContextId = context.id.split('/');
@@ -53,8 +53,10 @@ export function useGitHub() {
   }, [confirm]);
 
   const pushTokensToGitHub = useCallback(async (context: GithubCredentials): Promise<RemoteResponseData> => {
+    console.log('push');
     const storage = storageClientFactory(context);
     const content = await storage.retrieve();
+    console.log('retrconte', content);
     if (content?.status === 'failure') {
       return {
         status: 'failure',
@@ -90,6 +92,7 @@ export function useGitHub() {
         const metadata = {
           tokenSetOrder: Object.keys(tokens),
         };
+        console.log('befoirseave');
         await storage.save({
           themes,
           tokens,
@@ -97,6 +100,7 @@ export function useGitHub() {
         }, {
           commitMessage,
         });
+        console.log('save');
         saveLastSyncedState(dispatch, tokens, themes, metadata);
         dispatch.uiState.setLocalApiState({ ...localApiState, branch: customBranch } as GithubCredentials);
         dispatch.uiState.setApiData({ ...context, branch: customBranch });
@@ -114,6 +118,7 @@ export function useGitHub() {
         };
       } catch (e) {
         console.log('Error pushing to GitHub', e);
+        closeDialog();
         return {
           status: 'failure',
           errorMessage: ErrorMessages.GITHUB_CREDENTIAL_ERROR,
@@ -192,6 +197,7 @@ export function useGitHub() {
     try {
       const storage = storageClientFactory(context);
       const hasBranches = await storage.fetchBranches();
+      console.log('branh');
       dispatch.branchState.setBranches(hasBranches);
       if (!hasBranches || !hasBranches.length) {
         return {

--- a/src/app/store/providers/gitlab/gitlab.tsx
+++ b/src/app/store/providers/gitlab/gitlab.tsx
@@ -125,9 +125,15 @@ export function useGitLab() {
       } catch (e) {
         closeDialog();
         console.log('Error pushing to GitLab', e);
+        if (e instanceof Error) {
+          return {
+            status: 'failure',
+            errorMessage: e.message === ErrorMessages.GIT_MULTIFILE_PERMISSION_ERROR ? ErrorMessages.GIT_MULTIFILE_PERMISSION_ERROR : ErrorMessages.GITLAB_CREDENTIAL_ERROR,
+          };
+        }
         return {
           status: 'failure',
-          errorMessage: e === ErrorMessages.GIT_MULTIFILE_PERMISSION_ERROR ? ErrorMessages.GIT_MULTIFILE_PERMISSION_ERROR : ErrorMessages.GITLAB_CREDENTIAL_ERROR,
+          errorMessage: ErrorMessages.GITHUB_CREDENTIAL_ERROR,
         };
       }
     }
@@ -141,6 +147,7 @@ export function useGitLab() {
     dispatch,
     storageClientFactory,
     pushDialog,
+    closeDialog,
     tokens,
     themes,
     localApiState,

--- a/src/app/store/providers/gitlab/gitlab.tsx
+++ b/src/app/store/providers/gitlab/gitlab.tsx
@@ -48,7 +48,7 @@ export function useGitLab() {
   const dispatch = useDispatch<Dispatch>();
 
   const { confirm } = useConfirm();
-  const { pushDialog } = usePushDialog();
+  const { pushDialog, closeDialog } = usePushDialog();
 
   const storageClientFactory = useCallback(clientFactory, []);
 
@@ -123,10 +123,11 @@ export function useGitLab() {
           metadata: {},
         };
       } catch (e) {
+        closeDialog();
         console.log('Error pushing to GitLab', e);
         return {
           status: 'failure',
-          errorMessage: ErrorMessages.GITLAB_CREDENTIAL_ERROR,
+          errorMessage: e === ErrorMessages.GIT_MULTIFILE_PERMISSION_ERROR ? ErrorMessages.GIT_MULTIFILE_PERMISSION_ERROR : ErrorMessages.GITLAB_CREDENTIAL_ERROR,
         };
       }
     }

--- a/src/app/store/remoteTokens.test.ts
+++ b/src/app/store/remoteTokens.test.ts
@@ -583,6 +583,35 @@ describe('remoteTokens', () => {
 
   Object.entries(contextMap).forEach(([contextName, context]) => {
     if (context === gitHubContext || context === gitLabContext || context === adoContext || context === bitbucketContext) {
+      it(`Add newProviderItem to ${context.provider}, should return error message when a error occured while saving the data`, async () => {
+        mockFetchBranches.mockImplementation(() => (
+          Promise.resolve(['main'])
+        ));
+        mockRetrieve.mockImplementation(() => (
+          Promise.resolve(null)
+        ));
+        mockPushDialog.mockImplementation(() => (
+          Promise.resolve({
+            customBranch: 'development',
+            commitMessage: 'Initial commit',
+          })
+        ));
+        mockSave.mockImplementation(() => {
+          throw new Error(ErrorMessages.GENERAL_CONNECTION_ERROR);
+        });
+
+        await waitFor(() => { result.current.addNewProviderItem(context as StorageTypeCredentials); });
+        expect(mockCloseDialog).toBeCalledTimes(1);
+        expect(await result.current.addNewProviderItem(context as StorageTypeCredentials)).toEqual({
+          status: 'failure',
+          errorMessage: errorMessageMap[contextName as keyof typeof errorMessageMap],
+        });
+      });
+    }
+  });
+
+  Object.entries(contextMap).forEach(([contextName, context]) => {
+    if (context === gitHubContext || context === gitLabContext || context === adoContext || context === bitbucketContext) {
       it(`Add newProviderItem to ${context.provider}, should pull tokens and notify that no tokens stored on remote if there is no tokens on remote`, async () => {
         mockFetchBranches.mockImplementation(() => (
           Promise.resolve(['main'])

--- a/src/constants/ErrorMessages.ts
+++ b/src/constants/ErrorMessages.ts
@@ -11,4 +11,5 @@ export enum ErrorMessages {
   VALIDATION_ERROR = 'Contents don\'t pass schema validation',
   ID_NON_EXIST_ERROR = 'ID or Secret should be exist',
   JSONBIN_CREATE_ERROR = 'Error creating JSONbin token storage',
+  GIT_MULTIFILE_PERMISSION_ERROR = 'You try to save a multi-file project as a free user. Upgrade to Pro or add a json file at the end of the filepath (tokens.json)',
 }

--- a/src/storage/GitTokenStorage.ts
+++ b/src/storage/GitTokenStorage.ts
@@ -3,6 +3,7 @@ import { AnyTokenSet, SingleToken } from '@/types/tokens';
 import { SystemFilenames } from '@/constants/SystemFilenames';
 import { joinPath } from '@/utils/string';
 import { RemoteTokenStorage, RemoteTokenStorageFile, RemoteTokenStorageMetadata } from './RemoteTokenStorage';
+import { ErrorMessages } from '@/constants/ErrorMessages';
 
 type StorageFlags = {
   multiFileEnabled: boolean
@@ -111,7 +112,7 @@ export abstract class GitTokenStorage extends RemoteTokenStorage<GitStorageSaveO
       });
     } else {
       // When path is a directory and multiFile is disabled return
-      throw new Error('Multi-file storage is not enabled');
+      throw new Error(ErrorMessages.GIT_MULTIFILE_PERMISSION_ERROR);
     }
     return this.writeChangeset(
       filesChangeset,

--- a/src/storage/__tests__/GithubTokenStorage.test.ts
+++ b/src/storage/__tests__/GithubTokenStorage.test.ts
@@ -618,7 +618,7 @@ describe('GithubTokenStorage', () => {
       ], {
         commitMessage: '',
       });
-    }).rejects.toThrow('Multi-file storage is not enabled');
+    }).rejects.toThrow(ErrorMessages.GIT_MULTIFILE_PERMISSION_ERROR);
     expect(mockCreateOrUpdateFiles).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Currently when you try to save a Github repo as a free user, but have a multi-file setup (no .json in filepath), there is strange behaviour and you get stuck in a push-loop (see attached video).
Add a clear error that indicates the problem of this behaviour