### PR TITLE
1196 in the styles actions add a new sync styles option which renames styles according to their connected tokens via themes deletes any styles that are not referenced and creates new styles that do not exist yet

### DIFF
--- a/src/app/components/StylesDropdown.tsx
+++ b/src/app/components/StylesDropdown.tsx
@@ -12,6 +12,7 @@ export default function StylesDropdown() {
 
   const { pullStyles } = useTokens();
   const { createStylesFromTokens } = useTokens();
+  const { syncStyles } = useTokens();
   return (
     <DropdownMenu>
       <DropdownMenuTrigger>
@@ -24,6 +25,7 @@ export default function StylesDropdown() {
       <DropdownMenuContent side="top">
         <DropdownMenuItem textValue="Import styles" disabled={editProhibited} onSelect={pullStyles}>Import styles</DropdownMenuItem>
         <DropdownMenuItem textValue="Create styles" onSelect={createStylesFromTokens}>Create styles</DropdownMenuItem>
+        <DropdownMenuItem textValue="Sync styles" onSelect={syncStyles}>Sync styles</DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/src/app/components/StylesDropdown.tsx
+++ b/src/app/components/StylesDropdown.tsx
@@ -23,9 +23,9 @@ export default function StylesDropdown() {
       </DropdownMenuTrigger>
 
       <DropdownMenuContent side="top">
+        <DropdownMenuItem textValue="Sync styles" onSelect={syncStyles}>Sync styles</DropdownMenuItem>
         <DropdownMenuItem textValue="Import styles" disabled={editProhibited} onSelect={pullStyles}>Import styles</DropdownMenuItem>
         <DropdownMenuItem textValue="Create styles" onSelect={createStylesFromTokens}>Create styles</DropdownMenuItem>
-        <DropdownMenuItem textValue="Sync styles" onSelect={syncStyles}>Sync styles</DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/src/app/store/models/reducers/tokenState/assignStyleIdsToCurrentTheme.ts
+++ b/src/app/store/models/reducers/tokenState/assignStyleIdsToCurrentTheme.ts
@@ -6,10 +6,7 @@ export function assignStyleIdsToCurrentTheme(state: TokenState, styleIds: Record
   if (!state.activeTheme) return state;
   // ignore if the theme does not exist for some reason
   const themeObjectIndex = state.themes.findIndex(({ id }) => state.activeTheme === id);
-  if (
-    themeObjectIndex === -1
-    || isEqual(styleIds, state.themes[themeObjectIndex].$figmaStyleReferences)
-  ) return state;
+  if (themeObjectIndex === -1 || isEqual(styleIds, state.themes[themeObjectIndex].$figmaStyleReferences)) return state;
 
   const updatedThemes = [...state.themes];
   updatedThemes.splice(themeObjectIndex, 1, {

--- a/src/app/store/useManageTokens.tsx
+++ b/src/app/store/useManageTokens.tsx
@@ -115,7 +115,7 @@ export default function useManageTokens() {
         isInfinite: true,
       });
       deleteToken(data);
-      if (userConfirmation.data && userConfirmation.data.length) {
+      if (Array.isArray(userConfirmation.data) && userConfirmation.data.length) {
         removeStylesFromTokens(data);
       }
       dispatch.uiState.completeJob(BackgroundJobs.UI_DELETETOKEN);

--- a/src/app/store/useTokens.test.tsx
+++ b/src/app/store/useTokens.test.tsx
@@ -9,7 +9,9 @@ import {
 } from '@/types/tokens';
 import { AsyncMessageChannel } from '@/AsyncMessageChannel';
 import { AsyncMessageTypes, GetThemeInfoMessageResult } from '@/types/AsyncMessages';
-import { createStyles, renameStyles, removeStyles } from '@/plugin/asyncMessageHandlers';
+import {
+  createStyles, renameStyles, removeStyles, syncStyles,
+} from '@/plugin/asyncMessageHandlers';
 import { AllTheProviders, createMockStore, resetStore } from '../../../tests/config/setupTest';
 import { store } from '../store';
 import { TokenSetStatus } from '@/constants/TokenSetStatus';
@@ -329,6 +331,7 @@ describe('useToken test', () => {
     AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.CREATE_STYLES, createStyles);
     AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.RENAME_STYLES, renameStyles);
     AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.REMOVE_STYLES, removeStyles);
+    AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.SYNC_STYLES, syncStyles);
 
     it('creates all styles', async () => {
       mockConfirm.mockImplementation(() => Promise.resolve({ data: ['textStyles', 'colorStyles', 'effectStyles'] }));
@@ -444,6 +447,25 @@ describe('useToken test', () => {
         type: AsyncMessageTypes.REMOVE_STYLES,
         token: tokenToDelete,
         settings: store.getState().settings,
+      });
+    });
+
+    it('syncStyles', async () => {
+      mockConfirm.mockImplementation(() => Promise.resolve({ data: ['renameStyles', 'removeStyles'] }));
+      await act(async () => {
+        await result.current.syncStyles();
+      });
+
+      expect(messageSpy).toBeCalledWith({
+        type: AsyncMessageTypes.SYNC_STYLES,
+        tokens: {
+          global: [{ name: 'white', value: '#ffffff', type: TokenTypes.COLOR }, { name: 'headline', value: { fontFamily: 'Inter', fontWeight: 'Bold' }, type: TokenTypes.TYPOGRAPHY }, { name: 'shadow', value: '{shadows.default}', type: TokenTypes.BOX_SHADOW }],
+          light: [{ name: 'bg.default', value: '#ffffff', type: TokenTypes.COLOR }],
+        },
+        settings: {
+          renameStyle: true,
+          removeStyle: true,
+        },
       });
     });
   });

--- a/src/app/store/useTokens.tsx
+++ b/src/app/store/useTokens.tsx
@@ -247,7 +247,7 @@ export default function useTokens() {
       dispatch.tokenState.assignStyleIdsToCurrentTheme(syncStyleResult.styleIdsToCreate);
       dispatch.tokenState.removeStyleIdsFromThemes(syncStyleResult.styleIdsToRemove);
     }
-  }, [confirm, usedTokenSet, tokens, settings, dispatch.tokenState]);
+  }, [confirm, tokens, dispatch.tokenState]);
 
   const renameStylesFromTokens = useCallback(async ({ oldName, newName, parent }: { oldName: string, newName: string, parent: string }) => {
     track('renameStyles', { oldName, newName, parent });

--- a/src/app/store/useTokens.tsx
+++ b/src/app/store/useTokens.tsx
@@ -221,6 +221,27 @@ export default function useTokens() {
     }
   }, [confirm, usedTokenSet, tokens, settings, dispatch.tokenState]);
 
