### PR TITLE
Fix: Reset primaryAxisAlignItems when switching from AUTO spacing

### DIFF
--- a/packages/tokens-studio-for-figma/src/plugin/applySpacingValuesOnNode.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/applySpacingValuesOnNode.ts
@@ -98,13 +98,22 @@ export async function applySpacingValuesOnNode(
     && typeof data.itemSpacing !== 'undefined'
     && isPrimitiveValue(values.itemSpacing)
   ) {
-    if (String(values.itemSpacing) === 'AUTO') {
+    const itemSpacingValue = String(values.itemSpacing);
+
+    if (itemSpacingValue === 'AUTO') {
+      // Set alignment to SPACE_BETWEEN for AUTO spacing
       node.primaryAxisAlignItems = 'SPACE_BETWEEN';
-    } else if (node.primaryAxisAlignItems === 'SPACE_BETWEEN') {
-      node.primaryAxisAlignItems = 'MIN';
-    }
-    if (!(await tryApplyVariableId(node, 'itemSpacing', data.itemSpacing))) {
-      node.itemSpacing = transformValue(String(values.itemSpacing), 'spacing', baseFontSize);
+      // Don't set itemSpacing when using AUTO
+    } else {
+      // FIX: When switching from AUTO to a non-AUTO value, reset alignment to MIN
+      if (node.primaryAxisAlignItems === 'SPACE_BETWEEN') {
+        node.primaryAxisAlignItems = 'MIN';
+      }
+
+      // Apply the actual spacing value
+      if (!(await tryApplyVariableId(node, 'itemSpacing', data.itemSpacing))) {
+        node.itemSpacing = transformValue(itemSpacingValue, 'spacing', baseFontSize);
+      }
     }
   }
 


### PR DESCRIPTION
Title:
[Bug] Theme switching fails when transitioning from "AUTO" spacing

Description:
I encountered a bug where switching themes breaks if a component was previously set to an "AUTO" spacing token.

When a spacing token is set to "AUTO", the plugin correctly sets the Figma property primaryAxisAlignItems to 'SPACE_BETWEEN'. However, when switching to a different theme where that same token has a numeric value (e.g., 16px), the plugin updates the item spacing value but fails to reset the alignment mode.

Because primaryAxisAlignItems remains set to 'SPACE_BETWEEN', the new numeric spacing value is visually ignored by Figma, making it look like the theme switch failed.

In the example orange buttons should change to yellow but only buttons with AUTO fail to change tokens when switching themes

![Clipboard-20251128-165220-243](https://github.com/user-attachments/assets/48f2228a-8e6e-4ad2-a6bd-30d8f32cd804)


Steps to Reproduce:

Create a spacing token named spacing.gap.
In Theme A, set spacing.gap to "AUTO".
In Theme B, set spacing.gap to 24 or also "AUTO".
Apply this token to an Auto Layout frame.
Activate Theme A (Frame alignment becomes Space Between).
Activate Theme B.
Expected Behavior:
The frame should update to use 24px spacing or refresh AUTO, or the alignment mode should reset to Packed (or MIN).

Actual Behavior:
The frame retains Space Between alignment but doesn't apply ANY change, even a color change (see example it should go from orange to yellow but where it's AUTO spacing the plugin skips them)

Root Cause:
In applySpacingValuesOnNode.ts, the logic currently checks if the new value is "AUTO" to set SPACE_BETWEEN, but it lacks an else condition to explicitly reset the alignment to MIN when the new value is not "AUTO" but the node is currently set to SPACE_BETWEEN.

Proposed Solution:
Update the logic in applySpacingValuesOnNode.ts to handle the state transition. If the new token value is not "AUTO", we must check if the node is currently in SPACE_BETWEEN mode and reset it to MIN before applying the new numeric spacing.