### PR TITLE
Fix: Fetch/Pull of BitBucket branches

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/store/providers/bitbucket/bitbucket.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/bitbucket/bitbucket.tsx
@@ -199,7 +199,12 @@ export function useBitbucket() {
           };
         }
         if (content) {
-          return content;
+          const sortedTokens = applyTokenSetOrder(content.tokens, content.metadata?.tokenSetOrder ?? Object.keys(content.tokens));
+
+          return {
+            ...content,
+            tokens: sortedTokens,
+          };
         }
       } catch (e) {
         console.log('Error', e);


### PR DESCRIPTION
### Why does this PR exist?

This PR fixes 2 main issues when syncing to BitBucket. 

1. The sets are organized alphabetically after a pull
2. All the branches aren't visible when clicking the branch dropdown, just 10, making it impossible to switch/create a branch from `main`.

### What does this pull request do?  

It solves those two issues.

#### Issue 1. The sets are organized alphabetically after a pull

pullTokensFromBitbucket returns the sets in the order the API gives them, completely disregarding `$metadata`

https://github.com/tokens-studio/figma-plugin/blob/5f9d005a856249f01a825f4761f9c083c10cf602/packages/tokens-studio-for-figma/src/app/store/providers/bitbucket/bitbucket.tsx#L201-L203

All the other providers(GitHub, GitLab)  do an extra step, sort `content.tokens` with `applyTokenSetOrder`.
I added that extra step to Bitbucket too.

```javascript
        if (content) {
          const sortedTokens = applyTokenSetOrder(content.tokens, content.metadata?.tokenSetOrder ?? Object.keys(content.tokens));

          return {
            ...content,
            tokens: sortedTokens,
          };
        }
``` 

---

#### Issue 2. All the branches aren't visible when clicking the branch dropdown, just 10, making it impossible to switch/create a branch from `main`.

If no parameter is added, [BitBucket's API](https://bitbucketjs.netlify.app/#api-refs-refs_listBranches) only returns the  10 branches of page 1.

Currently, `fetchBranches` doesn't specify any parameter, which causes to return only 10 branches

https://github.com/tokens-studio/figma-plugin/blob/5f9d005a856249f01a825f4761f9c083c10cf602/packages/tokens-studio-for-figma/src/storage/BitbucketTokenStorage.ts#L61-L66

This fix adds a loop to get all the branches from all of the pages.
BB's API response returns a `next` object if there are more pages to fetch, so the loop keeps getting branches and adding them to the array until the response doesn't have a `next` in the object.

 _The API also supports a `pagelen` param to determine the number of items that it can return in the first page.
 I tried a solution where I set the pagelen to 999 instead of the loop, but if the pagelen parameter is larger than the total number of branches in a repo, the API will respond with a 400 error, AFAIK the API documentation doesn't mention a way of getting the total number of branches to always set the pagelen to the tota number of branches, so I ended up just adding the loop.
But I'm open to suggestions_


I also added a similar fix to the `createBranch`, given that this function also fetches the "origin branch".

### Testing this change

You can test it by running their respective test files i.e. `BitbucketTokenStorage.test.ts`
And also running the plugin, creating a branch on a BitBucket repo with more than 10 branches.

### Additional Notes (if any)

None
