### PR TITLE
Changes bulk remap to selection and includes

### DIFF
--- a/src/plugin/asyncMessageHandlers/bulkRemapTokens.ts
+++ b/src/plugin/asyncMessageHandlers/bulkRemapTokens.ts
@@ -1,4 +1,5 @@
 import { AsyncMessageChannelHandlers } from '@/AsyncMessageChannel';
+import { UpdateMode } from '@/constants/UpdateMode';
 import { AsyncMessageTypes } from '@/types/AsyncMessages';
 import { defaultNodeManager, NodeManagerNode } from '../NodeManager';
 import { updatePluginData } from '../pluginData';
@@ -7,13 +8,13 @@ import { sendSelectionChange } from '../sendSelectionChange';
 export const bulkRemapTokens: AsyncMessageChannelHandlers[AsyncMessageTypes.BULK_REMAP_TOKENS] = async (msg) => {
   try {
     const { oldName, newName } = msg;
-    const allWithData = await defaultNodeManager.findNodesWithData({});
+    const allWithData = await defaultNodeManager.findNodesWithData({ updateMode: UpdateMode.SELECTION });
     const updatedNodes: NodeManagerNode[] = [];
 
     allWithData.forEach((node) => {
       const { tokens } = node;
       const updatedTokens = Object.entries(tokens).reduce<Record<string, string>>((acc, [key, val]) => {
-        if (val.startsWith(oldName)) {
+        if (val.includes(oldName)) {
           acc[key] = val.replace(oldName, newName);
         } else {
           acc[key] = val;


### PR DESCRIPTION
This PR changes bulk remap to no longer scan the currently selected updateMode but instead always takes selection (because that's what should happen in Inspect)

Also changes implementation so the `match` doesn't just have to startWith the word, but can be anywhere.