### PR TITLE
Autofocus improvements

### DIFF
--- a/src/app/components/ApplySelector.tsx
+++ b/src/app/components/ApplySelector.tsx
@@ -13,16 +13,14 @@ import {
 } from './DropdownMenu';
 import { Dispatch } from '../store';
 import IconChevronDown from '@/icons/chevrondown.svg';
-import { settingsStateSelector, storageTypeSelector } from '@/selectors';
+import { settingsStateSelector } from '@/selectors';
 import { isEqual } from '@/utils/isEqual';
-import { StorageProviderType } from '@/constants/StorageProviderType';
 import { UpdateMode } from '@/constants/UpdateMode';
 
 export default function ApplySelector() {
   const {
     updateMode, updateRemote, updateOnChange, updateStyles,
   } = useSelector(settingsStateSelector, isEqual);
-  const storageType = useSelector(storageTypeSelector);
 
   const {
     setUpdateMode, setUpdateOnChange, setUpdateRemote, setUpdateStyles,
@@ -93,14 +91,12 @@ export default function ApplySelector() {
           </DropdownMenuItemIndicator>
           Update on change
         </DropdownMenuCheckboxItem>
-        {storageType.provider === StorageProviderType.JSONBIN && (
-          <DropdownMenuCheckboxItem checked={updateRemote} onCheckedChange={handleUpdateRemote}>
-            <DropdownMenuItemIndicator>
-              <CheckIcon />
-            </DropdownMenuItemIndicator>
-            Update remote
-          </DropdownMenuCheckboxItem>
-        )}
+        <DropdownMenuCheckboxItem checked={updateRemote} onCheckedChange={handleUpdateRemote}>
+          <DropdownMenuItemIndicator>
+            <CheckIcon />
+          </DropdownMenuItemIndicator>
+          Update remote
+        </DropdownMenuCheckboxItem>
         <DropdownMenuCheckboxItem checked={updateStyles} onCheckedChange={handleUpdateStyles}>
           <DropdownMenuItemIndicator>
             <CheckIcon />

--- a/src/app/components/ApplySelector.tsx
+++ b/src/app/components/ApplySelector.tsx
@@ -13,14 +13,16 @@ import {
 } from './DropdownMenu';
 import { Dispatch } from '../store';
 import IconChevronDown from '@/icons/chevrondown.svg';
-import { settingsStateSelector } from '@/selectors';
+import { settingsStateSelector, storageTypeSelector } from '@/selectors';
 import { isEqual } from '@/utils/isEqual';
+import { StorageProviderType } from '@/constants/StorageProviderType';
 import { UpdateMode } from '@/constants/UpdateMode';
 
 export default function ApplySelector() {
   const {
     updateMode, updateRemote, updateOnChange, updateStyles,
   } = useSelector(settingsStateSelector, isEqual);
+  const storageType = useSelector(storageTypeSelector);
 
   const {
     setUpdateMode, setUpdateOnChange, setUpdateRemote, setUpdateStyles,
@@ -91,12 +93,14 @@ export default function ApplySelector() {
           </DropdownMenuItemIndicator>
           Update on change
         </DropdownMenuCheckboxItem>
-        <DropdownMenuCheckboxItem checked={updateRemote} onCheckedChange={handleUpdateRemote}>
-          <DropdownMenuItemIndicator>
-            <CheckIcon />
-          </DropdownMenuItemIndicator>
-          Update remote
-        </DropdownMenuCheckboxItem>
+        {storageType.provider === StorageProviderType.JSONBIN && (
+          <DropdownMenuCheckboxItem checked={updateRemote} onCheckedChange={handleUpdateRemote}>
+            <DropdownMenuItemIndicator>
+              <CheckIcon />
+            </DropdownMenuItemIndicator>
+            Update remote
+          </DropdownMenuCheckboxItem>
+        )}
         <DropdownMenuCheckboxItem checked={updateStyles} onCheckedChange={handleUpdateStyles}>
           <DropdownMenuItemIndicator>
             <CheckIcon />

--- a/src/app/components/Button/Button.tsx
+++ b/src/app/components/Button/Button.tsx
@@ -6,7 +6,7 @@ import { StyledButton } from './StyledButton';
 export interface ButtonProps {
   type?: 'button' | 'submit';
   form?: string;
-  variant: 'secondary' | 'primary' | 'ghost';
+  variant: 'secondary' | 'primary' | 'ghost' | 'danger';
   onClick?: () => void;
   size?: 'large' | 'small';
   href?: string;
@@ -49,7 +49,7 @@ const Button: React.FC<ButtonProps> = ({
         href={href}
         data-cy={id}
         data-testid={id}
-        >
+      >
         <StyledButton
           ref={buttonRef}
           disabled={disabled}

--- a/src/app/components/Button/StyledButton.tsx
+++ b/src/app/components/Button/StyledButton.tsx
@@ -36,6 +36,11 @@ export const StyledButton = styled('button', {
           background: '$bgHoverBtnGhost',
         },
       },
+      danger: {
+        background: '$bgBtnSecondary',
+        color: '$fgDanger',
+        borderColor: '$border',
+      },
     },
   },
 });

--- a/src/app/components/Button/StyledButton.tsx
+++ b/src/app/components/Button/StyledButton.tsx
@@ -22,11 +22,17 @@ export const StyledButton = styled('button', {
     },
     variant: {
       primary: {
+        '&:focus': {
+          boxShadow: '$focus',
+        },
       },
       secondary: {
         background: '$bgBtnSecondary',
         color: '$fgBtnSecondary',
         borderColor: '$border',
+        '&:focus': {
+          boxShadow: '$focus',
+        },
       },
       ghost: {
         background: 'transparent',
@@ -35,11 +41,17 @@ export const StyledButton = styled('button', {
         '&:hover': {
           background: '$bgHoverBtnGhost',
         },
+        '&:focus': {
+          boxShadow: '$focus',
+        },
       },
       danger: {
         background: '$bgBtnSecondary',
         color: '$fgDanger',
         borderColor: '$border',
+        '&:focus': {
+          boxShadow: '$focusDanger',
+        },
       },
     },
   },

--- a/src/app/components/Checkbox.tsx
+++ b/src/app/components/Checkbox.tsx
@@ -18,7 +18,7 @@ const StyledCheckbox = styled(CheckboxPrimitive.Root, {
   justifyContent: 'center',
   width: 12,
   height: 12,
-  '&:focus': { boxShadow: '0 0 0 2px black' },
+  '&:focus': { boxShadow: '$focus' },
   variants: {
     isChecked: {
       true: {

--- a/src/app/components/EditTokenForm.tsx
+++ b/src/app/components/EditTokenForm.tsx
@@ -41,7 +41,6 @@ type Choice = { key: string; label: string; enabled?: boolean, unique?: boolean 
 
 // @TODO this needs to be reviewed from a typings perspective + performance
 function EditTokenForm({ resolvedTokens }: Props) {
-  const firstInput = React.useRef<HTMLInputElement | null>(null);
   const activeTokenSet = useSelector(activeTokenSetSelector);
   const editToken = useSelector(editTokenSelector);
   const themes = useSelector(themesListSelector);
@@ -363,12 +362,6 @@ function EditTokenForm({ resolvedTokens }: Props) {
     dispatch.uiState.setShowEditForm(false);
   }, [dispatch]);
 
-  React.useEffect(() => {
-    setTimeout(() => {
-      firstInput.current?.focus();
-    }, 50);
-  }, []);
-
   const resolvedValue = React.useMemo(() => {
     if (internalEditToken) {
       return typeof internalEditToken?.value === 'string'
@@ -481,8 +474,8 @@ function EditTokenForm({ resolvedTokens }: Props) {
           value={internalEditToken?.name}
           onChange={handleChange}
           type="text"
+          autofocus
           name="name"
-          inputRef={firstInput}
           error={error}
           placeholder="Unique name"
         />

--- a/src/app/components/EditTokenForm.tsx
+++ b/src/app/components/EditTokenForm.tsx
@@ -494,6 +494,7 @@ function EditTokenForm({ resolvedTokens }: Props) {
           <Textarea
             key="description"
             value={internalEditToken?.description || ''}
+            placeholder="Optional description"
             onChange={handleDescriptionChange}
             rows={3}
             border

--- a/src/app/components/EditTokenForm.tsx
+++ b/src/app/components/EditTokenForm.tsx
@@ -505,7 +505,7 @@ function EditTokenForm({ resolvedTokens }: Props) {
           </Button>
           <Button disabled={!isValid} variant="primary" type="submit">
             {internalEditToken?.status === EditTokenFormStatus.CREATE && 'Create'}
-            {internalEditToken?.status === EditTokenFormStatus.EDIT && 'Update'}
+            {internalEditToken?.status === EditTokenFormStatus.EDIT && 'Save'}
             {(
               internalEditToken?.status !== EditTokenFormStatus.CREATE
               && internalEditToken?.status !== EditTokenFormStatus.EDIT

--- a/src/app/components/Input.tsx
+++ b/src/app/components/Input.tsx
@@ -140,7 +140,7 @@ const StyledPrefix = styled('div', {
   },
 });
 
-const Input = React.forwardRef<HTMLInputElement, Props>(({
+const Input = ({
   form,
   name,
   autofocus,
@@ -157,13 +157,13 @@ const Input = React.forwardRef<HTMLInputElement, Props>(({
   suffix,
   step,
   custom = '',
-  inputRef = null,
+  inputRef,
   placeholder = '',
   capitalize = false,
   isMasked = false,
   size = 'small',
   ...inputProps
-}) => {
+}: Props) => {
   // if isMasked is true, then we need to handle toggle visibility
   const [show, setShow] = React.useState(false);
 
@@ -226,7 +226,7 @@ const Input = React.forwardRef<HTMLInputElement, Props>(({
       </Box>
     </label>
   );
-});
+};
 
 export default Input;
 export { StyledInput, StyledPrefix, StyledSuffix };

--- a/src/app/components/Input.tsx
+++ b/src/app/components/Input.tsx
@@ -163,7 +163,7 @@ const Input = React.forwardRef<HTMLInputElement, Props>(({
   isMasked = false,
   size = 'small',
   ...inputProps
-}, ref) => {
+}) => {
   // if isMasked is true, then we need to handle toggle visibility
   const [show, setShow] = React.useState(false);
 
@@ -174,6 +174,14 @@ const Input = React.forwardRef<HTMLInputElement, Props>(({
       inputRef.current.type = inputRef?.current?.type === 'password' ? 'text' : 'password';
     }
   }, [show, inputRef]);
+
+  const htmlInputRef = React.useRef<HTMLInputElement>(null);
+
+  React.useEffect(() => {
+    if (autofocus && htmlInputRef && htmlInputRef.current) {
+      htmlInputRef.current.focus();
+    }
+  }, [autofocus, htmlInputRef]);
 
   return (
     <label htmlFor={name} className="block font-medium text-xxs">
@@ -189,7 +197,7 @@ const Input = React.forwardRef<HTMLInputElement, Props>(({
         {!!prefix && <StyledPrefix>{prefix}</StyledPrefix>}
         <StyledInput
           form={form}
-          ref={inputRef ?? ref}
+          ref={inputRef ?? htmlInputRef}
           spellCheck={false}
           tabIndex={tabindex ?? undefined}
           type={type}

--- a/src/app/components/Input.tsx
+++ b/src/app/components/Input.tsx
@@ -179,7 +179,9 @@ const Input = React.forwardRef<HTMLInputElement, Props>(({
 
   React.useEffect(() => {
     if (autofocus && htmlInputRef && htmlInputRef.current) {
-      htmlInputRef.current.focus();
+      setTimeout(() => {
+        htmlInputRef.current?.focus();
+      }, 50);
     }
   }, [autofocus, htmlInputRef]);
 

--- a/src/app/components/Input.tsx
+++ b/src/app/components/Input.tsx
@@ -140,7 +140,7 @@ const StyledPrefix = styled('div', {
   },
 });
 
-const Input = ({
+const Input = React.forwardRef<HTMLInputElement, Props>(({
   form,
   name,
   autofocus,
@@ -163,7 +163,7 @@ const Input = ({
   isMasked = false,
   size = 'small',
   ...inputProps
-}: Props) => {
+}, ref) => {
   // if isMasked is true, then we need to handle toggle visibility
   const [show, setShow] = React.useState(false);
 
@@ -199,7 +199,7 @@ const Input = ({
         {!!prefix && <StyledPrefix>{prefix}</StyledPrefix>}
         <StyledInput
           form={form}
-          ref={inputRef ?? htmlInputRef}
+          ref={inputRef || ref || htmlInputRef}
           spellCheck={false}
           tabIndex={tabindex ?? undefined}
           type={type}
@@ -226,7 +226,7 @@ const Input = ({
       </Box>
     </label>
   );
-};
+});
 
 export default Input;
 export { StyledInput, StyledPrefix, StyledSuffix };

--- a/src/app/components/InspectorMultiView.tsx
+++ b/src/app/components/InspectorMultiView.tsx
@@ -134,7 +134,7 @@ export default function InspectorMultiView({ resolvedTokens }: { resolvedTokens:
           )}
         </Box>
       ) : (
-        <Stack direction="column" gap={4} css={{ padding: '$5' }}>
+        <Stack direction="column" gap={4} css={{ padding: '$5', margin: 'auto' }}>
           <Blankslate title={uiState.selectedLayers > 0 ? 'No tokens found' : 'No layers selected'} text={uiState.selectedLayers > 0 ? 'None of the selected layers contain any tokens' : 'Select a layer to see applied tokens'} />
           {uiState.onboardingExplainerInspect && (
             <OnboardingExplainer data={onboardingData} closeOnboarding={closeOnboarding} />

--- a/src/app/components/InspectorTokenSingle.tsx
+++ b/src/app/components/InspectorTokenSingle.tsx
@@ -13,7 +13,6 @@ import TokenNodes from './inspector/TokenNodes';
 import { inspectStateSelector } from '@/selectors';
 import { useTypeForProperty } from '../hooks/useTypeForProperty';
 import Button from './Button';
-import Heading from './Heading';
 import DownshiftInput from './DownshiftInput';
 import Modal from './Modal';
 import Stack from './Stack';
@@ -115,28 +114,21 @@ export default function InspectorTokenSingle({
         </Box>
         {
           showDialog && (
-            <Modal large isOpen close={onCancel}>
+            <Modal title={`Choose a new token for ${mappedToken?.name || token.value}`} large isOpen close={onCancel}>
               <form
                 onSubmit={onConfirm}
               >
                 <Stack direction="column" gap={4} css={{ minHeight: '215px', justifyContent: 'center' }}>
-                  <Stack direction="column" gap={2}>
-                    <Heading>
-                      Choose a new token for
-                      {' '}
-                      {mappedToken?.name || token.value}
-                    </Heading>
-                    <DownshiftInput
-                      value={newTokenName}
-                      type={property === 'fill' ? 'color' : property}
-                      resolvedTokens={resolvedTokens}
-                      handleChange={handleChange}
-                      setInputValue={handleDownShiftInputChange}
-                      placeholder="Choose a new token"
-                      suffix
-                    />
+                  <DownshiftInput
+                    value={newTokenName}
+                    type={property === 'fill' ? 'color' : property}
+                    resolvedTokens={resolvedTokens}
+                    handleChange={handleChange}
+                    setInputValue={handleDownShiftInputChange}
+                    placeholder="Choose a new token"
+                    suffix
+                  />
 
-                  </Stack>
                   <Stack direction="row" gap={4} justify="between">
                     <Button variant="secondary" onClick={onCancel}>
                       Cancel

--- a/src/app/components/ManageThemesModal/CreateOrEditThemeForm.tsx
+++ b/src/app/components/ManageThemesModal/CreateOrEditThemeForm.tsx
@@ -90,6 +90,7 @@ export const CreateOrEditThemeForm: React.FC<Props> = ({
           <Input
             data-cy="create-or-edit-theme-form--input--name"
             data-testid="create-or-edit-theme-form--input--name"
+            autofocus
             {...register('name', { required: true })}
           />
           <StyledCreateOrEditThemeFormTabsFlex>

--- a/src/app/components/ManageThemesModal/CreateOrEditThemeForm.tsx
+++ b/src/app/components/ManageThemesModal/CreateOrEditThemeForm.tsx
@@ -90,7 +90,6 @@ export const CreateOrEditThemeForm: React.FC<Props> = ({
           <Input
             data-cy="create-or-edit-theme-form--input--name"
             data-testid="create-or-edit-theme-form--input--name"
-            autofocus
             {...register('name', { required: true })}
           />
           <StyledCreateOrEditThemeFormTabsFlex>

--- a/src/app/components/ManageThemesModal/CreateOrEditThemeForm.tsx
+++ b/src/app/components/ManageThemesModal/CreateOrEditThemeForm.tsx
@@ -88,6 +88,7 @@ export const CreateOrEditThemeForm: React.FC<Props> = ({
             onClick={onCancel}
           />
           <Input
+            autofocus
             data-cy="create-or-edit-theme-form--input--name"
             data-testid="create-or-edit-theme-form--input--name"
             {...register('name', { required: true })}

--- a/src/app/components/ManageThemesModal/ManageThemesModal.tsx
+++ b/src/app/components/ManageThemesModal/ManageThemesModal.tsx
@@ -97,24 +97,24 @@ export const ManageThemesModal: React.FC<Props> = () => {
           {themeEditorOpen && (
             <>
               <Box css={{ marginRight: 'auto' }}>
-                <Button
-                  id="button-manage-themes-modal-cancel"
-                  variant="secondary"
-                  onClick={handleToggleThemeEditor}
-                >
-                  Cancel
-                </Button>
-              </Box>
-              {typeof themeEditorOpen === 'string' && (
+                {typeof themeEditorOpen === 'string' && (
                 <Button
                   id="button-manage-themes-modal-delete-theme"
-                  variant="secondary"
+                  variant="danger"
                   type="submit"
                   onClick={handleDeleteTheme}
                 >
                   Delete
                 </Button>
-              )}
+                )}
+              </Box>
+              <Button
+                id="button-manage-themes-modal-cancel"
+                variant="secondary"
+                onClick={handleToggleThemeEditor}
+              >
+                Cancel
+              </Button>
               <Button
                 id="button-manage-themes-modal-save-theme"
                 variant="primary"

--- a/src/app/components/OnboardingExplainer.tsx
+++ b/src/app/components/OnboardingExplainer.tsx
@@ -45,11 +45,9 @@ export default function OnboardingExplainer({ data, closeOnboarding }: Props) {
         </Stack>
         <IconButton dataCy="closeButton" onClick={closeOnboarding} icon={<Cross1Icon />} />
       </Stack>
-      {data.text.split('\n').map((text) => (
-        <StyledTextPlan>
-          {text}
-        </StyledTextPlan>
-      ))}
+      <StyledTextPlan>
+        {data.text}
+      </StyledTextPlan>
       <StyledReadMoreLink href={data.url} target="_blank" rel="noreferrer">
         Read more
       </StyledReadMoreLink>

--- a/src/app/components/PushDialog.tsx
+++ b/src/app/components/PushDialog.tsx
@@ -17,7 +17,7 @@ import { isGitProvider } from '@/utils/is';
 import Textarea from './Textarea';
 import { useShortcut } from '@/hooks/useShortcut';
 
-function ConfirmDialog() {
+function PushDialog() {
   const { onConfirm, onCancel, showPushDialog } = usePushDialog();
   const localApiState = useSelector(localApiStateSelector);
   const [commitMessage, setCommitMessage] = React.useState('');
@@ -179,4 +179,4 @@ function ConfirmDialog() {
     }
   }
 }
-export default ConfirmDialog;
+export default PushDialog;

--- a/src/app/components/Settings/Settings.tsx
+++ b/src/app/components/Settings/Settings.tsx
@@ -53,6 +53,7 @@ function Settings() {
     dispatch.uiState.setOnboardingExplainerSets(true);
     dispatch.uiState.setOnboardingExplainerInspect(true);
     dispatch.uiState.setOnboardingExplainerSyncProviders(true);
+    dispatch.uiState.setLastOpened(0);
   }, [dispatch]);
 
   return (

--- a/src/app/components/StorageItemForm/ADOForm.tsx
+++ b/src/app/components/StorageItemForm/ADOForm.tsx
@@ -50,6 +50,7 @@ export default function ADOForm({
     <form onSubmit={handleSubmit}>
       <Stack direction="column" gap={4}>
         <Input
+          autofocus
           full
           label="Organization Url"
           value={values.baseUrl}
@@ -108,12 +109,12 @@ export default function ADOForm({
           name="name"
         />
         <Stack direction="row" gap={4}>
-          <Button variant="secondary" size="large" onClick={onCancel}>
+          <Button variant="secondary" onClick={onCancel}>
             Cancel
           </Button>
 
           <Button variant="primary" type="submit" disabled={!values.secret && !values.name}>
-            Save
+            Save credentials
           </Button>
         </Stack>
         {hasErrored && (

--- a/src/app/components/StorageItemForm/GitForm.tsx
+++ b/src/app/components/StorageItemForm/GitForm.tsx
@@ -51,7 +51,7 @@ export default function GitForm({
   return (
     <form onSubmit={handleSubmit}>
       <Stack direction="column" gap={4}>
-        <Input full label="Name" value={values.name} onChange={onChange} type="text" name="name" required />
+        <Input autofocus full label="Name" value={values.name} onChange={onChange} type="text" name="name" required />
         <Box css={{ position: 'relative' }}>
           <Input
             full
@@ -102,12 +102,12 @@ export default function GitForm({
           name="baseUrl"
         />
         <Stack direction="row" gap={4}>
-          <Button variant="secondary" size="large" onClick={onCancel}>
+          <Button variant="secondary" onClick={onCancel}>
             Cancel
           </Button>
 
           <Button variant="primary" type="submit" disabled={!values.secret && !values.name}>
-            Save
+            Save credentials
           </Button>
         </Stack>
         {hasErrored && (

--- a/src/app/components/StorageItemForm/JSONBinForm.tsx
+++ b/src/app/components/StorageItemForm/JSONBinForm.tsx
@@ -45,7 +45,7 @@ export default function JSONBinForm({
   return (
     <form onSubmit={handleSubmit}>
       <Stack direction="column" gap={4}>
-        <Input full label="Name" value={values.name} onChange={onChange} type="text" name="name" required />
+        <Input autofocus full label="Name" value={values.name} onChange={onChange} type="text" name="name" required />
         <Input
           full
           label="Secret"
@@ -65,12 +65,12 @@ export default function JSONBinForm({
           required={!isNew}
         />
         <Stack direction="row" gap={4}>
-          <Button variant="secondary" size="large" onClick={onCancel}>
+          <Button variant="secondary" onClick={onCancel}>
             Cancel
           </Button>
 
           <Button variant="primary" type="submit" disabled={!values.secret && !values.name}>
-            Save
+            Save credentials
           </Button>
         </Stack>
         {hasErrored && (

--- a/src/app/components/StorageItemForm/URLForm.tsx
+++ b/src/app/components/StorageItemForm/URLForm.tsx
@@ -44,16 +44,16 @@ export default function URLForm({
   return (
     <form onSubmit={handleSubmit}>
       <Stack direction="column" gap={4}>
-        <Input full label="Name" value={values.name} onChange={onChange} type="text" name="name" required />
+        <Input autofocus full label="Name" value={values.name} onChange={onChange} type="text" name="name" required />
         <Input full label="Headers (optional)" value={values.secret} onChange={onChange} type="text" name="secret" />
         <Input full label="URL" value={values.id} onChange={onChange} type="text" name="id" required />
         <Stack direction="row" gap={4}>
-          <Button variant="secondary" size="large" onClick={onCancel}>
+          <Button variant="secondary" onClick={onCancel}>
             Cancel
           </Button>
 
           <Button variant="primary" type="submit" disabled={!values.secret && !values.name}>
-            Save
+            Save credentials
           </Button>
         </Stack>
         {hasErrored && (

--- a/src/app/components/SyncSettings.test.tsx
+++ b/src/app/components/SyncSettings.test.tsx
@@ -145,6 +145,6 @@ describe('ConfirmDialog', () => {
     expect(result.queryByText('Default Branch')).toBeInTheDocument();
     expect(result.queryByText('File Path (e.g. data/tokens.json)')).toBeInTheDocument();
     expect(result.queryByText('baseUrl (optional)')).toBeInTheDocument();
-    expect(result.queryByText('Save')).toBeInTheDocument();
+    expect(result.queryByText('Save credentials')).toBeInTheDocument();
   });
 });

--- a/src/app/components/TabButton/TabButton.tsx
+++ b/src/app/components/TabButton/TabButton.tsx
@@ -24,7 +24,7 @@ const StyledButton = styled('button', {
   },
   '&:disabled': {
     pointerEvents: 'none',
-    opacity: 0.5,
+    color: '$textDisbled',
   },
   variants: {
     isActive: {

--- a/src/app/components/TokenGroup/TokenGroupHeading.tsx
+++ b/src/app/components/TokenGroup/TokenGroupHeading.tsx
@@ -6,6 +6,7 @@ import {
 import Stack from '../Stack';
 import Button from '../Button';
 import Heading from '../Heading';
+import Text from '../Text';
 import Input from '../Input';
 import Modal from '../Modal';
 import useManageTokens from '../../store/useManageTokens';
@@ -100,14 +101,14 @@ export function TokenGroupHeading({
             </Stack>
           </ContextMenuTrigger>
           <ContextMenuContent>
-            <ContextMenuItem disabled={editProhibited} onSelect={handleDelete}>
-              Delete
-            </ContextMenuItem>
             <ContextMenuItem disabled={editProhibited} onSelect={handleRename}>
               Rename
             </ContextMenuItem>
             <ContextMenuItem disabled={editProhibited} onSelect={handleDuplicate}>
               Duplicate
+            </ContextMenuItem>
+            <ContextMenuItem disabled={editProhibited} onSelect={handleDelete}>
+              Delete
             </ContextMenuItem>
           </ContextMenuContent>
         </ContextMenu>
@@ -118,30 +119,29 @@ export function TokenGroupHeading({
         close={handleSetNewTokenGroupNameFileClose}
         footer={(
           <form id="renameTokenGroup" onSubmit={handleRenameTokenGroupSubmit}>
-            <Stack direction="row" gap={4}>
-              <Button variant="secondary" size="large" onClick={handleSetNewTokenGroupNameFileClose}>
+            <Stack direction="row" justify="end" gap={4}>
+              <Button variant="secondary" onClick={handleSetNewTokenGroupNameFileClose}>
                 Cancel
               </Button>
-              <Button type="submit" variant="primary" size="large" disabled={oldTokenGroupName === newTokenGroupName}>
+              <Button type="submit" variant="primary" disabled={oldTokenGroupName === newTokenGroupName}>
                 Change
               </Button>
             </Stack>
           </form>
         )}
       >
-        <Stack direction="column" justify="center" gap={4} css={{ textAlign: 'center' }}>
-          <Heading size="small">Renaming only affects tokens of the same type</Heading>
-          <Stack direction="column" gap={4}>
-            <Input
-              form="renameTokenGroup"
-              full
-              onChange={handleNewTokenGroupNameChange}
-              type="text"
-              name="tokengroupname"
-              value={newTokenGroupName}
-              required
-            />
-          </Stack>
+        <Stack direction="column" gap={4}>
+          <Input
+            form="renameTokenGroup"
+            full
+            onChange={handleNewTokenGroupNameChange}
+            type="text"
+            name="tokengroupname"
+            value={newTokenGroupName}
+            autofocus
+            required
+          />
+          <Text muted>Renaming only affects tokens of the same type</Text>
         </Stack>
       </Modal>
       <StyledTokenGroupAddIcon

--- a/src/app/components/TokenSetSelector.tsx
+++ b/src/app/components/TokenSetSelector.tsx
@@ -206,6 +206,7 @@ export default function TokenSetSelector({ saveScrollPositionSet }: { saveScroll
                 name="tokensetname"
                 required
                 data-cy="token-set-input"
+                autofocus
               />
               <Stack direction="row" gap={4}>
                 <Button variant="secondary" size="large" onClick={handleCloseNewTokenSetModal}>

--- a/src/app/components/TokenSetSelector.tsx
+++ b/src/app/components/TokenSetSelector.tsx
@@ -4,7 +4,6 @@ import { track } from '@/utils/analytics';
 import useConfirm from '../hooks/useConfirm';
 import { Dispatch } from '../store';
 import Button from './Button';
-import Heading from './Heading';
 import IconAdd from '@/icons/add.svg';
 import Input from './Input';
 import Modal from './Modal';
@@ -162,63 +161,63 @@ export default function TokenSetSelector({ saveScrollPositionSet }: { saveScroll
         saveScrollPositionSet={saveScrollPositionSet}
       />
       <Modal
+        title={`Rename ${tokenSetMarkedForChange}`}
         isOpen={showRenameTokenSetFields}
         close={handleCloseRenameModal}
-      >
-        <Stack direction="column" justify="center" gap={4} css={{ textAlign: 'center' }}>
-          <Heading size="small">
-            Rename
-            {' '}
-            {tokenSetMarkedForChange}
-          </Heading>
-          <form onSubmit={handleRenameTokenSetSubmit}>
-            <Stack direction="column" gap={4}>
-              <Input
-                full
-                value={newTokenSetName}
-                onChange={handleChangeName}
-                type="text"
-                name="tokensetname"
-                required
-              />
-              <Stack direction="row" gap={4}>
-                <Button variant="secondary" size="large" onClick={handleCloseRenameModal}>
-                  Cancel
-                </Button>
-                <Button type="submit" variant="primary" size="large" disabled={tokenSetMarkedForChange === newTokenSetName}>
-                  Change
-                </Button>
-              </Stack>
+        footer={(
+          <form id="renameTokenSet" onSubmit={handleRenameTokenSetSubmit}>
+            <Stack direction="row" justify="end" gap={4}>
+              <Button variant="secondary" onClick={handleCloseRenameModal}>
+                Cancel
+              </Button>
+              <Button type="submit" variant="primary" disabled={tokenSetMarkedForChange === newTokenSetName}>
+                Change
+              </Button>
             </Stack>
           </form>
+        )}
+      >
+        <Stack direction="column" gap={4}>
+          <Input
+            form="renameTokenSet"
+            full
+            value={newTokenSetName}
+            onChange={handleChangeName}
+            type="text"
+            name="tokensetname"
+            autofocus
+            required
+          />
         </Stack>
       </Modal>
-      <Modal isOpen={showNewTokenSetFields} close={handleCloseNewTokenSetModal}>
-        <Stack direction="column" justify="center" gap={4} css={{ textAlign: 'center' }}>
-          <Heading size="small">New set</Heading>
-          <form onSubmit={handleNewTokenSetSubmit}>
-            <Stack direction="column" gap={4}>
-              <Input
-                full
-                value={newTokenSetName}
-                onChange={handleChangeName}
-                type="text"
-                name="tokensetname"
-                required
-                data-cy="token-set-input"
-                autofocus
-              />
-              <Stack direction="row" gap={4}>
-                <Button variant="secondary" size="large" onClick={handleCloseNewTokenSetModal}>
-                  Cancel
-                </Button>
-                <Button data-cy="create-token-set" type="submit" variant="primary" size="large">
-                  Create
-                </Button>
-              </Stack>
+      <Modal
+        title="New set"
+        isOpen={showNewTokenSetFields}
+        close={handleCloseNewTokenSetModal}
+        footer={(
+          <form name="newTokenSetForm" onSubmit={handleNewTokenSetSubmit}>
+            <Stack direction="row" justify="end" gap={4}>
+              <Button variant="secondary" size="large" onClick={handleCloseNewTokenSetModal}>
+                Cancel
+              </Button>
+              <Button data-cy="create-token-set" type="submit" variant="primary" size="large">
+                Create
+              </Button>
             </Stack>
           </form>
-        </Stack>
+        )}
+      >
+        <Input
+          form="newTokenSetForm"
+          full
+          value={newTokenSetName}
+          onChange={handleChangeName}
+          type="text"
+          name="tokensetname"
+          required
+          data-cy="token-set-input"
+          autofocus
+        />
       </Modal>
       <StyledButton data-cy="button-new-token-set" type="button" disabled={editProhibited} onClick={handleOpenNewTokenSetModal}>
         New set

--- a/src/app/components/TokenSetSelector.tsx
+++ b/src/app/components/TokenSetSelector.tsx
@@ -164,39 +164,47 @@ export default function TokenSetSelector({ saveScrollPositionSet }: { saveScroll
         title={`Rename ${tokenSetMarkedForChange}`}
         isOpen={showRenameTokenSetFields}
         close={handleCloseRenameModal}
-        footer={(
-          <form id="renameTokenSet" onSubmit={handleRenameTokenSetSubmit}>
-            <Stack direction="row" justify="end" gap={4}>
-              <Button variant="secondary" onClick={handleCloseRenameModal}>
+      >
+        <form onSubmit={handleRenameTokenSetSubmit}>
+          <Stack direction="column" gap={4}>
+            <Input
+              full
+              autofocus
+              value={newTokenSetName}
+              onChange={handleChangeName}
+              type="text"
+              name="tokensetname"
+              required
+            />
+            <Stack direction="row" gap={4}>
+              <Button variant="secondary" size="large" onClick={handleCloseRenameModal}>
                 Cancel
               </Button>
-              <Button type="submit" variant="primary" disabled={tokenSetMarkedForChange === newTokenSetName}>
+              <Button type="submit" variant="primary" size="large" disabled={tokenSetMarkedForChange === newTokenSetName}>
                 Change
               </Button>
             </Stack>
-          </form>
-        )}
-      >
-        <Stack direction="column" gap={4}>
-          <Input
-            form="renameTokenSet"
-            full
-            value={newTokenSetName}
-            onChange={handleChangeName}
-            type="text"
-            name="tokensetname"
-            autofocus
-            required
-          />
-        </Stack>
+          </Stack>
+        </form>
       </Modal>
       <Modal
         title="New set"
         isOpen={showNewTokenSetFields}
         close={handleCloseNewTokenSetModal}
-        footer={(
-          <form name="newTokenSetForm" onSubmit={handleNewTokenSetSubmit}>
-            <Stack direction="row" justify="end" gap={4}>
+      >
+        <form onSubmit={handleNewTokenSetSubmit}>
+          <Stack direction="column" gap={4}>
+            <Input
+              full
+              value={newTokenSetName}
+              onChange={handleChangeName}
+              type="text"
+              name="tokensetname"
+              required
+              data-cy="token-set-input"
+              autofocus
+            />
+            <Stack direction="row" gap={4}>
               <Button variant="secondary" size="large" onClick={handleCloseNewTokenSetModal}>
                 Cancel
               </Button>
@@ -204,20 +212,8 @@ export default function TokenSetSelector({ saveScrollPositionSet }: { saveScroll
                 Create
               </Button>
             </Stack>
-          </form>
-        )}
-      >
-        <Input
-          form="newTokenSetForm"
-          full
-          value={newTokenSetName}
-          onChange={handleChangeName}
-          type="text"
-          name="tokensetname"
-          required
-          data-cy="token-set-input"
-          autofocus
-        />
+          </Stack>
+        </form>
       </Modal>
       <StyledButton data-cy="button-new-token-set" type="button" disabled={editProhibited} onClick={handleOpenNewTokenSetModal}>
         New set

--- a/src/app/components/modals/BulkRemapModal.tsx
+++ b/src/app/components/modals/BulkRemapModal.tsx
@@ -35,7 +35,7 @@ export default function BulkRemapModal({ isOpen, onClose }: Props) {
   }, []);
 
   return (
-    <Modal large showClose isOpen={isOpen} close={handleClose} title="Choose a new token for">
+    <Modal large showClose isOpen={isOpen} close={handleClose} title="Bulk remap">
       <form
         onSubmit={onConfirm}
       >

--- a/src/app/components/modals/CreateStorageItemModal.tsx
+++ b/src/app/components/modals/CreateStorageItemModal.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import Modal from '../Modal';
-import Heading from '../Heading';
 import StorageItemForm from '../StorageItemForm';
 import useRemoteTokens from '../../store/remoteTokens';
-import Stack from '../Stack';
 import { StorageTypeFormValues } from '@/types/StorageType';
 import { StorageProviderType } from '@/constants/StorageProviderType';
 
@@ -45,19 +43,16 @@ export default function CreateStorageItemModal({
   }, [handleCreateNewClick]);
 
   return (
-    <Modal large isOpen={isOpen} close={onClose}>
-      <Stack direction="column" gap={4}>
-        <Heading>Add new credentials</Heading>
-        <StorageItemForm
-          isNew
-          onChange={handleChange}
-          onSubmit={handleSubmit}
-          onCancel={onClose}
-          values={formFields}
-          hasErrored={hasErrored}
-          errorMessage={errorMessage}
-        />
-      </Stack>
+    <Modal title="Add new credentials" large isOpen={isOpen} close={onClose}>
+      <StorageItemForm
+        isNew
+        onChange={handleChange}
+        onSubmit={handleSubmit}
+        onCancel={onClose}
+        values={formFields}
+        hasErrored={hasErrored}
+        errorMessage={errorMessage}
+      />
     </Modal>
   );
 }

--- a/src/stitches.config.ts
+++ b/src/stitches.config.ts
@@ -151,6 +151,7 @@ export const stitchesInstance = createStitches({
       focus: `0 0 0 2px ${globalTokens.colors.primary500}`,
       'focus-subtle': `0 0 0 2px ${globalTokens.colors.primary300}`,
       focusMuted: `0 0 0 2px ${globalTokens.colors.primary400}`,
+      focusDanger: '0 0 0 2px $colors$bgDanger',
       tokenFocus: '0 0 0 2px $colors$borderMuted',
     },
   },


### PR DESCRIPTION
Mostly cleans up the UI
- to make use of the Modal Header props
- remove `Update remote` when not using JSONbin as it was only applicable there
- Adds a Danger button variant
- Makes the `Delete` button in Themes use Danger
- Integrates autofocus prop on Input so we can utilize that more generic
- Fixes the sizing of buttons on credential forms