### PR TITLE
fix credentials start message

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "figma-tokens",
   "version": "1.0.0",
-  "plugin_version": "126",
+  "plugin_version": "127",
   "description": "Figma Tokens",
   "license": "MIT",
   "scripts": {

--- a/script/release.sh
+++ b/script/release.sh
@@ -1,4 +1,4 @@
-VERSION=figma-tokens@126
+VERSION=figma-tokens@127
 sentry-cli releases -p figma-tokens files "$VERSION" upload-sourcemaps --ext ts --ext tsx --ext map --ext js --ignore-file .sentryignore .
 sentry-cli releases set-commits "$VERSION" --auto
 sentry-cli releases finalize "$VERSION"

--- a/src/app/components/AppContainer/__tests__/AppContainerIntegration.test.tsx
+++ b/src/app/components/AppContainer/__tests__/AppContainerIntegration.test.tsx
@@ -396,9 +396,8 @@ describe('AppContainer (integration)', () => {
           <AppContainer {...params} />
         </Provider>,
       );
-
-      await result.findByText('Remote storage detected');
-      expect(result.queryByText('Remote storage detected')).toBeInTheDocument();
+      await result.findByText("Couldn't load tokens stored on GitHub");
+      expect(result.queryByText("Couldn't load tokens stored on GitHub")).toBeInTheDocument();
     });
   }));
 });

--- a/src/app/components/AppContainer/startupProcessSteps/__tests__/pullTokensFactory.test.ts
+++ b/src/app/components/AppContainer/startupProcessSteps/__tests__/pullTokensFactory.test.ts
@@ -152,7 +152,7 @@ describe('pullTokensFactory', () => {
     expect(state.uiState.activeTab).toEqual(Tabs.TOKENS);
   });
 
