### PR TITLE
1077-support-folder-structure-for-non-multi-file

### DIFF
--- a/src/app/components/TokenSetSelector.tsx
+++ b/src/app/components/TokenSetSelector.tsx
@@ -11,12 +11,10 @@ import Modal from './Modal';
 import TokenSetTree from './TokenSetTree';
 import Box from './Box';
 import { styled } from '@/stitches.config';
-import TokenSetList from './TokenSetList';
 import {
   editProhibitedSelector, tokensSelector,
 } from '@/selectors';
 import Stack from './Stack';
-import { useIsGitMultiFileEnabled } from '../hooks/useIsGitMultiFileEnabled';
 
 const StyledButton = styled('button', {
   flexShrink: 0,
@@ -37,7 +35,6 @@ const StyledButton = styled('button', {
 export default function TokenSetSelector({ saveScrollPositionSet } : { saveScrollPositionSet: (tokenSet: string) => void }) {
   const tokens = useSelector(tokensSelector);
   const editProhibited = useSelector(editProhibitedSelector);
-  const mfsEnabled = useIsGitMultiFileEnabled();
   const dispatch = useDispatch<Dispatch>();
   const { confirm } = useConfirm();
 
@@ -144,25 +141,14 @@ export default function TokenSetSelector({ saveScrollPositionSet } : { saveScrol
       }}
       className="content"
     >
-      {mfsEnabled ? (
-        <TokenSetTree
-          tokenSets={allTokenSets}
-          onRename={handleRenameTokenSet}
-          onDelete={handleDelete}
-          onDuplicate={handleDuplicateTokenSet}
-          onReorder={handleReorder}
-          saveScrollPositionSet={saveScrollPositionSet}
-        />
-      ) : (
-        <TokenSetList
-          onReorder={handleReorder}
-          tokenSets={allTokenSets}
-          onRename={handleRenameTokenSet}
-          onDelete={handleDeleteTokenSet}
-          onDuplicate={handleDuplicateTokenSet}
-          saveScrollPositionSet={saveScrollPositionSet}
-        />
-      )}
+      <TokenSetTree
+        tokenSets={allTokenSets}
+        onRename={handleRenameTokenSet}
+        onDelete={handleDelete}
+        onDuplicate={handleDuplicateTokenSet}
+        onReorder={handleReorder}
+        saveScrollPositionSet={saveScrollPositionSet}
+      />
       <Modal
         isOpen={showRenameTokenSetFields}
         close={handleCloseRenameModal}


### PR DESCRIPTION
Make it possible to add folders/groups for sets. This should work the same as the feature in Multi File:
Simply renam token sets to have a folder path, eg folder/set-1 , folder/set-2