+  const syncStyles = useCallback(async () => {
+    const userConfirmation = await confirm({
+      text: 'Sync styles',
+      description: 'Choose sync option',
+      choices: [
+        { key: 'updateStyles', label: 'Remove styles without connection' },
+        { key: 'renameStyles', label: 'Rename styles' },
+      ],
+    });
+
+    if (userConfirmation && Array.isArray(userConfirmation.data) && userConfirmation.data.length) {
+      track('syncStyles', userConfirmation.data);
+
+      const syncStylesResult = await AsyncMessageChannel.ReactInstance.message({
+        type: AsyncMessageTypes.SYNC_STYLES,
+        tokens,
+      });
+      // dispatch.tokenState.assignStyleIdsToCurrentTheme(createStylesResult.styleIds);
+    }
+  }, [confirm, usedTokenSet, tokens, settings, dispatch.tokenState]);
+
   const removeStylesFromTokens = useCallback(async (token: DeleteTokenPayload) => {
     track('removeStyles', token);
 
@@ -245,6 +266,7 @@ export default function useTokens() {
     handleRemap,
     handleBulkRemap,
     removeStylesFromTokens,
+    syncStyles,
   }), [
     isAlias,
     getTokenValue,
@@ -258,5 +280,6 @@ export default function useTokens() {
     handleRemap,
     handleBulkRemap,
     removeStylesFromTokens,
+    syncStyles,
   ]);
 }

--- a/src/app/store/useTokens.tsx
+++ b/src/app/store/useTokens.tsx
@@ -7,7 +7,7 @@ import {
 import stringifyTokens from '@/utils/stringifyTokens';
 import formatTokens from '@/utils/formatTokens';
 import { mergeTokenGroups, resolveTokenValues } from '@/plugin/tokenHelpers';
-import useConfirm from '../hooks/useConfirm';
+import useConfirm, { ResolveCallbackPayload } from '../hooks/useConfirm';
 import { Properties } from '@/constants/Properties';
 import { track } from '@/utils/analytics';
 import { checkIfAlias } from '@/utils/alias';
@@ -41,6 +41,8 @@ type GetFormattedTokensOptions = {
 };
 
 type RemoveTokensByValueData = { property: Properties; nodes: NodeInfo[] }[];
+
+export type SyncOption = 'removeStyle' | 'renameStyle';
 
 export default function useTokens() {
   const dispatch = useDispatch<Dispatch>();
@@ -226,16 +228,20 @@ export default function useTokens() {
       text: 'Sync styles',
       description: 'Choose sync option',
       choices: [
-        { key: 'updateStyles', label: 'Remove styles without connection' },
+        { key: 'removeStyles', label: 'Remove styles without connection' },
         { key: 'renameStyles', label: 'Rename styles' },
       ],
-    });
+    }) as ResolveCallbackPayload<any>;
 
     if (userConfirmation && Array.isArray(userConfirmation.data) && userConfirmation.data.length) {
       track('syncStyles', userConfirmation.data);
       await AsyncMessageChannel.ReactInstance.message({
         type: AsyncMessageTypes.SYNC_STYLES,
         tokens,
+        settings: {
+          renameStyle: userConfirmation.data.includes('renameStyles'),
+          removeStyle: userConfirmation.data.includes('removeStyles'),
+        },
       });
       // dispatch.tokenState.assignStyleIdsToCurrentTheme(createStylesResult.styleIds);
     }

--- a/src/app/store/useTokens.tsx
+++ b/src/app/store/useTokens.tsx
@@ -16,6 +16,7 @@ import {
   settingsStateSelector,
   tokensSelector,
   usedTokenSetSelector,
+  themesListSelector,
 } from '@/selectors';
 import { TokenSetStatus } from '@/constants/TokenSetStatus';
 import { TokenTypes } from '@/constants/TokenTypes';
@@ -27,6 +28,9 @@ import { NodeInfo } from '@/types/NodeInfo';
 import { TokensContext } from '@/context';
 import { Dispatch, RootState } from '../store';
 import { DeleteTokenPayload } from '@/types/payloads';
+import { theme } from '@/stitches.config';
+import { UsedTokenSetsMap } from '@/types';
+import { appendTypeToToken } from '../components/createTokenObj';
 
 type ConfirmResult =
   ('textStyles' | 'colorStyles' | 'effectStyles')[]
