### PR TITLE
1278-120-rc1-renaming-token-groups-causes-them-to-collapse

### DIFF
--- a/src/app/components/TokenGroup/TokenGroup.test.tsx
+++ b/src/app/components/TokenGroup/TokenGroup.test.tsx
@@ -75,8 +75,8 @@ describe('TokenGroup', () => {
       schema={schema as TokenTypeSchema}
     />);
 
-    await fireEvent.click(getByTestId('tokenlisting-group-size.font'));
-    await fireEvent.click(getByTestId('tokenlisting-group-color'));
+    await fireEvent.click(getByTestId('group-heading-size.font-font-listing'));
+    await fireEvent.click(getByTestId('group-heading-color-color-listing'));
 
     const { collapsedTokens } = store.getState().tokenState;
     expect(collapsedTokens).toEqual(['size.font', 'color']);
@@ -90,9 +90,9 @@ describe('TokenGroup', () => {
       schema={schema as TokenTypeSchema}
     />);
 
-    await fireEvent.click(getByTestId('tokenlisting-group-size.font'));
-    await fireEvent.click(getByTestId('tokenlisting-group-size.font'));
-    await fireEvent.click(getByTestId('tokenlisting-group-color'));
+    await fireEvent.click(getByTestId('group-heading-size.font-font-listing'));
+    await fireEvent.click(getByTestId('group-heading-size.font-font-listing'));
+    await fireEvent.click(getByTestId('group-heading-color-color-listing'));
 
     const { collapsedTokens } = store.getState().tokenState;
     expect(collapsedTokens).toEqual(['color']);

--- a/src/app/components/TokenGroup/TokenGroupHeading.tsx
+++ b/src/app/components/TokenGroup/TokenGroupHeading.tsx
@@ -95,7 +95,7 @@ export function TokenGroupHeading({
       >
         {collapsed.includes(path) ? <IconCollapseArrow /> : <IconExpandArrow />}
         <ContextMenu>
-          <ContextMenuTrigger id={`group-heading-${path}-${label}-${id}`} onClick={handleToggleCollapsed}>
+          <ContextMenuTrigger data-testid={`group-heading-${path}-${label}-${id}`} onClick={handleToggleCollapsed}>
             <Heading muted size="small">{label}</Heading>
           </ContextMenuTrigger>
           <ContextMenuContent>

--- a/src/app/components/TokenGroup/TokenGroupHeading.tsx
+++ b/src/app/components/TokenGroup/TokenGroupHeading.tsx
@@ -79,7 +79,6 @@ export function TokenGroupHeading({
   }, [duplicateGroup, path, type]);
 
   const handleToggleCollapsed = useCallback(() => {
-    console.log('collapse');
     dispatch.tokenState.setCollapsedTokens(collapsed.includes(path) ? collapsed.filter((s) => s !== path) : [...collapsed, path]);
   }, [collapsed, dispatch.tokenState, path]);
 

--- a/src/app/components/TokenGroup/TokenGroupHeading.tsx
+++ b/src/app/components/TokenGroup/TokenGroupHeading.tsx
@@ -79,6 +79,7 @@ export function TokenGroupHeading({
   }, [duplicateGroup, path, type]);
 
   const handleToggleCollapsed = useCallback(() => {
+    console.log('collapse');
     dispatch.tokenState.setCollapsedTokens(collapsed.includes(path) ? collapsed.filter((s) => s !== path) : [...collapsed, path]);
   }, [collapsed, dispatch.tokenState, path]);
 
@@ -91,11 +92,10 @@ export function TokenGroupHeading({
         data-cy={`tokenlisting-group-${path}`}
         data-testid={`tokenlisting-group-${path}`}
         type="button"
-        onClick={handleToggleCollapsed}
       >
         {collapsed.includes(path) ? <IconCollapseArrow /> : <IconExpandArrow />}
         <ContextMenu>
-          <ContextMenuTrigger id={`group-heading-${path}-${label}-${id}`}>
+          <ContextMenuTrigger id={`group-heading-${path}-${label}-${id}`} onClick={handleToggleCollapsed}>
             <Heading muted size="small">{label}</Heading>
           </ContextMenuTrigger>
           <ContextMenuContent>
@@ -110,39 +110,39 @@ export function TokenGroupHeading({
             </ContextMenuItem>
           </ContextMenuContent>
         </ContextMenu>
-        <Modal
-          title={`Rename ${oldTokenGroupName}`}
-          isOpen={showNewGroupNameField}
-          close={handleSetNewTokenGroupNameFileClose}
-          footer={(
-            <form id="renameTokenGroup" onSubmit={handleRenameTokenGroupSubmit}>
-              <Stack direction="row" gap={4}>
-                <Button variant="secondary" size="large" onClick={handleSetNewTokenGroupNameFileClose}>
-                  Cancel
-                </Button>
-                <Button type="submit" variant="primary" size="large" disabled={oldTokenGroupName === newTokenGroupName}>
-                  Change
-                </Button>
-              </Stack>
-            </form>
-        )}
-        >
-          <Stack direction="column" justify="center" gap={4} css={{ textAlign: 'center' }}>
-            <Heading size="small">Renaming only affects tokens of the same type</Heading>
-            <Stack direction="column" gap={4}>
-              <Input
-                form="renameTokenGroup"
-                full
-                onChange={handleNewTokenGroupNameChange}
-                type="text"
-                name="tokengroupname"
-                value={newTokenGroupName}
-                required
-              />
-            </Stack>
-          </Stack>
-        </Modal>
       </StyledTokenGroupHeadingCollapsable>
+      <Modal
+        title={`Rename ${oldTokenGroupName}`}
+        isOpen={showNewGroupNameField}
+        close={handleSetNewTokenGroupNameFileClose}
+        footer={(
+          <form id="renameTokenGroup" onSubmit={handleRenameTokenGroupSubmit}>
+            <Stack direction="row" gap={4}>
+              <Button variant="secondary" size="large" onClick={handleSetNewTokenGroupNameFileClose}>
+                Cancel
+              </Button>
+              <Button type="submit" variant="primary" size="large" disabled={oldTokenGroupName === newTokenGroupName}>
+                Change
+              </Button>
+            </Stack>
+          </form>
+        )}
+      >
+        <Stack direction="column" justify="center" gap={4} css={{ textAlign: 'center' }}>
+          <Heading size="small">Renaming only affects tokens of the same type</Heading>
+          <Stack direction="column" gap={4}>
+            <Input
+              form="renameTokenGroup"
+              full
+              onChange={handleNewTokenGroupNameChange}
+              type="text"
+              name="tokengroupname"
+              value={newTokenGroupName}
+              required
+            />
+          </Stack>
+        </Stack>
+      </Modal>
       <StyledTokenGroupAddIcon
         icon={<IconAdd />}
         tooltip="Add a new token"


### PR DESCRIPTION
Renaming a token group seems to have a strange side-effect: It collapses the token group while renaming.
Expected: Don't collapse groups while renaming
https://www.loom.com/share/eeb6db0d63884bd6b5e1a0be6ad1457e