### PR TITLE
feat: add SlotNode support for Figma Slots

### DIFF
--- a/.changeset/slot-node-support.md
+++ b/.changeset/slot-node-support.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Add SlotNode support so theme propagation and token persistence work correctly on Figma Slots

--- a/packages/tokens-studio-for-figma/src/app/components/inspector/NodeIcon.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/inspector/NodeIcon.tsx
@@ -12,7 +12,8 @@ import {
 import Box from '../Box';
 
 interface NodeIconProps {
-  type: NodeType;
+  // Allow 'SLOT' in addition to standard NodeType (not yet in @figma/plugin-typings)
+  type: NodeType | 'SLOT';
   width?: number;
   height?: number;
 }
@@ -24,6 +25,7 @@ export default function NodeIcon({ type, width = 12, height = 12 }: NodeIconProp
       icon = <TextIcon width={width} height={height} />;
       break;
     case 'FRAME':
+    case 'SLOT':
       icon = <FrameIcon width={width} height={height} />;
       break;
     case 'INSTANCE':

--- a/packages/tokens-studio-for-figma/src/constants/ValidNodeTypes.ts
+++ b/packages/tokens-studio-for-figma/src/constants/ValidNodeTypes.ts
@@ -1,4 +1,6 @@
-export const ValidNodeTypes: NodeType[] = [
+// Cast as unknown first because 'SLOT' is not yet in @figma/plugin-typings.
+// Remove the cast once Figma ships official SlotNode typings.
+export const ValidNodeTypes = [
   'BOOLEAN_OPERATION',
   'COMPONENT',
   'COMPONENT_SET',
@@ -9,7 +11,8 @@ export const ValidNodeTypes: NodeType[] = [
   'LINE',
   'POLYGON',
   'RECTANGLE',
+  'SLOT',
   'TEXT',
   'VECTOR',
   'STAR',
-];
+] as unknown as NodeType[];

--- a/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/__tests__/applySiblingStyle.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/__tests__/applySiblingStyle.test.ts
@@ -1,0 +1,130 @@
+import { applySiblingStyleId } from '../applySiblingStyle';
+import { getNewStyleId } from '../getSiblingStyleId';
+
+jest.mock('../getSiblingStyleId', () => ({
+  getNewStyleId: jest.fn(),
+}));
+
+const mockedGetNewStyleId = getNewStyleId as jest.MockedFunction<typeof getNewStyleId>;
+
+describe('applySiblingStyleId', () => {
+  const styleIds = { 'S:abc,': 'color.primary' };
+  const styleMap = { 'color.primary': { light: 'S:def,' } };
+  const activeThemes = ['light'];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should swap fill, stroke and effect styles on a FRAME node', async () => {
+    mockedGetNewStyleId
+      .mockResolvedValueOnce('newFill')
+      .mockResolvedValueOnce('newStroke')
+      .mockResolvedValueOnce('newEffect');
+
+    const node = {
+      type: 'FRAME',
+      fillStyleId: 'S:abc,',
+      strokeStyleId: 'S:abc,',
+      effectStyleId: 'S:abc,',
+      children: [],
+    } as unknown as BaseNode;
+
+    await applySiblingStyleId(node, styleIds, styleMap, activeThemes);
+
+    expect(mockedGetNewStyleId).toHaveBeenCalledTimes(3);
+    expect((node as any).fillStyleId).toBe('newFill');
+    expect((node as any).strokeStyleId).toBe('newStroke');
+    expect((node as any).effectStyleId).toBe('newEffect');
+  });
+
+  it('should swap styles on a SLOT node and recurse into children', async () => {
+    mockedGetNewStyleId
+      .mockResolvedValueOnce('newFillSlot')
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      // child calls
+      .mockResolvedValueOnce('childFill')
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+
+    const child = {
+      type: 'RECTANGLE',
+      fillStyleId: 'S:abc,',
+      strokeStyleId: '',
+      effectStyleId: '',
+    } as unknown as BaseNode;
+
+    const slotNode = {
+      type: 'SLOT',
+      fillStyleId: 'S:abc,',
+      strokeStyleId: '',
+      effectStyleId: '',
+      children: [child],
+    } as unknown as BaseNode;
+
+    await applySiblingStyleId(slotNode, styleIds, styleMap, activeThemes);
+
+    expect((slotNode as any).fillStyleId).toBe('newFillSlot');
+    // Child was also processed
+    expect((child as any).fillStyleId).toBe('childFill');
+  });
+
+  it('should recurse into SLOT children just like FRAME children', async () => {
+    mockedGetNewStyleId.mockResolvedValue(null);
+
+    const grandchild = {
+      type: 'RECTANGLE',
+      fillStyleId: '',
+      strokeStyleId: '',
+      effectStyleId: '',
+    } as unknown as BaseNode;
+
+    const child = {
+      type: 'FRAME',
+      fillStyleId: '',
+      strokeStyleId: '',
+      effectStyleId: '',
+      children: [grandchild],
+    } as unknown as BaseNode;
+
+    const slotNode = {
+      type: 'SLOT',
+      fillStyleId: '',
+      strokeStyleId: '',
+      effectStyleId: '',
+      children: [child],
+    } as unknown as BaseNode;
+
+    await applySiblingStyleId(slotNode, styleIds, styleMap, activeThemes);
+
+    // 3 calls for slot + 3 for child frame + 3 for grandchild rectangle = 9
+    expect(mockedGetNewStyleId).toHaveBeenCalledTimes(9);
+  });
+
+  it('should handle GROUP nodes by recursing into children', async () => {
+    mockedGetNewStyleId.mockResolvedValue(null);
+
+    const child = {
+      type: 'RECTANGLE',
+      fillStyleId: '',
+      strokeStyleId: '',
+      effectStyleId: '',
+    } as unknown as BaseNode;
+
+    const group = {
+      type: 'GROUP',
+      children: [child],
+    } as unknown as BaseNode;
+
+    await applySiblingStyleId(group, styleIds, styleMap, activeThemes);
+
+    // 3 calls for the RECTANGLE child
+    expect(mockedGetNewStyleId).toHaveBeenCalledTimes(3);
+  });
+
+  it('should not throw on unknown node types', async () => {
+    const node = { type: 'UNKNOWN_TYPE' } as unknown as BaseNode;
+    await expect(applySiblingStyleId(node, styleIds, styleMap, activeThemes)).resolves.not.toThrow();
+  });
+});

--- a/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/applySiblingStyle.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/applySiblingStyle.ts
@@ -62,6 +62,8 @@ export async function applySiblingStyleId(node: BaseNode, styleIds: StyleIdMap, 
       case 'INSTANCE':
       case 'COMPONENT_SET':
       case 'FRAME':
+      // @ts-expect-error SlotNode not yet in @figma/plugin-typings
+      case 'SLOT':
       case 'SECTION':
       case 'BOOLEAN_OPERATION':
         {
@@ -77,7 +79,7 @@ export async function applySiblingStyleId(node: BaseNode, styleIds: StyleIdMap, 
           if (newEffectStyleId) {
             node.effectStyleId = newEffectStyleId;
           }
-          if (['COMPONENT', 'COMPONENT_SET', 'SECTION', 'INSTANCE', 'FRAME', 'BOOLEAN_OPERATION'].includes(node.type) && 'children' in node) {
+          if (['COMPONENT', 'COMPONENT_SET', 'SECTION', 'INSTANCE', 'FRAME', 'SLOT', 'BOOLEAN_OPERATION'].includes(node.type) && 'children' in node) {
             await Promise.all(node.children.map((child) => applySiblingStyleId(child, styleIds, styleMap, activeThemes)));
           }
         }

--- a/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/applySiblingStyle.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/applySiblingStyle.ts
@@ -63,7 +63,7 @@ export async function applySiblingStyleId(node: BaseNode, styleIds: StyleIdMap, 
       case 'COMPONENT_SET':
       case 'FRAME':
       // @ts-expect-error SlotNode not yet in @figma/plugin-typings
-      case 'SLOT':
+      case 'SLOT': // eslint-disable-line no-fallthrough
       case 'SECTION':
       case 'BOOLEAN_OPERATION':
         {

--- a/packages/tokens-studio-for-figma/src/plugin/figma-slot.d.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/figma-slot.d.ts
@@ -1,26 +1,16 @@
 /**
  * Temporary type declarations for Figma's SlotNode.
- * Figma released Slots but has not yet updated @figma/plugin-typings.
+ * Figma released Slots but has not yet updated @figma/plugin-typings on npm.
+ * Source: https://github.com/figma/plugin-typings/tree/owong/slots-plugin-typings
  * Remove this file once official typings land.
  */
 declare global {
-  // SlotNode behaves like a FrameNode — it supports children, layout, fills,
-  // strokes, corner radius, effects, variables, and all frame-equivalent properties.
-  interface SlotNode
-    extends BaseNodeMixin,
-      ChildrenMixin,
-      CornerMixin,
-      RectangleCornerMixin,
-      BlendMixin,
-      ConstraintMixin,
-      LayoutMixin,
-      ExplicitVariableModesMixin,
-      MinimalBlendMixin,
-      FramePrototypingMixin,
-      ReactionMixin,
-      VariableConsumptionMixin {
+  // SlotNode extends DefaultFrameMixin — same capability surface as FrameNode.
+  interface SlotNode extends DefaultFrameMixin {
     readonly type: 'SLOT';
-    clone(): SlotNode;
+    /** Resets a given slot node to the original component slot content. */
+    resetSlot(): void;
+    readonly isAssignedSlot: boolean;
   }
 }
 

--- a/packages/tokens-studio-for-figma/src/plugin/figma-slot.d.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/figma-slot.d.ts
@@ -1,0 +1,27 @@
+/**
+ * Temporary type declarations for Figma's SlotNode.
+ * Figma released Slots but has not yet updated @figma/plugin-typings.
+ * Remove this file once official typings land.
+ */
+declare global {
+  // SlotNode behaves like a FrameNode — it supports children, layout, fills,
+  // strokes, corner radius, effects, variables, and all frame-equivalent properties.
+  interface SlotNode
+    extends BaseNodeMixin,
+      ChildrenMixin,
+      CornerMixin,
+      RectangleCornerMixin,
+      BlendMixin,
+      ConstraintMixin,
+      LayoutMixin,
+      ExplicitVariableModesMixin,
+      MinimalBlendMixin,
+      FramePrototypingMixin,
+      ReactionMixin,
+      VariableConsumptionMixin {
+    readonly type: 'SLOT';
+    clone(): SlotNode;
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary

Figma recently released Slots, and the plugin had no awareness of the `'SLOT'` node type. This caused two bugs reported by users:

- **Theme propagation broken**: Switching a page's theme didn't update SlotNodes because `findAll()` never traversed them (they weren't in the `ValidNodeTypes` allowlist)
- **Tokens lost on copy-paste**: Tokens applied to slots disappeared when copying components to a working file for the same reason — the plugin never read/wrote plugin data on SlotNodes

### Changes

- **`src/plugin/figma-slot.d.ts`** *(new)* — Global `SlotNode` TypeScript interface declaration extending all FrameNode-equivalent mixins. `@figma/plugin-typings` has no `SlotNode` definition yet; delete this file once official typings ship.
- **`src/constants/ValidNodeTypes.ts`** — Added `'SLOT'` to the traversal allowlist. This is the core fix for both bugs.
- **`src/plugin/asyncMessageHandlers/applySiblingStyle.ts`** — Added `case 'SLOT':` to the switch block and `'SLOT'` to the `.includes()` guard for recursive children traversal.
- **`src/app/components/inspector/NodeIcon.tsx`** — Added `case 'SLOT':` using `FrameIcon` so slots render with the correct icon in the inspector.
- **`.changeset/slot-node-support.md`** — Patch changeset.

### Notes

- `setValuesOnNode.ts` and other value-application code use property existence checks (`'fills' in node`, etc.) rather than type guards, so SlotNodes will be handled correctly automatically once traversed — no changes needed there.
- When `@figma/plugin-typings` adds official `SlotNode` support: delete `figma-slot.d.ts`, remove the `as unknown as NodeType[]` cast in `ValidNodeTypes.ts`, remove the `// @ts-expect-error` in `applySiblingStyle.ts`, and remove `| 'SLOT'` from `NodeIconProps.type`.

## Test plan

- [ ] Apply a token to a slot in a component library
- [ ] Place the component in a working file and switch the page theme — slot should update
- [ ] Copy a component with slot tokens to a working file — tokens should persist
- [ ] Verify inspector shows a frame icon for slot nodes
- [ ] Run `yarn test` — all 1317 tests pass

---

_Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>_