### PR TITLE
Improve error setting font weight/family

### DIFF
--- a/src/app/components/Initiator.tsx
+++ b/src/app/components/Initiator.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react';
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { MessageFromPluginTypes, PostToUIMessage } from '@/types/messages';
@@ -72,6 +73,10 @@ export function Initiator() {
               if (existTokens) dispatch.uiState.setActiveTab(Tabs.TOKENS);
               else dispatch.uiState.setActiveTab(Tabs.START);
             }
+            break;
+          }
+          case MessageFromPluginTypes.NOTIFY_EXCEPTION: {
+            Sentry.captureException({ error: pluginMessage.error, ...pluginMessage.opts });
             break;
           }
           case MessageFromPluginTypes.API_PROVIDERS: {

--- a/src/plugin/__tests__/notifiers.test.ts
+++ b/src/plugin/__tests__/notifiers.test.ts
@@ -47,7 +47,7 @@ describe('notifySetTokens', () => {
 
 describe('notifyException', () => {
   it('should work', () => {
-    notifyException({ error: 'does not work', opts: { foo: 'bar' } });
+    notifyException('does not work', { foo: 'bar' });
     expect(mockUiPostMessage).toBeCalledTimes(1);
     expect(mockUiPostMessage).toBeCalledWith({
       type: MessageFromPluginTypes.NOTIFY_EXCEPTION,

--- a/src/plugin/__tests__/notifiers.test.ts
+++ b/src/plugin/__tests__/notifiers.test.ts
@@ -2,7 +2,7 @@ import { StorageProviderType } from '@/constants/StorageProviderType';
 import { MessageFromPluginTypes } from '@/types/messages';
 import { TokenStore } from '@/types/tokens';
 import { mockUiPostMessage } from '../../../tests/__mocks__/figmaMock';
-import { notifySelection, notifySetTokens } from '../notifiers';
+import { notifyException, notifySelection, notifySetTokens } from '../notifiers';
 
 describe('notifySelection', () => {
   it('should work', () => {
@@ -41,6 +41,18 @@ describe('notifySetTokens', () => {
     expect(mockUiPostMessage).toBeCalledWith({
       type: MessageFromPluginTypes.SET_TOKENS,
       values: mockStoreValues,
+    });
+  });
+});
+
+describe('notifyException', () => {
+  it('should work', () => {
+    notifyException({ error: 'does not work', opts: { foo: 'bar' } });
+    expect(mockUiPostMessage).toBeCalledTimes(1);
+    expect(mockUiPostMessage).toBeCalledWith({
+      type: MessageFromPluginTypes.NOTIFY_EXCEPTION,
+      error: 'does not work',
+      opts: { foo: 'bar' },
     });
   });
 });

--- a/src/plugin/notifiers.ts
+++ b/src/plugin/notifiers.ts
@@ -110,3 +110,11 @@ export function notifyStyleValues(values: Record<string, AnyTokenList>) {
 export function notifySetTokens(values: TokenStore) {
   postToUI({ type: MessageFromPluginTypes.SET_TOKENS, values });
 }
+
+export function notifyException(error: string, opts = {}) {
+  postToUI({
+    type: MessageFromPluginTypes.NOTIFY_EXCEPTION,
+    error,
+    opts,
+  });
+}

--- a/src/plugin/setTextValuesOnTarget.ts
+++ b/src/plugin/setTextValuesOnTarget.ts
@@ -1,8 +1,7 @@
 /* eslint-disable no-param-reassign */
-import * as Sentry from '@sentry/react';
 import { SingleTypographyToken } from '@/types/tokens';
 import { transformValue } from './helpers';
-import { notifyUI } from './notifiers';
+import { notifyException, notifyUI } from './notifiers';
 
 export default async function setTextValuesOnTarget(
   target: TextNode | TextStyle,
@@ -69,7 +68,7 @@ export default async function setTextValuesOnTarget(
             })
             .catch(() => {
               notifyUI(`Error setting font family/weight combination for ${family}/${style}`, { error: true });
-              Sentry.captureException({ error: 'Font not found', family, style });
+              notifyException('Font not found', { family, style });
             });
           if (isApplied) break;
         }

--- a/src/plugin/setTextValuesOnTarget.ts
+++ b/src/plugin/setTextValuesOnTarget.ts
@@ -68,8 +68,8 @@ export default async function setTextValuesOnTarget(
               }
             })
             .catch(() => {
-              notifyUI('Error setting font, font family/weight combination not found', { error: true });
-              Sentry.captureException({ error: 'Font not found', fontFamily, fontWeight });
+              notifyUI(`Error setting font family/weight combination for ${family}/${style}`, { error: true });
+              Sentry.captureException({ error: 'Font not found', family, style });
             });
           if (isApplied) break;
         }

--- a/src/plugin/setTextValuesOnTarget.ts
+++ b/src/plugin/setTextValuesOnTarget.ts
@@ -1,6 +1,8 @@
 /* eslint-disable no-param-reassign */
+import * as Sentry from '@sentry/react';
 import { SingleTypographyToken } from '@/types/tokens';
 import { transformValue } from './helpers';
+import { notifyUI } from './notifiers';
 
 export default async function setTextValuesOnTarget(
   target: TextNode | TextStyle,
@@ -66,7 +68,8 @@ export default async function setTextValuesOnTarget(
               }
             })
             .catch(() => {
-              // TODO: Track this in mixpanel so we can add missing weights
+              notifyUI('Error setting font, font family/weight combination not found', { error: true });
+              Sentry.captureException({ error: 'Font not found', fontFamily, fontWeight });
             });
           if (isApplied) break;
         }

--- a/src/types/messages.tsx
+++ b/src/types/messages.tsx
@@ -18,6 +18,7 @@ export enum MessageFromPluginTypes {
   ADD_JOB_TASKS = 'add_job_tasks',
   COMPLETE_JOB_TASKS = 'complete_job_tasks',
   SET_TOKENS = 'set_tokens',
+  NOTIFY_EXCEPTION = 'notify_exception',
 }
 
 export type NoSelectionFromPluginMessage = { type: MessageFromPluginTypes.NO_SELECTION };
@@ -86,6 +87,12 @@ export type SetTokensFromPluginMessage = {
   values: TokenStore;
 };
 
+export type NotifyExceptionFromPluginMessage = {
+  type: MessageFromPluginTypes.NOTIFY_EXCEPTION;
+  error: string;
+  opts?: Record<string, unknown>;
+};
+
 export type PostToUIMessage =
   | NoSelectionFromPluginMessage
   | SelectionFromPluginMessage
@@ -98,4 +105,5 @@ export type PostToUIMessage =
   | ClearJobsFromPluginMessage
   | AddJobTasksFromPluginMessage
   | CompleteJobTasksFromPluginMessage
-  | SetTokensFromPluginMessage;
+  | SetTokensFromPluginMessage
+  | NotifyExceptionFromPluginMessage;


### PR DESCRIPTION
Fixes https://github.com/six7/figma-tokens/issues/1396

Shows a more prominent error when font weight/family combination can't be applied.

Also adds error tracking so we're aware of which combinations don't work.

<img width="743" alt="CleanShot 2022-11-03 at 22 21 50@2x" src="https://user-images.githubusercontent.com/4548309/199836726-36b127c3-78cf-4702-9ce4-96446ba13d1c.png">
