### PR TITLE
fix blue dot issue

### DIFF
--- a/.changeset/neat-scissors-wait.md
+++ b/.changeset/neat-scissors-wait.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fixed a bug that caused the blue dot to remain visible when renaming a token set

--- a/packages/tokens-studio-for-figma/src/utils/tokenset/updateTokenSetsInState.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokenset/updateTokenSetsInState.ts
@@ -70,9 +70,13 @@ export function updateTokenSetsInState(
     nextThemes = nextThemes.map((theme) => {
       let nextSelectedTokenSets = { ...theme.selectedTokenSets };
       renamedTokenSets.forEach((newName, originalName) => {
-        const tokenSetStatus = nextSelectedTokenSets[originalName] ?? TokenSetStatus.DISABLED;
+        const tokenSetStatus = nextSelectedTokenSets[originalName];
         nextSelectedTokenSets = omit(nextSelectedTokenSets, originalName);
-        nextSelectedTokenSets[newName] = tokenSetStatus;
+
+        // Only add to selectedTokenSets if it was previously enabled/source
+        if (tokenSetStatus !== undefined) {
+          nextSelectedTokenSets[newName] = tokenSetStatus;
+        }
       });
       return {
         ...theme,


### PR DESCRIPTION
## Summary
  • Fixed token set renaming bug where disabled token sets were incorrectly added to theme `selectedTokenSets`

  ## Changes
  Modified `updateTokenSetsInState.ts` to only add renamed token sets to `selectedTokenSets` if they were
  previously enabled or source status. Disabled token sets now remain excluded from theme configurations after
  renaming.

  ## Test plan
  - [ ] Rename a disabled token set and verify it doesn't appear in theme `selectedTokenSets`
  - [ ] Rename an enabled token set and verify it maintains its status in theme config
  - [ ] Rename a source token set and verify it maintains its status in theme config

Fixes #3522