@@ -51,6 +55,7 @@ export default function useTokens() {
   const { confirm } = useConfirm<ConfirmResult>();
   const store = useStore<RootState>();
   const tokensContext = useContext(TokensContext);
+  const themes = useSelector(themesListSelector);
 
   // Gets value of token
   const getTokenValue = useCallback((name: string, resolved: AnyTokenList) => (
@@ -233,7 +238,6 @@ export default function useTokens() {
 
     if (userConfirmation && Array.isArray(userConfirmation.data) && userConfirmation.data.length) {
       track('syncStyles', userConfirmation.data);
-
       const syncStylesResult = await AsyncMessageChannel.ReactInstance.message({
         type: AsyncMessageTypes.SYNC_STYLES,
         tokens,

--- a/src/app/store/useTokens.tsx
+++ b/src/app/store/useTokens.tsx
@@ -6,7 +6,7 @@ import {
 } from '@/types/tokens';
 import stringifyTokens from '@/utils/stringifyTokens';
 import formatTokens from '@/utils/formatTokens';
-import { mergeTokenGroups, resolveTokenValues } from '@/plugin/tokenHelpers';
+import { mergeTokenGroups, resolveTokenValues, ResolveTokenValuesResult } from '@/plugin/tokenHelpers';
 import useConfirm, { ResolveCallbackPayload } from '../hooks/useConfirm';
 import { Properties } from '@/constants/Properties';
 import { track } from '@/utils/analytics';
@@ -14,6 +14,7 @@ import { checkIfAlias } from '@/utils/alias';
 import {
   activeTokenSetSelector,
   settingsStateSelector,
+  themesListSelector,
   tokensSelector,
   usedTokenSetSelector,
 } from '@/selectors';
@@ -49,6 +50,7 @@ export default function useTokens() {
   const usedTokenSet = useSelector(usedTokenSetSelector);
   const activeTokenSet = useSelector(activeTokenSetSelector);
   const tokens = useSelector(tokensSelector);
+  const themes = useSelector(themesListSelector);
   const settings = useSelector(settingsStateSelector, isEqual);
   const { confirm } = useConfirm<ConfirmResult>();
   const store = useStore<RootState>();
@@ -213,6 +215,7 @@ export default function useTokens() {
           userDecision.data.includes('effectStyles') && token.type === TokenTypes.BOX_SHADOW,
         ].some((isEnabled) => isEnabled)
       ));
+      console.log('token', tokensToCreate)
 
       const createStylesResult = await AsyncMessageChannel.ReactInstance.message({
         type: AsyncMessageTypes.CREATE_STYLES,
@@ -234,10 +237,33 @@ export default function useTokens() {
     }) as ResolveCallbackPayload<any>;
 
     if (userConfirmation && Array.isArray(userConfirmation.data) && userConfirmation.data.length) {
+      let tokensToCreate: ResolveTokenValuesResult[] = [];
       track('syncStyles', userConfirmation.data);
+      themes.forEach(theme => {
+        const enabledTokenSets = Object.entries(theme.selectedTokenSets)
+          .filter(([, status]) => status === TokenSetStatus.ENABLED)
+          .map(([tokenSet]) => tokenSet);
+        const resolved = resolveTokenValues(mergeTokenGroups(tokens, theme.selectedTokenSets));
+        console.log('resolve', resolved)
+        const withoutIgnoredAndSourceTokens = resolved.filter((token) => (
+          !token.name.split('.').some((part) => part.startsWith('_')) // filter out ignored tokens
+          && (!token.internal__Parent || enabledTokenSets.includes(token.internal__Parent)) // filter out SOURCE tokens
+        ));
+      
+        const candidateTokens = withoutIgnoredAndSourceTokens.filter((token) => (
+          [
+            token.type === TokenTypes.TYPOGRAPHY,
+            token.type === TokenTypes.COLOR,
+            token.type === TokenTypes.BOX_SHADOW,
+          ].some((isEnabled) => isEnabled)
+        ));
+        console.log('candida', candidateTokens)
+        tokensToCreate = [...tokensToCreate, ...candidateTokens];
+      });
+
       const syncStyleResult = await AsyncMessageChannel.ReactInstance.message({
         type: AsyncMessageTypes.SYNC_STYLES,
-        tokens,
+        tokens: tokensToCreate,
         settings: {
           renameStyle: userConfirmation.data.includes('renameStyles'),
           removeStyle: userConfirmation.data.includes('removeStyles'),

--- a/src/app/store/useTokens.tsx
+++ b/src/app/store/useTokens.tsx
@@ -235,7 +235,7 @@ export default function useTokens() {
 
     if (userConfirmation && Array.isArray(userConfirmation.data) && userConfirmation.data.length) {
       track('syncStyles', userConfirmation.data);
-      await AsyncMessageChannel.ReactInstance.message({
+      const syncStyleResult = await AsyncMessageChannel.ReactInstance.message({
         type: AsyncMessageTypes.SYNC_STYLES,
         tokens,
         settings: {
@@ -243,7 +243,8 @@ export default function useTokens() {
           removeStyle: userConfirmation.data.includes('removeStyles'),
         },
       });
-      // dispatch.tokenState.assignStyleIdsToCurrentTheme(createStylesResult.styleIds);
+      dispatch.tokenState.assignStyleIdsToCurrentTheme(syncStyleResult.styleIdsToCreate);
+      dispatch.tokenState.removeStyleIdsFromThemes(syncStyleResult.styleIdsToRemove);
     }
   }, [confirm, usedTokenSet, tokens, settings, dispatch.tokenState]);
 

--- a/src/plugin/asyncMessageHandlers/index.ts
+++ b/src/plugin/asyncMessageHandlers/index.ts
@@ -8,6 +8,7 @@ export * from './remapTokens';
 export * from './gotoNode';
 export * from './selectNodes';
 export * from './pullStyles';
+export * from './syncStyles';
 export * from './notify';
 export * from './cancelOperation';
 export * from './resizeWindow';

--- a/src/plugin/asyncMessageHandlers/syncStyles.ts
+++ b/src/plugin/asyncMessageHandlers/syncStyles.ts
@@ -1,0 +1,7 @@
+import { AsyncMessageChannelHandlers } from '@/AsyncMessageChannel';
+import { AsyncMessageTypes } from '@/types/AsyncMessages';
+import syncStylesFn from '../syncStyles';
+
+export const syncStyles: AsyncMessageChannelHandlers[AsyncMessageTypes.SYNC_STYLES] = async (msg) => {
+  syncStylesFn(msg.tokens);
+};

--- a/src/plugin/asyncMessageHandlers/syncStyles.ts
+++ b/src/plugin/asyncMessageHandlers/syncStyles.ts
@@ -3,5 +3,18 @@ import { AsyncMessageTypes } from '@/types/AsyncMessages';
 import syncStylesFn from '../syncStyles';
 
 export const syncStyles: AsyncMessageChannelHandlers[AsyncMessageTypes.SYNC_STYLES] = async (msg) => {
-  syncStylesFn(msg.tokens, msg.settings);
+  try {
+    const styleIds = await syncStylesFn(msg.tokens, msg.settings);
+    return {
+      styleIdsToCreate: styleIds.styleIdsToCreate,
+      styleIdsToRemove: styleIds.styleIdsToRemove,
+    };
+  } catch (e) {
+    console.error(e);
+  }
+
+  return {
+    styleIdsToCreate: {},
+    styleIdsToRemove: [],
+  };
 };

--- a/src/plugin/asyncMessageHandlers/syncStyles.ts
+++ b/src/plugin/asyncMessageHandlers/syncStyles.ts
@@ -3,5 +3,5 @@ import { AsyncMessageTypes } from '@/types/AsyncMessages';
 import syncStylesFn from '../syncStyles';
 
 export const syncStyles: AsyncMessageChannelHandlers[AsyncMessageTypes.SYNC_STYLES] = async (msg) => {
-  syncStylesFn(msg.tokens);
+  syncStylesFn(msg.tokens, msg.settings);
 };

--- a/src/plugin/compareStyleWithToken.ts
+++ b/src/plugin/compareStyleWithToken.ts
@@ -1,0 +1,28 @@
+/* eslint-disable no-param-reassign */
+import { TokenTypes } from '@/constants/TokenTypes';
+import {
+  SingleToken, SingleColorToken, AnyTokenList, SingleBoxShadowToken, SingleTypographyToken,
+} from '@/types/tokens';
+import { isPaintEqual } from '@/utils/isPaintEqual';
+import { convertToFigmaColor } from './figmaTransforms/colors';
+import { convertStringToFigmaGradient } from './figmaTransforms/gradients';
+
+export default function compareStyleValueWithTokenValue(style: PaintStyle | EffectStyle | TextStyle, token: SingleColorToken | SingleBoxShadowToken | SingleTypographyToken): boolean {
+  if (style.type === 'PAINT' && token.type === TokenTypes.COLOR) {
+    const { value } = token;
+    const existingPaint = style.paints[0] ?? null;
+    if (value.startsWith('linear-gradient')) {
+      const { gradientStops, gradientTransform } = convertStringToFigmaGradient(value);
+      const newPaint: GradientPaint = {
+        type: 'GRADIENT_LINEAR',
+        gradientTransform,
+        gradientStops,
+      };
+      return isPaintEqual(newPaint, existingPaint);
+    }
+    const { color, opacity } = convertToFigmaColor(value);
+    const newPaint: SolidPaint = { color, opacity, type: 'SOLID' };
+    return isPaintEqual(newPaint, existingPaint);
+  }
+  return false;
+}

--- a/src/plugin/compareStyleWithToken.ts
+++ b/src/plugin/compareStyleWithToken.ts
@@ -10,7 +10,6 @@ export default function compareStyleValueWithTokenValue(
   style: PaintStyle | EffectStyle | TextStyle,
   token: SingleToken<true, { path: string }>,
 ): boolean {
-  console.log('compare', style, token)
   try {
     if (style.type === 'PAINT' && token.type === TokenTypes.COLOR) {
       const { value } = token;
@@ -23,9 +22,9 @@ export default function compareStyleValueWithTokenValue(
     if (style.type === 'EFFECT' && token.type === TokenTypes.BOX_SHADOW) {
       const { value } = token;
       return effectStyleMatchesBoxShadowToken(style, value);
-    }  
+    }
   } catch (e) {
-    console.log('error in compare styles', e)
+    console.log('error in compare styles', e);
   }
   return false;
 }

--- a/src/plugin/compareStyleWithToken.ts
+++ b/src/plugin/compareStyleWithToken.ts
@@ -10,17 +10,22 @@ export default function compareStyleValueWithTokenValue(
   style: PaintStyle | EffectStyle | TextStyle,
   token: SingleToken<true, { path: string }>,
 ): boolean {
-  if (style.type === 'PAINT' && token.type === TokenTypes.COLOR) {
-    const { value } = token;
-    return paintStyleMatchesColorToken(style, value);
-  }
-  if (style.type === 'TEXT' && token.type === TokenTypes.TYPOGRAPHY) {
-    const { value } = token;
-    return textStyleMatchesTypographyToken(style, value);
-  }
-  if (style.type === 'EFFECT' && token.type === TokenTypes.BOX_SHADOW) {
-    const { value } = token;
-    return effectStyleMatchesBoxShadowToken(style, value);
+  console.log('compare', style, token)
+  try {
+    if (style.type === 'PAINT' && token.type === TokenTypes.COLOR) {
+      const { value } = token;
+      return paintStyleMatchesColorToken(style, value);
+    }
+    if (style.type === 'TEXT' && token.type === TokenTypes.TYPOGRAPHY) {
+      const { value } = token;
+      return textStyleMatchesTypographyToken(style, value);
+    }
+    if (style.type === 'EFFECT' && token.type === TokenTypes.BOX_SHADOW) {
+      const { value } = token;
+      return effectStyleMatchesBoxShadowToken(style, value);
+    }  
+  } catch (e) {
+    console.log('error in compare styles', e)
   }
   return false;
 }

--- a/src/plugin/compareStyleWithToken.ts
+++ b/src/plugin/compareStyleWithToken.ts
@@ -1,8 +1,15 @@
 import { TokenTypes } from '@/constants/TokenTypes';
 import { SingleToken } from '@/types/tokens';
-import { effectStyleMatchesBoxShadowToken, paintStyleMatchesColorToken, textStyleMatchesTypographyToken } from './figmaUtils/styleMatchers';
+import {
+  effectStyleMatchesBoxShadowToken,
+  paintStyleMatchesColorToken,
+  textStyleMatchesTypographyToken,
+} from './figmaUtils/styleMatchers';
 
-export default function compareStyleValueWithTokenValue(style: PaintStyle | EffectStyle | TextStyle, token: SingleToken<true, { path: string }>): boolean {
+export default function compareStyleValueWithTokenValue(
+  style: PaintStyle | EffectStyle | TextStyle,
+  token: SingleToken<true, { path: string }>,
+): boolean {
   if (style.type === 'PAINT' && token.type === TokenTypes.COLOR) {
     const { value } = token;
     return paintStyleMatchesColorToken(style, value);

--- a/src/plugin/compareStyleWithToken.ts
+++ b/src/plugin/compareStyleWithToken.ts
@@ -1,28 +1,19 @@
-/* eslint-disable no-param-reassign */
 import { TokenTypes } from '@/constants/TokenTypes';
-import {
-  SingleToken, SingleColorToken, AnyTokenList, SingleBoxShadowToken, SingleTypographyToken,
-} from '@/types/tokens';
-import { isPaintEqual } from '@/utils/isPaintEqual';
-import { convertToFigmaColor } from './figmaTransforms/colors';
-import { convertStringToFigmaGradient } from './figmaTransforms/gradients';
+import { SingleToken } from '@/types/tokens';
+import { effectStyleMatchesBoxShadowToken, paintStyleMatchesColorToken, textStyleMatchesTypographyToken } from './figmaUtils/styleMatchers';
 
-export default function compareStyleValueWithTokenValue(style: PaintStyle | EffectStyle | TextStyle, token: SingleColorToken | SingleBoxShadowToken | SingleTypographyToken): boolean {
+export default function compareStyleValueWithTokenValue(style: PaintStyle | EffectStyle | TextStyle, token: SingleToken<true, { path: string }>): boolean {
   if (style.type === 'PAINT' && token.type === TokenTypes.COLOR) {
     const { value } = token;
-    const existingPaint = style.paints[0] ?? null;
-    if (value.startsWith('linear-gradient')) {
-      const { gradientStops, gradientTransform } = convertStringToFigmaGradient(value);
-      const newPaint: GradientPaint = {
-        type: 'GRADIENT_LINEAR',
-        gradientTransform,
-        gradientStops,
-      };
-      return isPaintEqual(newPaint, existingPaint);
-    }
-    const { color, opacity } = convertToFigmaColor(value);
-    const newPaint: SolidPaint = { color, opacity, type: 'SOLID' };
-    return isPaintEqual(newPaint, existingPaint);
+    return paintStyleMatchesColorToken(style, value);
+  }
+  if (style.type === 'TEXT' && token.type === TokenTypes.TYPOGRAPHY) {
+    const { value } = token;
+    return textStyleMatchesTypographyToken(style, value);
+  }
+  if (style.type === 'EFFECT' && token.type === TokenTypes.BOX_SHADOW) {
+    const { value } = token;
+    return effectStyleMatchesBoxShadowToken(style, value);
   }
   return false;
 }

--- a/src/plugin/controller.ts
+++ b/src/plugin/controller.ts
@@ -22,6 +22,7 @@ AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.BULK_REMAP_TOKENS, a
 AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.GOTO_NODE, asyncHandlers.gotoNode);
 AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.SELECT_NODES, asyncHandlers.selectNodes);
 AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.PULL_STYLES, asyncHandlers.pullStyles);
+AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.SYNC_STYLES, asyncHandlers.syncStyles);
 AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.NOTIFY, asyncHandlers.notify);
 AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.RESIZE_WINDOW, asyncHandlers.resizeWindow);
 AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.CANCEL_OPERATION, asyncHandlers.cancelOperation);

--- a/src/plugin/generateTokensToCreate.ts
+++ b/src/plugin/generateTokensToCreate.ts
@@ -1,0 +1,21 @@
+import { TokenSetStatus } from '@/constants/TokenSetStatus';
+import { TokenTypes } from '@/constants/TokenTypes';
+import { ThemeObject } from '@/types';
+import { AnyTokenList } from '@/types/tokens';
+import { mergeTokenGroups, resolveTokenValues } from './tokenHelpers';
+
+export function generateTokensToCreate(theme: ThemeObject, tokens: Record<string, AnyTokenList>) {
+  const enabledTokenSets = Object.entries(theme.selectedTokenSets)
+    .filter(([, status]) => status === TokenSetStatus.ENABLED)
+    .map(([tokenSet]) => tokenSet);
+  const resolved = resolveTokenValues(mergeTokenGroups(tokens, theme.selectedTokenSets));
+  const withoutIgnoredAndSourceTokens = resolved.filter(
+    (token) => !token.name.split('.').some((part) => part.startsWith('_')) // filter out ignored tokens
+      && (!token.internal__Parent || enabledTokenSets.includes(token.internal__Parent)), // filter out SOURCE tokens
+  );
+
+  const tokensToCreate = withoutIgnoredAndSourceTokens.filter((token) => [token.type === TokenTypes.TYPOGRAPHY, token.type === TokenTypes.COLOR, token.type === TokenTypes.BOX_SHADOW].some(
+    (isEnabled) => isEnabled,
+  ));
+  return tokensToCreate;
+}

--- a/src/plugin/removeStylesFromPlugin.test.ts
+++ b/src/plugin/removeStylesFromPlugin.test.ts
@@ -1,0 +1,61 @@
+import { AsyncMessageChannel } from '@/AsyncMessageChannel';
+import { TokenSetStatus } from '@/constants/TokenSetStatus';
+import { AsyncMessageTypes, GetThemeInfoMessageResult } from '@/types/AsyncMessages';
+import removeStylesFromPlugin from './removeStylesFromPlugin';
+
+describe('removeStylesFromPlugin', () => {
+  const tokenToDelete = {
+    path: 'color.red',
+    parent: 'global',
+  };
+
+  figma.getLocalPaintStyles.mockReturnValue([
+    {
+      name: 'Light/color/red',
+      id: '456',
+      description: 'the red one',
+      paints: [{ type: 'SOLID', color: { r: 1, g: 0, b: 0 }, opacity: 1 }],
+      remove: jest.fn(),
+    },
+    {
+      name: 'Light/color/blue',
+      id: '567',
+      description: 'the blue one',
+      paints: [{ type: 'other', color: { r: 0, g: 0, b: 1 }, opacity: 0.5 }],
+      remove: jest.fn(),
+    },
+    {
+      name: 'Dark/color/red',
+      id: '678',
+      description: 'the red one',
+      paints: [{ type: 'other', color: { r: 0, g: 0, b: 1 }, opacity: 0.5 }],
+      remove: jest.fn(),
+    },
+  ]);
+  figma.getLocalTextStyles.mockReturnValue([]);
+  figma.getLocalEffectStyles.mockReturnValue([]);
+
+  const runAfter: (() => void)[] = [];
+
+  const mockGetThemeInfoHandler = async (): Promise<GetThemeInfoMessageResult> => ({
+    type: AsyncMessageTypes.GET_THEME_INFO,
+    activeTheme: 'light',
+    themes: [{
+      id: 'light',
+      name: 'Light',
+      selectedTokenSets: {
+        global: TokenSetStatus.ENABLED,
+      },
+      $figmaStyleReferences: {},
+    }],
+  });
+
+  runAfter.push(AsyncMessageChannel.ReactInstance.connect());
+  AsyncMessageChannel.ReactInstance.handle(AsyncMessageTypes.GET_THEME_INFO, mockGetThemeInfoHandler);
+
+  runAfter.push(AsyncMessageChannel.PluginInstance.connect());
+
+  it('should remove styles from plugin', async () => {
+    expect(await removeStylesFromPlugin(tokenToDelete)).toEqual(['456']);
+  });
+});

--- a/src/plugin/removeStylesFromPlugin.ts
+++ b/src/plugin/removeStylesFromPlugin.ts
@@ -15,9 +15,11 @@ export default async function removeStylesFromPlugin(token: DeleteTokenPayload) 
     type: AsyncMessageTypes.GET_THEME_INFO,
   });
   const themesToContainToken = themeInfo.themes
-    .filter((theme) => Object.entries(theme.selectedTokenSets).some(
-      ([tokenSet, value]) => tokenSet === token.parent && value === TokenSetStatus.ENABLED,
-    ))
+    .filter((theme) =>
+      Object.entries(theme.selectedTokenSets).some(
+        ([tokenSet, value]) => tokenSet === token.parent && value === TokenSetStatus.ENABLED
+      )
+    )
     .map((filteredTheme) => filteredTheme.name);
   const pathNames = themesToContainToken.map((theme) => convertTokenNameToPath(token.path, theme));
 

--- a/src/plugin/removeStylesFromPlugin.ts
+++ b/src/plugin/removeStylesFromPlugin.ts
@@ -5,9 +5,7 @@ import { DeleteTokenPayload } from '@/types/payloads';
 import { convertTokenNameToPath } from '@/utils/convertTokenNameToPath';
 import { isMatchingStyle } from '@/utils/is/isMatchingStyle';
 
-export default async function removeStylesFromPlugin(
-  token: DeleteTokenPayload,
-) {
+export default async function removeStylesFromPlugin(token: DeleteTokenPayload) {
   const effectStyles = figma.getLocalEffectStyles();
   const paintStyles = figma.getLocalPaintStyles();
   const textStyles = figma.getLocalTextStyles();
@@ -16,10 +14,15 @@ export default async function removeStylesFromPlugin(
   const themeInfo = await AsyncMessageChannel.PluginInstance.message({
     type: AsyncMessageTypes.GET_THEME_INFO,
   });
-  const themesToContainToken = themeInfo.themes.filter((theme) => Object.entries(theme.selectedTokenSets).some(([tokenSet, value]) => tokenSet === token.parent && value === TokenSetStatus.ENABLED)).map((filteredTheme) => filteredTheme.name);
+  const themesToContainToken = themeInfo.themes
+    .filter((theme) => Object.entries(theme.selectedTokenSets).some(
+      ([tokenSet, value]) => tokenSet === token.parent && value === TokenSetStatus.ENABLED,
+    ))
+    .map((filteredTheme) => filteredTheme.name);
   const pathNames = themesToContainToken.map((theme) => convertTokenNameToPath(token.path, theme));
 
-  const allStyleIds = allStyles.filter((style) => pathNames.some((pathName) => isMatchingStyle(pathName, style)))
+  const allStyleIds = allStyles
+    .filter((style) => pathNames.some((pathName) => isMatchingStyle(pathName, style)))
     .map((filteredStyle) => {
       filteredStyle.remove();
       return filteredStyle.id;

--- a/src/plugin/syncStyles.ts
+++ b/src/plugin/syncStyles.ts
@@ -17,13 +17,14 @@ import { transformValue } from './helpers';
 import setColorValuesOnTarget from './setColorValuesOnTarget';
 import setEffectValuesOnTarget from './setEffectValuesOnTarget';
 import setTextValuesOnTarget from './setTextValuesOnTarget';
+import { mergeTokenGroups, resolveTokenValues } from './tokenHelpers';
 import updateStyles from './updateStyles';
 
-export default async function syncStyles(tokens: AnyTokenList, settings: Record<SyncOption, boolean>) {
+export default async function syncStyles(tokens: Record<string, AnyTokenList>, settings: Record<SyncOption, boolean>) {
   const effectStyles = figma.getLocalEffectStyles();
   const paintStyles = figma.getLocalPaintStyles();
   const textStyles = figma.getLocalTextStyles();
-  const allStyles = [...effectStyles, ...paintStyles, ...textStyles];
+  let allStyles = [...effectStyles, ...paintStyles, ...textStyles];
 
   const themeInfo = await AsyncMessageChannel.PluginInstance.message({
     type: AsyncMessageTypes.GET_THEME_INFO,
@@ -31,70 +32,81 @@ export default async function syncStyles(tokens: AnyTokenList, settings: Record<
   const activeThemeObject = themeInfo.activeTheme
     ? themeInfo.themes.find(({ id }) => id === themeInfo.activeTheme)
     : null;
+
   // styleSet store all possible styles which could be created from current tokens
-  console.log('tokens', tokens)
   const styleSet: Record<string, SingleToken<true, { path: string }>> = {};
   themeInfo.themes.forEach((theme) => {
-    Object.entries(theme.selectedTokenSets).forEach(([tokenSet, value]) => {
-      if (value === TokenSetStatus.ENABLED) {
-        tokens.forEach((token) => {
-          if (token.internal__Parent === tokenSet) {
-            const pathName = convertTokenNameToPath(token.name, theme.name);
-            styleSet[pathName] = {
-              ...token,
-              path: pathName,
-              value: typeof token.value === 'string' ? transformValue(token.value, token.type) : token.value,
-            } as SingleToken<true, { path: string }>;
-          }
-        });
-      }
+    const enabledTokenSets = Object.entries(theme.selectedTokenSets)
+      .filter(([, status]) => status === TokenSetStatus.ENABLED)
+      .map(([tokenSet]) => tokenSet);
+    const resolved = resolveTokenValues(mergeTokenGroups(tokens, theme.selectedTokenSets));
+    const withoutIgnoredAndSourceTokens = resolved.filter(
+      (token) => !token.name.split('.').some((part) => part.startsWith('_')) // filter out ignored tokens
+        && (!token.internal__Parent || enabledTokenSets.includes(token.internal__Parent)), // filter out SOURCE tokens
+    );
+
+    const styleTokens = withoutIgnoredAndSourceTokens.filter((token) => [
+      token.type === TokenTypes.TYPOGRAPHY,
+      token.type === TokenTypes.COLOR,
+      token.type === TokenTypes.BOX_SHADOW,
+    ].some((isEnabled) => isEnabled));
+    styleTokens.forEach((token) => {
+      const pathName = convertTokenNameToPath(token.name, theme.name);
+      styleSet[pathName] = {
+        ...token,
+        path: pathName,
+        value: typeof token.value === 'string' ? transformValue(token.value, token.type) : token.value,
+      } as SingleToken<true, { path: string }>;
     });
   });
 
+  // Remove any styles that do not have a token that matches its name
   const styleIdsToRemove: string[] = [];
-  console.log('styleSet', styleSet, 'setting', settings, 'all', allStyles);
-  allStyles.forEach((style) => {
-    console.log('style', style, 'boolea', !Object.keys(styleSet).some((pathName) => isMatchingStyle(pathName, style)));
-
-    if (settings.removeStyle && !Object.keys(styleSet).some((pathName) => isMatchingStyle(pathName, style))) {
-      console.log('style', style);
-      style.remove();
-      styleIdsToRemove.push(style.id);
-    }
-    // console.log('!compareStyleValueWithTokenValue(style, styleSet[style.name])', !compareStyleValueWithTokenValue(style, styleSet[style.name]))
-    // if (!compareStyleValueWithTokenValue(style, styleSet[style.name])) {
-    //   console.log('update')
-    //   if (style.type === 'PAINT' && styleSet[style.name].type === TokenTypes.COLOR) {
-    //     console.log('paint', styleSet[style.name])
-    //     setColorValuesOnTarget(style, styleSet[style.name] as SingleColorToken);
-    //   }
-    //   if (style.type === 'TEXT' && styleSet[style.name].type === TokenTypes.TYPOGRAPHY) {
-    //     console.log('text', styleSet[style.name])
-    //     setTextValuesOnTarget(style, styleSet[style.name] as SingleTypographyToken);
-    //   }
-    //   if (style.type === 'EFFECT' && styleSet[style.name].type === TokenTypes.BOX_SHADOW) {
-    //     console.log('effect', styleSet[style.name])
-    //     setEffectValuesOnTarget(style, styleSet[style.name] as SingleBoxShadowToken);
-    //   }
-    // }
-  });
-  // create styles for renamed tokens
-  const tokenToCreate: SingleToken[] = [];
-  if (settings.renameStyle && activeThemeObject) {
-    Object.entries(activeThemeObject.selectedTokenSets).forEach(([tokenSet, value]) => {
-      if (value === TokenSetStatus.ENABLED) {
-        tokens.forEach((token) => {
-          if (token.internal__Parent === tokenSet) {
-            tokenToCreate.push(token);
-          }
-        });
+  if (settings.removeStyle) {
+    allStyles = allStyles.filter((style) => {
+      if (!Object.keys(styleSet).some((pathName) => isMatchingStyle(pathName, style))) {
+        style.remove();
+        styleIdsToRemove.push(style.id);
+        return false;
       }
+      return true;
     });
   }
-  console.log('token', tokenToCreate);
-  console.log('figmaStyleReferences', activeThemeObject?.$figmaStyleReferences)
-  const styleIdsToCreate = await updateStyles(tokenToCreate, true, { prefixStylesWithThemeName: true });
-  console.log('styleIdsToCreate', styleIdsToCreate);
+
+  // Rename styles that are associated with a token and where the token name is different than the style name
+  let styleIdsToCreate: Record<string, string> = {};
+  if (settings.renameStyle && activeThemeObject) {
+    const enabledTokenSets = Object.entries(activeThemeObject.selectedTokenSets)
+      .filter(([, status]) => status === TokenSetStatus.ENABLED)
+      .map(([tokenSet]) => tokenSet);
+    const resolved = resolveTokenValues(mergeTokenGroups(tokens, activeThemeObject.selectedTokenSets));
+    const withoutIgnoredAndSourceTokens = resolved.filter(
+      (token) => !token.name.split('.').some((part) => part.startsWith('_')) // filter out ignored tokens
+        && (!token.internal__Parent || enabledTokenSets.includes(token.internal__Parent)), // filter out SOURCE tokens
+    );
+
+    const tokensToCreate = withoutIgnoredAndSourceTokens.filter((token) => [
+      token.type === TokenTypes.TYPOGRAPHY,
+      token.type === TokenTypes.COLOR,
+    ].some((isEnabled) => isEnabled));
+    styleIdsToCreate = await updateStyles(tokensToCreate, true, { prefixStylesWithThemeName: true });
+  }
+
+  // Update all different style values
+  allStyles.forEach((style) => {
+    if (!compareStyleValueWithTokenValue(style, styleSet[style.name])) {
+      if (style.type === 'PAINT' && styleSet[style.name].type === TokenTypes.COLOR) {
+        setColorValuesOnTarget(style, styleSet[style.name] as SingleColorToken);
+      }
+      if (style.type === 'TEXT' && styleSet[style.name].type === TokenTypes.TYPOGRAPHY) {
+        setTextValuesOnTarget(style, styleSet[style.name] as SingleTypographyToken);
+      }
+      if (style.type === 'EFFECT' && styleSet[style.name].type === TokenTypes.BOX_SHADOW) {
+        setEffectValuesOnTarget(style, styleSet[style.name] as SingleBoxShadowToken);
+      }
+    }
+  });
+
   return {
     styleIdsToRemove,
     styleIdsToCreate,

--- a/src/plugin/syncStyles.ts
+++ b/src/plugin/syncStyles.ts
@@ -1,0 +1,5 @@
+import { AnyTokenList } from '@/types/tokens';
+
+export default function syncStyles(tokens: Record<string, AnyTokenList>): void {
+
+}

--- a/src/plugin/syncStyles.ts
+++ b/src/plugin/syncStyles.ts
@@ -1,5 +1,45 @@
-import { AnyTokenList } from '@/types/tokens';
+import { AsyncMessageChannel } from '@/AsyncMessageChannel';
+import { TokenSetStatus } from '@/constants/TokenSetStatus';
+import { TokenTypes } from '@/constants/TokenTypes';
+import { AsyncMessageTypes } from '@/types/AsyncMessages';
+import {
+  AnyTokenList, SingleBoxShadowToken, SingleColorToken, SingleTypographyToken,
+} from '@/types/tokens';
+import { convertTokenNameToPath } from '@/utils/convertTokenNameToPath';
+import { isMatchingStyle } from '@/utils/is/isMatchingStyle';
+import compareStyleValueWithTokenValue from './compareStyleWithToken';
+import updateStyles from './updateStyles';
 
-export default function syncStyles(tokens: Record<string, AnyTokenList>): void {
+export default async function syncStyles(tokens: Record<string, AnyTokenList>) {
+  const effectStyles = figma.getLocalEffectStyles();
+  const paintStyles = figma.getLocalPaintStyles();
+  const textStyles = figma.getLocalTextStyles();
+  const allStyles = [...effectStyles, ...paintStyles, ...textStyles];
 
+  const themeInfo = await AsyncMessageChannel.PluginInstance.message({
+    type: AsyncMessageTypes.GET_THEME_INFO,
+  });
+  // styleSet store all possible styles which could be created from current tokens
+  const styleSet: Record<string, SingleColorToken | SingleBoxShadowToken | SingleTypographyToken> = {};
+  themeInfo.themes.forEach((theme) => {
+    Object.entries(theme.selectedTokenSets).forEach(([tokenSet, value]) => {
+      if (value === TokenSetStatus.ENABLED) {
+        tokens[tokenSet].forEach((token) => {
+          if (token.type === TokenTypes.COLOR || token.type === TokenTypes.BOX_SHADOW || token.type === TokenTypes.TYPOGRAPHY) {
+            const pathName = convertTokenNameToPath(token.name, theme.name);
+            styleSet[pathName] = token;
+          }
+        });
+      }
+    });
+  });
+
+  allStyles.forEach((style) => {
+    if (!Object.keys(styleSet).some((pathName) => isMatchingStyle(pathName, style))) {
+      style.remove();
+    }
+    if (!compareStyleValueWithTokenValue(style, styleSet[style.name])) {
+      // updateStyle();
+    }
+  });
 }

--- a/src/plugin/updateStyles.ts
+++ b/src/plugin/updateStyles.ts
@@ -29,12 +29,7 @@ export default async function updateStyles(
       ...token,
       path,
       value: typeof token.value === 'string' ? transformValue(token.value, token.type) : token.value,
-    } as SingleToken<
-    true,
-    {
-      path: string;
-    }
-    >;
+    } as SingleToken< true, { path: string }>;
   });
 
   const colorTokens = styleTokens.filter((n) => [TokenTypes.COLOR].includes(n.type)) as Extract<

--- a/src/plugin/updateStyles.ts
+++ b/src/plugin/updateStyles.ts
@@ -31,6 +31,7 @@ export default async function updateStyles(
       value: typeof token.value === 'string' ? transformValue(token.value, token.type) : token.value,
     } as SingleToken< true, { path: string }>;
   });
+  console.log('styleTokens', styleTokens)
 
   const colorTokens = styleTokens.filter((n) => [TokenTypes.COLOR].includes(n.type)) as Extract<
     typeof styleTokens[number],
@@ -46,6 +47,7 @@ export default async function updateStyles(
   >[];
 
   if (!colorTokens && !textTokens && !effectTokens) return {};
+  console.log('color', colorTokens)
 
   const allStyleIds = {
     ...(colorTokens.length > 0 ? updateColorStyles(colorTokens, shouldCreate) : {}),

--- a/src/plugin/updateStyles.ts
+++ b/src/plugin/updateStyles.ts
@@ -29,9 +29,8 @@ export default async function updateStyles(
       ...token,
       path,
       value: typeof token.value === 'string' ? transformValue(token.value, token.type) : token.value,
-    } as SingleToken< true, { path: string }>;
+    } as SingleToken<true, { path: string }>;
   });
-  console.log('styleTokens', styleTokens)
 
   const colorTokens = styleTokens.filter((n) => [TokenTypes.COLOR].includes(n.type)) as Extract<
     typeof styleTokens[number],
@@ -47,7 +46,6 @@ export default async function updateStyles(
   >[];
 
   if (!colorTokens && !textTokens && !effectTokens) return {};
-  console.log('color', colorTokens)
 
   const allStyleIds = {
     ...(colorTokens.length > 0 ? updateColorStyles(colorTokens, shouldCreate) : {}),

--- a/src/plugin/updateStyles.ts
+++ b/src/plugin/updateStyles.ts
@@ -43,7 +43,7 @@ export default async function updateStyles(
   const colorTokens = styleTokens.filter((n) => [TokenTypes.COLOR].includes(n.type)) as Extract<typeof styleTokens[number], { type: TokenTypes.COLOR }>[];
   const textTokens = styleTokens.filter((n) => [TokenTypes.TYPOGRAPHY].includes(n.type)) as Extract<typeof styleTokens[number], { type: TokenTypes.TYPOGRAPHY }>[];
   const effectTokens = styleTokens.filter((n) => [TokenTypes.BOX_SHADOW].includes(n.type)) as Extract<typeof styleTokens[number], { type: TokenTypes.BOX_SHADOW }>[];
-  console.log('color', colorTokens);
+
   if (!colorTokens && !textTokens && !effectTokens) return {};
 
   const allStyleIds = {

--- a/src/plugin/updateStyles.ts
+++ b/src/plugin/updateStyles.ts
@@ -43,7 +43,7 @@ export default async function updateStyles(
   const colorTokens = styleTokens.filter((n) => [TokenTypes.COLOR].includes(n.type)) as Extract<typeof styleTokens[number], { type: TokenTypes.COLOR }>[];
   const textTokens = styleTokens.filter((n) => [TokenTypes.TYPOGRAPHY].includes(n.type)) as Extract<typeof styleTokens[number], { type: TokenTypes.TYPOGRAPHY }>[];
   const effectTokens = styleTokens.filter((n) => [TokenTypes.BOX_SHADOW].includes(n.type)) as Extract<typeof styleTokens[number], { type: TokenTypes.BOX_SHADOW }>[];
-
+  console.log('color', colorTokens);
   if (!colorTokens && !textTokens && !effectTokens) return {};
 
   const allStyleIds = {

--- a/src/plugin/updateStyles.ts
+++ b/src/plugin/updateStyles.ts
@@ -2,9 +2,7 @@ import { SettingsState } from '@/app/store/models/settings';
 import { AsyncMessageChannel } from '@/AsyncMessageChannel';
 import { TokenTypes } from '@/constants/TokenTypes';
 import { AsyncMessageTypes } from '@/types/AsyncMessages';
-import {
-  AnyTokenList, SingleToken,
-} from '@/types/tokens';
+import { AnyTokenList, SingleToken } from '@/types/tokens';
 import { convertTokenNameToPath } from '@/utils/convertTokenNameToPath';
 import { transformValue } from './helpers';
 import updateColorStyles from './updateColorStyles';
@@ -24,25 +22,33 @@ export default async function updateStyles(
     : null;
 
   const styleTokens = tokens.map((token) => {
-    const prefix = settings.prefixStylesWithThemeName && activeThemeObject
-      ? activeThemeObject.name
-      : null;
+    const prefix = settings.prefixStylesWithThemeName && activeThemeObject ? activeThemeObject.name : null;
     const slice = settings?.ignoreFirstPartForStyles ? 1 : 0;
     const path = convertTokenNameToPath(token.name, prefix, slice);
     return {
       ...token,
       path,
-      value: (typeof token.value === 'string')
-        ? transformValue(token.value, token.type)
-        : token.value,
-    } as SingleToken<true, {
-      path: string
-    }>;
+      value: typeof token.value === 'string' ? transformValue(token.value, token.type) : token.value,
+    } as SingleToken<
+    true,
+    {
+      path: string;
+    }
+    >;
   });
 
-  const colorTokens = styleTokens.filter((n) => [TokenTypes.COLOR].includes(n.type)) as Extract<typeof styleTokens[number], { type: TokenTypes.COLOR }>[];
-  const textTokens = styleTokens.filter((n) => [TokenTypes.TYPOGRAPHY].includes(n.type)) as Extract<typeof styleTokens[number], { type: TokenTypes.TYPOGRAPHY }>[];
-  const effectTokens = styleTokens.filter((n) => [TokenTypes.BOX_SHADOW].includes(n.type)) as Extract<typeof styleTokens[number], { type: TokenTypes.BOX_SHADOW }>[];
+  const colorTokens = styleTokens.filter((n) => [TokenTypes.COLOR].includes(n.type)) as Extract<
+    typeof styleTokens[number],
+  { type: TokenTypes.COLOR }
+  >[];
+  const textTokens = styleTokens.filter((n) => [TokenTypes.TYPOGRAPHY].includes(n.type)) as Extract<
+    typeof styleTokens[number],
+  { type: TokenTypes.TYPOGRAPHY }
+  >[];
+  const effectTokens = styleTokens.filter((n) => [TokenTypes.BOX_SHADOW].includes(n.type)) as Extract<
+    typeof styleTokens[number],
+  { type: TokenTypes.BOX_SHADOW }
+  >[];
 
   if (!colorTokens && !textTokens && !effectTokens) return {};
 

--- a/src/types/AsyncMessages.ts
+++ b/src/types/AsyncMessages.ts
@@ -153,7 +153,7 @@ export type RemoveStylesAsyncMessageResult = AsyncMessage<AsyncMessageTypes.REMO
 }>;
 
 export type SyncStylesAsyncMessage = AsyncMessage<AsyncMessageTypes.SYNC_STYLES, {
-  tokens: AnyTokenList;
+  tokens: Record<string, AnyTokenList>;
   settings: Record<SyncOption, boolean>
 }>;
 export type SyncStylesAsyncMessageResult = AsyncMessage<AsyncMessageTypes.SYNC_STYLES, {

--- a/src/types/AsyncMessages.ts
+++ b/src/types/AsyncMessages.ts
@@ -156,7 +156,10 @@ export type SyncStylesAsyncMessage = AsyncMessage<AsyncMessageTypes.SYNC_STYLES,
   tokens: Record<string, AnyTokenList>;
   settings: Record<SyncOption, boolean>
 }>;
-export type SyncStylesAsyncMessageResult = AsyncMessage<AsyncMessageTypes.SYNC_STYLES>;
+export type SyncStylesAsyncMessageResult = AsyncMessage<AsyncMessageTypes.SYNC_STYLES, {
+  styleIdsToCreate: Record<string, string>;
+  styleIdsToRemove: string[];
+}>;
 
 export type UpdateAsyncMessage = AsyncMessage<AsyncMessageTypes.UPDATE, {
   tokenValues: Record<string, AnyTokenList>;

--- a/src/types/AsyncMessages.ts
+++ b/src/types/AsyncMessages.ts
@@ -153,7 +153,7 @@ export type RemoveStylesAsyncMessageResult = AsyncMessage<AsyncMessageTypes.REMO
 }>;
 
 export type SyncStylesAsyncMessage = AsyncMessage<AsyncMessageTypes.SYNC_STYLES, {
-  tokens: Record<string, AnyTokenList>;
+  tokens: AnyTokenList;
   settings: Record<SyncOption, boolean>
 }>;
 export type SyncStylesAsyncMessageResult = AsyncMessage<AsyncMessageTypes.SYNC_STYLES, {

--- a/src/types/AsyncMessages.ts
+++ b/src/types/AsyncMessages.ts
@@ -19,6 +19,7 @@ export enum AsyncMessageTypes {
   // the below messages are going from UI to plugin
   CREATE_STYLES = 'async/create-styles',
   REMOVE_STYLES = 'async/remove-styles',
+  SYNC_STYLES = 'async/sync-styles',
   CREDENTIALS = 'async/credentials',
   CHANGED_TABS = 'async/changed-tabs',
   REMOVE_SINGLE_CREDENTIAL = 'async/remove-single-credential',
@@ -139,6 +140,11 @@ export type RemoveStylesAsyncMessageResult = AsyncMessage<AsyncMessageTypes.REMO
   styleIds: string[];
 }>;
 
+export type SyncStylesAsyncMessage = AsyncMessage<AsyncMessageTypes.SYNC_STYLES, {
+  tokens: Record<string, AnyTokenList>;
+}>;
+export type SyncStylesAsyncMessageResult = AsyncMessage<AsyncMessageTypes.SYNC_STYLES>;
+
 export type UpdateAsyncMessage = AsyncMessage<AsyncMessageTypes.UPDATE, {
   tokenValues: Record<string, AnyTokenList>;
   tokens: AnyTokenList | null;
@@ -191,6 +197,7 @@ export type StartupMessageResult = AsyncMessage<AsyncMessageTypes.STARTUP>;
 export type AsyncMessages =
   CreateStylesAsyncMessage
   | RemoveStylesAsyncMessage
+  | SyncStylesAsyncMessage
   | CredentialsAsyncMessage
   | ChangedTabsAsyncMessage
   | RemoveSingleCredentialAsyncMessage
@@ -218,6 +225,7 @@ export type AsyncMessages =
 export type AsyncMessageResults =
   CreateStylesAsyncMessageResult
   | RemoveStylesAsyncMessageResult
+  | SyncStylesAsyncMessageResult
   | CredentialsAsyncMessageResult
   | ChangedTabsAsyncMessageResult
   | RemoveSingleCredentialAsyncMessageResult

--- a/src/types/AsyncMessages.ts
+++ b/src/types/AsyncMessages.ts
@@ -14,6 +14,7 @@ import type { SelectionValue } from './SelectionValue';
 import type { startup } from '@/utils/plugin';
 import type { ThemeObject } from './ThemeObject';
 import { DeleteTokenPayload } from './payloads';
+import { SyncOption } from '@/app/store/useTokens';
 
 export enum AsyncMessageTypes {
   // the below messages are going from UI to plugin
@@ -153,6 +154,7 @@ export type RemoveStylesAsyncMessageResult = AsyncMessage<AsyncMessageTypes.REMO
 
 export type SyncStylesAsyncMessage = AsyncMessage<AsyncMessageTypes.SYNC_STYLES, {
   tokens: Record<string, AnyTokenList>;
+  settings: Record<SyncOption, boolean>
 }>;
 export type SyncStylesAsyncMessageResult = AsyncMessage<AsyncMessageTypes.SYNC_STYLES>;
 


### PR DESCRIPTION
- If you check Remove styles without connection option on the modal, then all styles that do not have a token that matches its name
- To rename styles, you have to check Rename styles option on the modal and also have to have activeTheme. If there is no activeTheme, Renaming style function doesn't work.
- In any case, values will be updated.

https://user-images.githubusercontent.com/25951419/193768477-5f48d54d-0f8a-4c61-ade1-817a480247b2.mp4

