### PR TITLE
Allow multiline description in token

### DIFF
--- a/src/app/components/EditTokenForm.tsx
+++ b/src/app/components/EditTokenForm.tsx
@@ -22,6 +22,8 @@ import { UpdateMode } from '@/constants/UpdateMode';
 import trimValue from '@/utils/trimValue';
 import BoxShadowInput from './BoxShadowInput';
 import { EditTokenFormStatus } from '@/constants/EditTokenFormStatus';
+import Textarea from './Textarea';
+import Heading from './Heading';
 
 type Props = {
   resolvedTokens: ResolveTokenValuesResult[];
@@ -184,13 +186,12 @@ function EditTokenForm({ resolvedTokens }: Props) {
     } as typeof editToken);
   }, [internalEditToken]);
 
-  const handleDescriptionChange = React.useCallback<React.ChangeEventHandler<HTMLInputElement>>(
-    (e) => {
-      e.persist();
+  const handleDescriptionChange = React.useCallback(
+    (val: string) => {
       if (internalEditToken) {
         setInternalEditToken({
           ...internalEditToken,
-          description: e.target.value,
+          description: val,
         });
       }
     },
@@ -408,15 +409,14 @@ function EditTokenForm({ resolvedTokens }: Props) {
         {renderTokenForm()}
 
         {internalEditToken?.schema?.explainer && <div className="mt-1 text-gray-600 text-xxs">{internalEditToken.schema.explainer}</div>}
-        <Input
-          full
+        <Heading size="small">Description</Heading>
+
+        <Textarea
           key="description"
-          label="description"
-          value={internalEditToken?.description}
+          value={internalEditToken?.description || ''}
           onChange={handleDescriptionChange}
-          type="text"
-          name="description"
-          capitalize
+          rows={3}
+          border
         />
         <Stack direction="row" justify="end" gap={2}>
           <Button variant="secondary" type="button" onClick={handleReset}>


### PR DESCRIPTION
Fixes #1244 

Changes `Input` to `Textarea` in `EditTokenForm` so that we can show and create multiline text descriptions.

https://user-images.githubusercontent.com/4548309/189426693-7cbe436a-2939-428e-ae12-760f67570ad6.mp4