-  it('should pull remote tokens and go to START tab if there are no tokens in the remote storage', async () => {
+  it('should pull remote tokens and go to Tokens tab if there are no tokens in the remote storage', async () => {
     const mockStore = createMockStore({
       uiState: {
         storageType: mockStorageType,
@@ -193,7 +193,7 @@ describe('pullTokensFactory', () => {
     expect(state.uiState.api).toEqual({ ...mockStorageType, secret: 'secret' });
     expect(state.uiState.localApiState).toEqual({ ...mockStorageType, secret: 'secret' });
     expect(mockPullTokens).toBeCalledTimes(1);
-    expect(state.uiState.activeTab).toEqual(Tabs.START);
+    expect(state.uiState.activeTab).toEqual(Tabs.TOKENS);
   });
 
   it('should verify the API credentials without pulling if there are local changes', async () => {

--- a/src/app/components/AppContainer/startupProcessSteps/__tests__/pullTokensFactory.test.ts
+++ b/src/app/components/AppContainer/startupProcessSteps/__tests__/pullTokensFactory.test.ts
@@ -196,6 +196,45 @@ describe('pullTokensFactory', () => {
     expect(state.uiState.activeTab).toEqual(Tabs.TOKENS);
   });
 
+  it('should go to Start if the file on the remote cannot be read', async () => {
+    const mockStore = createMockStore({
+      uiState: {
+        storageType: mockStorageType,
+      },
+    });
+
+    const mockParams = {
+      localTokenData: {
+        checkForChanges: false,
+        values: {
+        },
+      },
+      localApiProviders: [
+        { ...mockStorageType, secret: 'secret' },
+      ],
+    } as unknown as StartupMessage;
+
+    const fn = pullTokensFactory(
+      mockStore,
+      mockStore.dispatch,
+      {},
+      mockParams,
+      mockUseConfirm,
+      mockUseRemoteTokens,
+    );
+
+    mockFetchBranches.mockResolvedValueOnce(['main']);
+    mockPullTokens.mockResolvedValueOnce(null);
+
+    await fn();
+    const state = mockStore.getState();
+    expect(state.branchState.branches).toEqual(['main']);
+    expect(state.uiState.api).toEqual({ ...mockStorageType, secret: 'secret' });
+    expect(state.uiState.localApiState).toEqual({ ...mockStorageType, secret: 'secret' });
+    expect(mockPullTokens).toBeCalledTimes(1);
+    expect(state.uiState.activeTab).toEqual(Tabs.START);
+  });
+
   it('should verify the API credentials without pulling if there are local changes', async () => {
     const mockStore = createMockStore({
       uiState: {

--- a/src/app/components/AppContainer/startupProcessSteps/pullTokensFactory.ts
+++ b/src/app/components/AppContainer/startupProcessSteps/pullTokensFactory.ts
@@ -77,16 +77,20 @@ export function pullTokensFactory(
               activeTheme: params.activeTheme,
               usedTokenSet: params.localTokenData?.usedTokenSet,
             });
+            // If there's no data stored on the remote, show a message - e.g. file doesn't exist.
+            if (!remoteData) {
+              notifyToUI('Failed to fetch tokens from remote storage', { error: true });
+              dispatch.uiState.setActiveTab(Tabs.START);
+              return;
+            }
+
             if (remoteData?.status === 'failure') {
+              // If we have some error reading tokens, we let the user know - e.g. schema validation doesn't pass.
               notifyToUI(remoteData.errorMessage, { error: true });
               dispatch.uiState.setActiveTab(Tabs.START);
             } else {
-              const existTokens = hasTokenValues(remoteData?.tokens ?? {});
-              if (existTokens) {
-                dispatch.uiState.setActiveTab(Tabs.TOKENS);
-              } else {
-                dispatch.uiState.setActiveTab(Tabs.START);
-              }
+              // If we succeeded we can move on to show the tokens screen
+              dispatch.uiState.setActiveTab(Tabs.TOKENS);
             }
           } else {
             dispatch.uiState.setActiveTab(Tabs.TOKENS);

--- a/src/app/components/DownshiftInput/DownshiftInput.tsx
+++ b/src/app/components/DownshiftInput/DownshiftInput.tsx
@@ -122,7 +122,7 @@ export const DownshiftInput: React.FunctionComponent<DownShiftProps> = ({
   ]); // removing non-alphanumberic except . from the input value
   const getHighlightedText = useCallback((text: string, highlight: string) => {
     // Split on highlight term and include term into parts, ignore case
-    const parts = text.split(new RegExp(`(${highlight})`, 'gi'));
+    const parts = text.split(new RegExp(`(${highlight.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')})`, 'gi'));
     return (
       <span>
         {parts.map((part, i) => (

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -29,6 +29,7 @@ import { isGitProvider } from '@/utils/is';
 import IconLibrary from '@/icons/library.svg';
 import ProBadge from './ProBadge';
 import { compareLastSyncedState } from '@/utils/compareLastSyncedState';
+import { transformProviderName } from '@/utils/transformProviderName';
 
 export default function Footer() {
   const storageType = useSelector(storageTypeSelector);
@@ -58,25 +59,6 @@ export default function Footer() {
   }, [lastSyncedState, storageType, tokens, themes, dispatch.tokenState]);
 
   const hasChanges = React.useMemo(() => checkForChanges(), [checkForChanges]);
-
-  const transformProviderName = React.useCallback((provider: StorageProviderType) => {
-    switch (provider) {
-      case StorageProviderType.JSONBIN:
-        return 'JSONBin.io';
-      case StorageProviderType.GITHUB:
-        return 'GitHub';
-      case StorageProviderType.GITLAB:
-        return 'GitLab';
-      case StorageProviderType.BITBUCKET:
-        return 'Bitbucket';
-      case StorageProviderType.ADO:
-        return 'ADO';
-      case StorageProviderType.URL:
-        return 'URL';
-      default:
-        return provider;
-    }
-  }, []);
 
   const onPushButtonClicked = React.useCallback(() => pushTokens(), [pushTokens]);
   const onPullButtonClicked = React.useCallback(() => pullTokens({ usedTokenSet, activeTheme }), [pullTokens, usedTokenSet, activeTheme]);

--- a/src/app/components/StartScreen.tsx
+++ b/src/app/components/StartScreen.tsx
@@ -56,9 +56,8 @@ function StartScreen() {
       return;
     }
     const matchingProvider = apiProviders.find((i) => i.internalId === storageType?.internalId);
-    const credentialsToSet = { ...matchingProvider, provider: storageType.provider, new: true } || {
+    const credentialsToSet = matchingProvider ? { ...matchingProvider, provider: storageType.provider, new: true } : {
       ...storageType,
-      provider: storageType.provider,
       new: true,
     };
     dispatch.uiState.setActiveTab(Tabs.SETTINGS);

--- a/src/app/components/StartScreen.tsx
+++ b/src/app/components/StartScreen.tsx
@@ -10,12 +10,13 @@ import Text from './Text';
 import Button from './Button';
 import Callout from './Callout';
 import { Dispatch } from '../store';
-import { storageTypeSelector } from '@/selectors';
+import { apiProvidersSelector, storageTypeSelector } from '@/selectors';
 import Stack from './Stack';
 import { styled } from '@/stitches.config';
 import { Tabs } from '@/constants/Tabs';
 import { StorageProviderType } from '@/constants/StorageProviderType';
 import Box from './Box';
+import { transformProviderName } from '@/utils/transformProviderName';
 
 const StyledFigmaTokensLogo = styled(FigmaLetter, {
   width: '90px',
@@ -43,6 +44,7 @@ function StartScreen() {
   const dispatch = useDispatch<Dispatch>();
 
   const storageType = useSelector(storageTypeSelector);
+  const apiProviders = useSelector(apiProvidersSelector);
 
   const onSetDefaultTokens = React.useCallback(() => {
     dispatch.uiState.setActiveTab(Tabs.TOKENS);
@@ -50,14 +52,19 @@ function StartScreen() {
   }, [dispatch]);
 
   const onSetSyncClick = React.useCallback(() => {
-    dispatch.uiState.setActiveTab(Tabs.SETTINGS);
-    dispatch.tokenState.setEmptyTokens();
-    dispatch.uiState.setLocalApiState({
+    if (storageType.provider === StorageProviderType.LOCAL) {
+      return;
+    }
+    const matchingProvider = apiProviders.find((i) => i.internalId === storageType?.internalId);
+    const credentialsToSet = { ...matchingProvider, provider: storageType.provider, new: true } || {
       ...storageType,
       provider: storageType.provider,
       new: true,
-    });
-  }, [dispatch, storageType]);
+    };
+    dispatch.uiState.setActiveTab(Tabs.SETTINGS);
+    dispatch.tokenState.setEmptyTokens();
+    dispatch.uiState.setLocalApiState(credentialsToSet);
+  }, [apiProviders, dispatch.tokenState, dispatch.uiState, storageType]);
 
   return (
     <Box className="content scroll-container" css={{ padding: '$5', height: '100%', display: 'flex' }}>
@@ -96,8 +103,8 @@ function StartScreen() {
         {storageType?.provider !== StorageProviderType.LOCAL ? (
           <Callout
             id="callout-action-setupsync"
-            heading="Remote storage detected"
-            description="This document was setup with a remote storage. Ask your team for the credentials, then enter them in the Sync dialog."
+            heading={`Couldn't fetch tokens stored on ${transformProviderName(storageType?.provider)}`}
+            description="Unable to fetch tokens, if you haven't added credentials yet add them in the next step. Otherwise make sure the file exists and you have access to it."
             action={{
               onClick: onSetSyncClick,
               text: 'Enter credentials',

--- a/src/app/components/StartScreen.tsx
+++ b/src/app/components/StartScreen.tsx
@@ -103,8 +103,8 @@ function StartScreen() {
         {storageType?.provider !== StorageProviderType.LOCAL ? (
           <Callout
             id="callout-action-setupsync"
-            heading={`Couldn't fetch tokens stored on ${transformProviderName(storageType?.provider)}`}
-            description="Unable to fetch tokens, if you haven't added credentials yet add them in the next step. Otherwise make sure the file exists and you have access to it."
+            heading={`Couldn't load tokens stored on ${transformProviderName(storageType?.provider)}`}
+            description="Unable to fetch tokens from remote storage, if you haven't added credentials yet add them in the next step. Otherwise make sure the file exists and you have access to it."
             action={{
               onClick: onSetSyncClick,
               text: 'Enter credentials',

--- a/src/app/components/StorageItemForm/ADOForm.tsx
+++ b/src/app/components/StorageItemForm/ADOForm.tsx
@@ -83,7 +83,7 @@ export default function ADOForm({
         />
         <Input
           full
-          label="Default Branch"
+          label="Branch"
           value={values.branch}
           onChange={onChange}
           type="text"
@@ -92,7 +92,7 @@ export default function ADOForm({
         />
         <Input
           full
-          label="File Path (e.g. data/tokens.json)"
+          label="File Path (e.g. tokens.json) or Folder Path (e.g. tokens)"
           defaultValue=""
           value={values.filePath}
           onChange={onChange}

--- a/src/app/components/StorageItemForm/BitbucketForm.tsx
+++ b/src/app/components/StorageItemForm/BitbucketForm.tsx
@@ -77,7 +77,7 @@ export default function BitbucketForm({
         />
         <Input
           full
-          label="Default Branch"
+          label="Branch"
           value={values.branch}
           onChange={onChange}
           type="text"
@@ -86,7 +86,7 @@ export default function BitbucketForm({
         />
         <Input
           full
-          label="File Path (e.g. data/tokens.json)"
+          label="File Path (e.g. tokens.json) or Folder Path (e.g. tokens)"
           value={values.filePath}
           onChange={onChange}
           type="text"

--- a/src/app/components/StorageItemForm/GitForm.tsx
+++ b/src/app/components/StorageItemForm/GitForm.tsx
@@ -76,7 +76,7 @@ export default function GitForm({
         />
         <Input
           full
-          label="Default Branch"
+          label="Branch"
           value={values.branch}
           onChange={onChange}
           type="text"
@@ -85,7 +85,7 @@ export default function GitForm({
         />
         <Input
           full
-          label="File Path (e.g. data/tokens.json)"
+          label="File Path (e.g. tokens.json) or Folder Path (e.g. tokens)"
           defaultValue=""
           value={values.filePath}
           onChange={onChange}

--- a/src/app/components/StorageItemForm/GitForm.tsx
+++ b/src/app/components/StorageItemForm/GitForm.tsx
@@ -67,7 +67,7 @@ export default function GitForm({
         </Box>
         <Input
           full
-          label="Repository (username/repo)"
+          label="Repository (owner/repo)"
           value={values.id}
           onChange={onChange}
           type="text"

--- a/src/app/components/SyncSettings.test.tsx
+++ b/src/app/components/SyncSettings.test.tsx
@@ -124,7 +124,7 @@ describe('ConfirmDialog', () => {
       result.queryByText('Edit')?.click();
     });
 
-    expect(result.queryByText('Edit storage item')).toBeInTheDocument();
+    expect(result.queryByText('Edit credentials')).toBeInTheDocument();
   });
 
   it('should return CreateStorageItemModal when create new remote storage', async () => {
@@ -141,9 +141,9 @@ describe('ConfirmDialog', () => {
 
     expect(result.queryAllByText('Add new credentials')).toHaveLength(2);
     expect(result.queryByText('Personal Access Token')).toBeInTheDocument();
-    expect(result.queryByText('Repository (username/repo)')).toBeInTheDocument();
-    expect(result.queryByText('Default Branch')).toBeInTheDocument();
-    expect(result.queryByText('File Path (e.g. data/tokens.json)')).toBeInTheDocument();
+    expect(result.queryByText('Repository (owner/repo)')).toBeInTheDocument();
+    expect(result.queryByText('Branch')).toBeInTheDocument();
+    expect(result.queryByText('File Path (e.g. tokens.json) or Folder Path (e.g. tokens)')).toBeInTheDocument();
     expect(result.queryByText('baseUrl (optional)')).toBeInTheDocument();
     expect(result.queryByText('Save')).toBeInTheDocument();
   });

--- a/src/app/components/modals/EditStorageItemModal.tsx
+++ b/src/app/components/modals/EditStorageItemModal.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import Modal from '../Modal';
-import Heading from '../Heading';
 import StorageItemForm from '../StorageItemForm';
 import useRemoteTokens from '../../store/remoteTokens';
 import Stack from '../Stack';
@@ -36,9 +35,8 @@ export default function EditStorageItemModal({
   }, [addNewProviderItem, onSuccess]);
 
   return (
-    <Modal large id="modal-edit-storage-item" isOpen={isOpen} close={onClose}>
+    <Modal title="Edit credentials" large id="modal-edit-storage-item" isOpen={isOpen} close={onClose}>
       <Stack direction="column" gap={4}>
-        <Heading>Edit storage item</Heading>
         <StorageItemForm
           onChange={handleChange}
           onSubmit={handleSubmit}

--- a/src/utils/alias/getAliasValue.ts
+++ b/src/utils/alias/getAliasValue.ts
@@ -58,37 +58,37 @@ export function getAliasValue(token: SingleToken | string | number, tokens: Sing
             return isSingleTokenValueObject(token) ? token.value.toString() : token.toString();
           }
 
-          const tokenAliasSplited = nameToLookFor.split('.');
-          const tokenAliasSplitedLast: TokenNameNodeType = tokenAliasSplited.pop();
-          const tokenAliasLastExcluded = tokenAliasSplited.join('.');
-          const tokenAliasSplitedLastPrevious: number = Number(tokenAliasSplited.pop());
-          const tokenAliasLastPreviousExcluded = tokenAliasSplited.join('.');
+          const tokenAliasSplitted = nameToLookFor.split('.');
+          const tokenAliasSplittedLast: TokenNameNodeType = tokenAliasSplitted.pop();
+          const tokenAliasLastExcluded = tokenAliasSplitted.join('.');
+          const tokenAliasSplittedLastPrevious: number = Number(tokenAliasSplitted.pop());
+          const tokenAliasLastPreviousExcluded = tokenAliasSplitted.join('.');
           const foundToken = tokens.find((t) => t.name === nameToLookFor || t.name === tokenAliasLastExcluded || t.name === tokenAliasLastPreviousExcluded);
 
           if (foundToken?.name === nameToLookFor) { return getAliasValue(foundToken, tokens); }
 
           if (
-            !!tokenAliasSplitedLast
+            !!tokenAliasSplittedLast
             && foundToken?.name === tokenAliasLastExcluded
-            && foundToken.rawValue?.hasOwnProperty(tokenAliasSplitedLast)
+            && foundToken.rawValue?.hasOwnProperty(tokenAliasSplittedLast)
           ) {
             const { rawValue } = foundToken;
             if (typeof rawValue === 'object' && !Array.isArray(rawValue)) {
-              const value = rawValue[tokenAliasSplitedLast as keyof typeof rawValue] as string | number;
+              const value = rawValue[tokenAliasSplittedLast as keyof typeof rawValue] as string | number;
               return getAliasValue(value, tokens);
             }
           }
 
           if (
-            tokenAliasSplitedLastPrevious !== undefined
-            && !!tokenAliasSplitedLast
+            tokenAliasSplittedLastPrevious !== undefined
+            && !!tokenAliasSplittedLast
             && foundToken?.name === tokenAliasLastPreviousExcluded
             && Array.isArray(foundToken?.rawValue)
-            && !!foundToken?.rawValue[tokenAliasSplitedLastPrevious]
-            && foundToken?.rawValue[tokenAliasSplitedLastPrevious].hasOwnProperty(tokenAliasSplitedLast)
+            && !!foundToken?.rawValue[tokenAliasSplittedLastPrevious]
+            && foundToken?.rawValue[tokenAliasSplittedLastPrevious].hasOwnProperty(tokenAliasSplittedLast)
           ) {
-            const rawValueEntry = foundToken?.rawValue[tokenAliasSplitedLastPrevious];
-            return getAliasValue(rawValueEntry[tokenAliasSplitedLast as keyof typeof rawValueEntry] || tokenAliasSplitedLastPrevious, tokens);
+            const rawValueEntry = foundToken?.rawValue[tokenAliasSplittedLastPrevious];
+            return getAliasValue(rawValueEntry[tokenAliasSplittedLast as keyof typeof rawValueEntry] || tokenAliasSplittedLastPrevious, tokens);
           }
         }
         return ref;

--- a/src/utils/transformProviderName.tsx
+++ b/src/utils/transformProviderName.tsx
@@ -1,0 +1,20 @@
+import { StorageProviderType } from '@/constants/StorageProviderType';
+
+export const transformProviderName = (provider: StorageProviderType) => {
+  switch (provider) {
+    case StorageProviderType.JSONBIN:
+      return 'JSONBin.io';
+    case StorageProviderType.GITHUB:
+      return 'GitHub';
+    case StorageProviderType.GITLAB:
+      return 'GitLab';
+    case StorageProviderType.BITBUCKET:
+      return 'Bitbucket';
+    case StorageProviderType.ADO:
+      return 'ADO';
+    case StorageProviderType.URL:
+      return 'URL';
+    default:
+      return provider;
+  }
+};


### PR DESCRIPTION
Fixes an edge case bug where users who had an empty tokens file were shown the `Enter credentials` message.

Also cleans up some of the UI copy to make it a bit clearer what's going on.