### PR TITLE
feat(oauth): add real-time server-side token resolution via Studio gR…

### DIFF
--- a/.changeset/wild-apples-study.md
+++ b/.changeset/wild-apples-study.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Introduced server-side token resolution for Tokens Studio OAuth projects, leveraging our gRPC-backed engine to provide more accurate, theme-aware token values directly within the plugin.

--- a/packages/tokens-studio-for-figma/src/app/components/App.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/App.tsx
@@ -16,9 +16,13 @@ import LoadingBar from './LoadingBar';
 import { ConvertToDTCGModal } from './ConvertToDTCGModal';
 import Subscription from './Subscription';
 import { OAuthDeviceCodeModal } from './Login/OAuthDeviceCodeModal';
+import { useServerTokenResolver } from '@/app/hooks/useServerTokenResolver';
 
 function App() {
   const activeTab = useSelector(activeTabSelector);
+  // Watches activeTheme + token changes for OAuth projects and fires server-side
+  // resolution via the Studio gRPC-backed endpoint, storing results in Redux.
+  useServerTokenResolver();
 
   return (
     <Box css={{ isolation: 'isolate' }}>

--- a/packages/tokens-studio-for-figma/src/app/components/Inspector.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/Inspector.tsx
@@ -10,9 +10,9 @@ import InspectorDebugView from './InspectorDebugView';
 import InspectorMultiView from './InspectorMultiView';
 import IconDebug from '@/icons/debug.svg';
 import IconInspect from '@/icons/multiinspect.svg';
-import { Dispatch } from '../store';
+import { Dispatch, RootState } from '../store';
 import Label from './Label';
-import { mergeTokenGroups } from '@/utils/tokenHelpers';
+import { mergeTokenGroups, mergeServerResolvedTokens } from '@/utils/tokenHelpers';
 import { track } from '@/utils/analytics';
 import {
   inspectDeepSelector,
@@ -31,10 +31,14 @@ function Inspector() {
   const tokens = useSelector(tokensSelector);
   const usedTokenSet = useSelector(usedTokenSetSelector);
   const inspectDeep = useSelector(inspectDeepSelector);
+  const serverResolvedTokens = useSelector((state: RootState) => state.tokenState.serverResolvedTokens);
   // TODO: Put this into state in a performant way
   const resolvedTokens = React.useMemo(() => (
-    defaultTokenResolver.setTokens(mergeTokenGroups(tokens, usedTokenSet))
-  ), [tokens, usedTokenSet]);
+    mergeServerResolvedTokens(
+      defaultTokenResolver.setTokens(mergeTokenGroups(tokens, usedTokenSet)),
+      serverResolvedTokens,
+    )
+  ), [tokens, usedTokenSet, serverResolvedTokens]);
 
   const handleSetInspectView = React.useCallback((view: 'multi' | 'debug') => {
     if (view) {

--- a/packages/tokens-studio-for-figma/src/app/components/RemConfiguration.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/RemConfiguration.tsx
@@ -8,8 +8,8 @@ import {
 import remConfigurationImage from '@/app/assets/hints/remConfiguration.png';
 import IconBrokenLink from '@/icons/brokenlink.svg';
 import { TokenTypes } from '@/constants/TokenTypes';
-import { mergeTokenGroups } from '@/utils/tokenHelpers';
-import { Dispatch } from '../store';
+import { mergeTokenGroups, mergeServerResolvedTokens } from '@/utils/tokenHelpers';
+import { Dispatch, RootState } from '../store';
 import {
   tokensSelector, usedTokenSetSelector, activeTokenSetSelector, aliasBaseFontSizeSelector,
 } from '@/selectors';
@@ -31,11 +31,15 @@ const RemConfiguration = () => {
 
   const toggleModalVisible = React.useCallback(() => setModalVisible((prev) => !prev), []);
 
+  const serverResolvedTokens = useSelector((state: RootState) => state.tokenState.serverResolvedTokens);
   const resolvedTokens = React.useMemo(
-    () => defaultTokenResolver.setTokens(
-      mergeTokenGroups(tokens, usedTokenSet, {}, activeTokenSet),
+    () => mergeServerResolvedTokens(
+      defaultTokenResolver.setTokens(
+        mergeTokenGroups(tokens, usedTokenSet, {}, activeTokenSet),
+      ),
+      serverResolvedTokens,
     ),
-    [tokens, usedTokenSet, activeTokenSet],
+    [tokens, usedTokenSet, activeTokenSet, serverResolvedTokens],
   );
 
   const displayBaseFontValue = React.useMemo(() => {

--- a/packages/tokens-studio-for-figma/src/app/components/Tokens.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/Tokens.tsx
@@ -3,12 +3,12 @@ import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { AnimatePresence, motion } from 'framer-motion';
 import { ToggleGroup, IconButton } from '@tokens-studio/ui';
-import { mergeTokenGroups } from '@/utils/tokenHelpers';
+import { mergeTokenGroups, mergeServerResolvedTokens } from '@/utils/tokenHelpers';
 import TokenListing from './TokenListing';
 import TokensBottomBar from './TokensBottomBar';
 import ToggleEmptyButton from './ToggleEmptyButton';
 import { mappedTokens } from './createTokenObj';
-import { Dispatch } from '../store';
+import { Dispatch, RootState } from '../store';
 import TokenSetSelector from './TokenSetSelector';
 import TokenFilter from './TokenFilter';
 import EditTokenFormModal from './EditTokenFormModal';
@@ -93,6 +93,7 @@ function Tokens({ isActive }: { isActive: boolean }) {
   const scrollPositionSet = useSelector(scrollPositionSetSelector);
   const tokenFilter = useSelector(tokenFilterSelector);
   const aliasBaseFontSize = useSelector(aliasBaseFontSizeSelector);
+  const serverResolvedTokens = useSelector((state: RootState) => state.tokenState.serverResolvedTokens);
   const dispatch = useDispatch<Dispatch>();
   const [tokenSetsVisible, setTokenSetsVisible] = React.useState(true);
   const { getStringTokens } = useTokens();
@@ -111,8 +112,11 @@ function Tokens({ isActive }: { isActive: boolean }) {
   }, [activeTokenSet]);
 
   const resolvedTokens = React.useMemo(
-    () => defaultTokenResolver.setTokens(mergeTokenGroups(tokens, usedTokenSet, {}, activeTokenSet)),
-    [tokens, usedTokenSet, activeTokenSet],
+    () => mergeServerResolvedTokens(
+      defaultTokenResolver.setTokens(mergeTokenGroups(tokens, usedTokenSet, {}, activeTokenSet)),
+      serverResolvedTokens,
+    ),
+    [tokens, usedTokenSet, activeTokenSet, serverResolvedTokens],
   );
 
   const tokenType = useSelector(tokenTypeSelector);

--- a/packages/tokens-studio-for-figma/src/app/components/modals/LivingDocumentationModal.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/modals/LivingDocumentationModal.tsx
@@ -17,8 +17,9 @@ import {
   activeThemeSelector,
   themesListSelector,
 } from '@/selectors';
-import { mergeTokenGroups, getOverallConfig } from '@/utils/tokenHelpers';
+import { mergeTokenGroups, getOverallConfig, mergeServerResolvedTokens } from '@/utils/tokenHelpers';
 import { defaultTokenResolver } from '@/utils/TokenResolver';
+import { RootState } from '../../store';
 import { track } from '@/utils/analytics';
 
 const StyledCode = styled('code', {
@@ -60,6 +61,7 @@ export default function LivingDocumentationModal({
     }
   }, [isOpen, initialTokenSet, initialStartsWith]);
 
+  const serverResolvedTokens = useSelector((state: RootState) => state.tokenState.serverResolvedTokens);
   // Get resolved tokens using the same pattern as other components, including proper theme configuration
   const resolvedTokens = React.useMemo(() => {
     // Get the active theme IDs (activeTheme is Record<string, string>)
@@ -71,8 +73,11 @@ export default function LivingDocumentationModal({
     // Merge tokens with proper theme configuration
     const mergedTokens = mergeTokenGroups(tokens, usedTokenSet, overallConfig, activeTokenSet);
 
-    return defaultTokenResolver.setTokens(mergedTokens);
-  }, [tokens, usedTokenSet, activeTokenSet, activeTheme, themes]);
+    return mergeServerResolvedTokens(
+      defaultTokenResolver.setTokens(mergedTokens),
+      serverResolvedTokens,
+    );
+  }, [tokens, usedTokenSet, activeTokenSet, activeTheme, themes, serverResolvedTokens]);
 
   const handleTokenSetChange = React.useCallback((value: string) => {
     setTokenSet(value);

--- a/packages/tokens-studio-for-figma/src/app/hooks/useServerTokenResolver.ts
+++ b/packages/tokens-studio-for-figma/src/app/hooks/useServerTokenResolver.ts
@@ -84,12 +84,7 @@ export function useServerTokenResolver() {
         .filter(([, status]) => status === 'enabled')
         .map(([name]) => name);
 
-      console.log('[ServerResolver] Fetching resolved tokens from server…', {
-        projectId: serverResolverContext.projectId,
-        changeSetId: serverResolverContext.changeSetId,
-        themeSelections,
-        activeSets,
-      });
+
 
       const resolved = await fetchServerResolvedTokens({
         apiBaseUrl: serverResolverContext.apiBaseUrl,

--- a/packages/tokens-studio-for-figma/src/app/hooks/useServerTokenResolver.ts
+++ b/packages/tokens-studio-for-figma/src/app/hooks/useServerTokenResolver.ts
@@ -63,7 +63,7 @@ export function useServerTokenResolver() {
       storageProvider !== StorageProviderType.TOKENS_STUDIO_OAUTH
       || !serverResolverContext
     ) {
-      return;
+      return undefined;
     }
 
     // Clear any pending debounce

--- a/packages/tokens-studio-for-figma/src/app/hooks/useServerTokenResolver.ts
+++ b/packages/tokens-studio-for-figma/src/app/hooks/useServerTokenResolver.ts
@@ -108,7 +108,5 @@ export function useServerTokenResolver() {
         clearTimeout(debounceTimer.current);
       }
     };
-    // Deliberately omit buildThemeSelections from deps — theme/activeTheme already cover it
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeTheme, tokens, usedTokenSet, serverResolverContext, storageProvider, dispatch, lastSyncedState]);
+  }, [activeTheme, buildThemeSelections, tokens, usedTokenSet, serverResolverContext, storageProvider, dispatch, lastSyncedState]);
 }

--- a/packages/tokens-studio-for-figma/src/app/hooks/useServerTokenResolver.ts
+++ b/packages/tokens-studio-for-figma/src/app/hooks/useServerTokenResolver.ts
@@ -10,6 +10,7 @@ import {
 import { Dispatch, RootState } from '@/app/store';
 import { useAuthStore } from '@/app/store/useAuthStore';
 import { StorageProviderType } from '@/constants/StorageProviderType';
+import { TokenSetStatus } from '@/constants/TokenSetStatus';
 import { fetchServerResolvedTokens } from '@/utils/tokensStudio/fetchServerResolvedTokens';
 
 const SERVER_RESOLVE_DEBOUNCE_MS = 150;
@@ -81,7 +82,7 @@ export function useServerTokenResolver() {
 
       const themeSelections = buildThemeSelections();
       const activeSets = Object.entries(usedTokenSet)
-        .filter(([, status]) => status === 'enabled')
+        .filter(([, status]) => status === TokenSetStatus.ENABLED)
         .map(([name]) => name);
 
 

--- a/packages/tokens-studio-for-figma/src/app/hooks/useServerTokenResolver.ts
+++ b/packages/tokens-studio-for-figma/src/app/hooks/useServerTokenResolver.ts
@@ -86,6 +86,9 @@ export function useServerTokenResolver() {
 
 
 
+      // Clear any stale server-resolved tokens before starting a new fetch cycle
+      dispatch.tokenState.setServerResolvedTokens(null);
+
       const resolved = await fetchServerResolvedTokens({
         apiBaseUrl: serverResolverContext.apiBaseUrl,
         projectId: serverResolverContext.projectId,
@@ -95,10 +98,9 @@ export function useServerTokenResolver() {
         activeSets,
       });
 
-      // Dispatch the flat map directly — updateSources merges it on top of local resolution
-      if (resolved !== null) {
-        dispatch.tokenState.setServerResolvedTokens(resolved);
-      }
+      // Always dispatch — if the server returned null (error/no delta),
+      // we must ensure any previous delta is cleared so the UI falls back to local resolution.
+      dispatch.tokenState.setServerResolvedTokens(resolved);
     }, SERVER_RESOLVE_DEBOUNCE_MS);
 
     return () => {

--- a/packages/tokens-studio-for-figma/src/app/hooks/useServerTokenResolver.ts
+++ b/packages/tokens-studio-for-figma/src/app/hooks/useServerTokenResolver.ts
@@ -40,6 +40,7 @@ export function useServerTokenResolver() {
   const lastSyncedState = useSelector(lastSyncedStateSelector);
 
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const requestId = useRef(0);
 
   /**
    * Build theme_selections in the format the server expects:
@@ -85,7 +86,8 @@ export function useServerTokenResolver() {
         .filter(([, status]) => status === TokenSetStatus.ENABLED)
         .map(([name]) => name);
 
-
+      requestId.current += 1;
+      const thisRequest = requestId.current;
 
       // Clear any stale server-resolved tokens before starting a new fetch cycle
       dispatch.tokenState.setServerResolvedTokens(null);
@@ -98,6 +100,8 @@ export function useServerTokenResolver() {
         themeSelections,
         activeSets,
       });
+
+      if (thisRequest !== requestId.current) return;
 
       // Always dispatch — if the server returned null (error/no delta),
       // we must ensure any previous delta is cleared so the UI falls back to local resolution.

--- a/packages/tokens-studio-for-figma/src/app/hooks/useServerTokenResolver.ts
+++ b/packages/tokens-studio-for-figma/src/app/hooks/useServerTokenResolver.ts
@@ -5,6 +5,7 @@ import {
   themesListSelector,
   tokensSelector,
   usedTokenSetSelector,
+  lastSyncedStateSelector,
 } from '@/selectors';
 import { Dispatch, RootState } from '@/app/store';
 import { useAuthStore } from '@/app/store/useAuthStore';
@@ -35,6 +36,7 @@ export function useServerTokenResolver() {
     (state: RootState) => state.uiState.storageType?.provider,
   );
   const usedTokenSet = useSelector(usedTokenSetSelector);
+  const lastSyncedState = useSelector(lastSyncedStateSelector);
 
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -111,5 +113,5 @@ export function useServerTokenResolver() {
     };
     // Deliberately omit buildThemeSelections from deps — theme/activeTheme already cover it
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeTheme, tokens, usedTokenSet, serverResolverContext, storageProvider, dispatch]);
+  }, [activeTheme, tokens, usedTokenSet, serverResolverContext, storageProvider, dispatch, lastSyncedState]);
 }

--- a/packages/tokens-studio-for-figma/src/app/hooks/useServerTokenResolver.ts
+++ b/packages/tokens-studio-for-figma/src/app/hooks/useServerTokenResolver.ts
@@ -83,19 +83,15 @@ export function useServerTokenResolver() {
         themeSelections,
       });
 
-      const resolved = await fetchServerResolvedTokens(
-        {
-          apiBaseUrl: serverResolverContext.apiBaseUrl,
-          projectId: serverResolverContext.projectId,
-          changeSetId: serverResolverContext.changeSetId,
-          authToken: oauthTokens.accessToken,
-          themeSelections,
-        },
-        tokens,
-      );
+      const resolved = await fetchServerResolvedTokens({
+        apiBaseUrl: serverResolverContext.apiBaseUrl,
+        projectId: serverResolverContext.projectId,
+        changeSetId: serverResolverContext.changeSetId,
+        authToken: oauthTokens.accessToken,
+        themeSelections,
+      });
 
-      // Only update state if we got a valid response — errors leave the previous
-      // serverResolvedTokens intact (which may be null, causing local fallback)
+      // Dispatch the flat map directly — updateSources merges it on top of local resolution
       if (resolved !== null) {
         dispatch.tokenState.setServerResolvedTokens(resolved);
       }

--- a/packages/tokens-studio-for-figma/src/app/hooks/useServerTokenResolver.ts
+++ b/packages/tokens-studio-for-figma/src/app/hooks/useServerTokenResolver.ts
@@ -4,6 +4,7 @@ import {
   activeThemeSelector,
   themesListSelector,
   tokensSelector,
+  usedTokenSetSelector,
 } from '@/selectors';
 import { Dispatch, RootState } from '@/app/store';
 import { useAuthStore } from '@/app/store/useAuthStore';
@@ -33,6 +34,7 @@ export function useServerTokenResolver() {
   const storageProvider = useSelector(
     (state: RootState) => state.uiState.storageType?.provider,
   );
+  const usedTokenSet = useSelector(usedTokenSetSelector);
 
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -76,11 +78,15 @@ export function useServerTokenResolver() {
       if (!oauthTokens?.accessToken) return;
 
       const themeSelections = buildThemeSelections();
+      const activeSets = Object.entries(usedTokenSet)
+        .filter(([, status]) => status === 'enabled')
+        .map(([name]) => name);
 
       console.log('[ServerResolver] Fetching resolved tokens from server…', {
         projectId: serverResolverContext.projectId,
         changeSetId: serverResolverContext.changeSetId,
         themeSelections,
+        activeSets,
       });
 
       const resolved = await fetchServerResolvedTokens({
@@ -89,6 +95,7 @@ export function useServerTokenResolver() {
         changeSetId: serverResolverContext.changeSetId,
         authToken: oauthTokens.accessToken,
         themeSelections,
+        activeSets,
       });
 
       // Dispatch the flat map directly — updateSources merges it on top of local resolution
@@ -104,5 +111,5 @@ export function useServerTokenResolver() {
     };
     // Deliberately omit buildThemeSelections from deps — theme/activeTheme already cover it
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeTheme, tokens, serverResolverContext, storageProvider, dispatch]);
+  }, [activeTheme, tokens, usedTokenSet, serverResolverContext, storageProvider, dispatch]);
 }

--- a/packages/tokens-studio-for-figma/src/app/hooks/useServerTokenResolver.ts
+++ b/packages/tokens-studio-for-figma/src/app/hooks/useServerTokenResolver.ts
@@ -1,0 +1,112 @@
+import { useEffect, useRef, useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  activeThemeSelector,
+  themesListSelector,
+  tokensSelector,
+} from '@/selectors';
+import { Dispatch, RootState } from '@/app/store';
+import { useAuthStore } from '@/app/store/useAuthStore';
+import { StorageProviderType } from '@/constants/StorageProviderType';
+import { fetchServerResolvedTokens } from '@/utils/tokensStudio/fetchServerResolvedTokens';
+
+const SERVER_RESOLVE_DEBOUNCE_MS = 150;
+
+/**
+ * Mounts once at the app root (inside TokensContext.Provider).
+ * Whenever activeTheme, tokens, or usedTokenSet change and the project is
+ * connected via Tokens Studio OAuth, this hook debounces a call to the
+ * Studio gRPC-backed REST endpoint and stores the result in Redux as
+ * `tokenState.serverResolvedTokens`.
+ *
+ * On any failure it silently does nothing — callers fall back to the local
+ * TokenResolver automatically.
+ */
+export function useServerTokenResolver() {
+  const dispatch = useDispatch<Dispatch>();
+  const tokens = useSelector(tokensSelector);
+  const activeTheme = useSelector(activeThemeSelector);
+  const themes = useSelector(themesListSelector);
+  const serverResolverContext = useSelector(
+    (state: RootState) => state.tokenState.serverResolverContext,
+  );
+  const storageProvider = useSelector(
+    (state: RootState) => state.uiState.storageType?.provider,
+  );
+
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  /**
+   * Build theme_selections in the format the server expects:
+   *   { [themeGroupName]: themeOptionName }
+   *
+   * Plugin stores activeTheme as { [themeGroupId]: themeOptionId }.
+   * We resolve the names by looking them up in the full themes list.
+   */
+  const buildThemeSelections = useCallback((): Record<string, string> => {
+    const selections: Record<string, string> = {};
+    Object.entries(activeTheme).forEach(([groupId, optionId]) => {
+      const matchingTheme = themes.find(
+        (t) => t.id === optionId,
+      );
+      if (matchingTheme) {
+        // Use group name as key, option name as value
+        selections[matchingTheme.group || groupId] = matchingTheme.name;
+      }
+    });
+    return selections;
+  }, [activeTheme, themes]);
+
+  useEffect(() => {
+    // Only run for Tokens Studio OAuth projects that have a valid context
+    if (
+      storageProvider !== StorageProviderType.TOKENS_STUDIO_OAUTH
+      || !serverResolverContext
+    ) {
+      return;
+    }
+
+    // Clear any pending debounce
+    if (debounceTimer.current) {
+      clearTimeout(debounceTimer.current);
+    }
+
+    debounceTimer.current = setTimeout(async () => {
+      const { oauthTokens } = useAuthStore.getState();
+      if (!oauthTokens?.accessToken) return;
+
+      const themeSelections = buildThemeSelections();
+
+      console.log('[ServerResolver] Fetching resolved tokens from server…', {
+        projectId: serverResolverContext.projectId,
+        changeSetId: serverResolverContext.changeSetId,
+        themeSelections,
+      });
+
+      const resolved = await fetchServerResolvedTokens(
+        {
+          apiBaseUrl: serverResolverContext.apiBaseUrl,
+          projectId: serverResolverContext.projectId,
+          changeSetId: serverResolverContext.changeSetId,
+          authToken: oauthTokens.accessToken,
+          themeSelections,
+        },
+        tokens,
+      );
+
+      // Only update state if we got a valid response — errors leave the previous
+      // serverResolvedTokens intact (which may be null, causing local fallback)
+      if (resolved !== null) {
+        dispatch.tokenState.setServerResolvedTokens(resolved);
+      }
+    }, SERVER_RESOLVE_DEBOUNCE_MS);
+
+    return () => {
+      if (debounceTimer.current) {
+        clearTimeout(debounceTimer.current);
+      }
+    };
+    // Deliberately omit buildThemeSelections from deps — theme/activeTheme already cover it
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeTheme, tokens, serverResolverContext, storageProvider, dispatch]);
+}

--- a/packages/tokens-studio-for-figma/src/app/store/models/reducers/tokenState/setTokenData.ts
+++ b/packages/tokens-studio-for-figma/src/app/store/models/reducers/tokenState/setTokenData.ts
@@ -61,5 +61,6 @@ export function setTokenData(state: TokenState, payload: SetTokenDataPayload): T
     usedTokenSet: Array.isArray(payload.values) ? { global: TokenSetStatus.ENABLED } : usedTokenSets,
     tokensSize,
     themesSize,
+    serverResolvedTokens: null,
   };
 }

--- a/packages/tokens-studio-for-figma/src/app/store/models/tokenState.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/models/tokenState.tsx
@@ -885,7 +885,7 @@ export const tokenState = createModel<RootModel>()({
     },
     setServerResolvedTokens() {
       // Trigger document update whenever server-resolved tokens change
-      dispatch.tokenState.updateDocument({ shouldUpdateNodes: true });
+      dispatch.tokenState.updateDocument({ shouldUpdateNodes: true, updateRemote: false });
     },
     toggleUsedTokenSet() {
       dispatch.tokenState.updateDocument({ updateRemote: false });

--- a/packages/tokens-studio-for-figma/src/app/store/models/tokenState.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/models/tokenState.tsx
@@ -57,6 +57,15 @@ import { CreateSingleTokenData, EditSingleTokenData } from '../useManageTokens';
 import { singleTokensToRawTokenSet } from '@/utils/convert';
 import { checkStorageSize } from '@/utils/checkStorageSize';
 import { compareLastSyncedState } from '@/utils/compareLastSyncedState';
+import { ResolveTokenValuesResult } from '@/utils/tokenHelpers';
+
+
+/** Context required to call the Studio gRPC-backed resolver endpoint */
+export interface ServerResolverContext {
+  projectId: string;
+  changeSetId: string;
+  apiBaseUrl: string;
+}
 
 export interface TokenState {
   tokens: Record<string, AnyTokenList>;
@@ -89,6 +98,10 @@ export interface TokenState {
   tokensSize: number;
   themesSize: number;
   renamedCollections: [string, string][] | null;
+  /** Set when connected via Tokens Studio OAuth — used to call the gRPC resolver */
+  serverResolverContext: ServerResolverContext | null;
+  /** Last resolved token list fetched from the Studio server. null = use local resolver */
+  serverResolvedTokens: ResolveTokenValuesResult[] | null;
 }
 
 export const tokenState = createModel<RootModel>()({
@@ -134,6 +147,8 @@ export const tokenState = createModel<RootModel>()({
     tokensSize: 0,
     themesSize: 0,
     renamedCollections: null,
+    serverResolverContext: null,
+    serverResolvedTokens: null,
   } as unknown as TokenState,
   reducers: {
     setTokensSize: (state, size: number) => ({
@@ -720,6 +735,16 @@ export const tokenState = createModel<RootModel>()({
       compressedTokens: payload.compressedTokens,
       compressedThemes: payload.compressedThemes,
     }),
+    setServerResolverContext: (state, payload: ServerResolverContext | null): TokenState => ({
+      ...state,
+      serverResolverContext: payload,
+      // Clear cached server results whenever the context changes (e.g. branch switch)
+      serverResolvedTokens: null,
+    }),
+    setServerResolvedTokens: (state, payload: ResolveTokenValuesResult[] | null): TokenState => ({
+      ...state,
+      serverResolvedTokens: payload,
+    }),
     ...tokenStateReducers,
   },
   effects: (dispatch) => ({
@@ -992,6 +1017,7 @@ export const tokenState = createModel<RootModel>()({
               tokenFormat: rootState.tokenState.tokenFormat,
               tokensSize: rootState.tokenState.tokensSize,
               themesSize: rootState.tokenState.themesSize,
+              serverResolvedTokens: rootState.tokenState.serverResolvedTokens,
             });
           },
         );

--- a/packages/tokens-studio-for-figma/src/app/store/models/tokenState.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/models/tokenState.tsx
@@ -57,7 +57,7 @@ import { CreateSingleTokenData, EditSingleTokenData } from '../useManageTokens';
 import { singleTokensToRawTokenSet } from '@/utils/convert';
 import { checkStorageSize } from '@/utils/checkStorageSize';
 import { compareLastSyncedState } from '@/utils/compareLastSyncedState';
-import { ResolveTokenValuesResult } from '@/utils/tokenHelpers';
+
 
 
 /** Context required to call the Studio gRPC-backed resolver endpoint */

--- a/packages/tokens-studio-for-figma/src/app/store/models/tokenState.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/models/tokenState.tsx
@@ -100,8 +100,13 @@ export interface TokenState {
   renamedCollections: [string, string][] | null;
   /** Set when connected via Tokens Studio OAuth — used to call the gRPC resolver */
   serverResolverContext: ServerResolverContext | null;
-  /** Last resolved token list fetched from the Studio server. null = use local resolver */
-  serverResolvedTokens: ResolveTokenValuesResult[] | null;
+  /**
+   * Flat map of tokenName → resolved value string, as returned by the Studio gRPC server.
+   * Only contains theme-affected tokens (delta), not the full token set.
+   * These values are merged on top of local resolution in updateSources.
+   * null = server hasn't responded yet or is unavailable → use local resolver only.
+   */
+  serverResolvedTokens: Record<string, string> | null;
 }
 
 export const tokenState = createModel<RootModel>()({
@@ -741,7 +746,7 @@ export const tokenState = createModel<RootModel>()({
       // Clear cached server results whenever the context changes (e.g. branch switch)
       serverResolvedTokens: null,
     }),
-    setServerResolvedTokens: (state, payload: ResolveTokenValuesResult[] | null): TokenState => ({
+    setServerResolvedTokens: (state, payload: Record<string, string> | null): TokenState => ({
       ...state,
       serverResolvedTokens: payload,
     }),

--- a/packages/tokens-studio-for-figma/src/app/store/models/tokenState.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/models/tokenState.tsx
@@ -746,10 +746,15 @@ export const tokenState = createModel<RootModel>()({
       // Clear cached server results whenever the context changes (e.g. branch switch)
       serverResolvedTokens: null,
     }),
-    setServerResolvedTokens: (state, payload: Record<string, string> | null): TokenState => ({
-      ...state,
-      serverResolvedTokens: payload,
-    }),
+    setServerResolvedTokens: (state, payload: Record<string, string> | null): TokenState => {
+      if (isEqual(state.serverResolvedTokens, payload)) {
+        return state;
+      }
+      return {
+        ...state,
+        serverResolvedTokens: payload,
+      };
+    },
     ...tokenStateReducers,
   },
   effects: (dispatch) => ({
@@ -877,6 +882,10 @@ export const tokenState = createModel<RootModel>()({
       if (payload.shouldUpdate) {
         dispatch.tokenState.updateDocument();
       }
+    },
+    setServerResolvedTokens() {
+      // Trigger document update whenever server-resolved tokens change
+      dispatch.tokenState.updateDocument({ shouldUpdateNodes: true });
     },
     toggleUsedTokenSet() {
       dispatch.tokenState.updateDocument({ updateRemote: false });

--- a/packages/tokens-studio-for-figma/src/app/store/providers/tokens-studio/tokensStudioOAuth.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/tokens-studio/tokensStudioOAuth.tsx
@@ -86,6 +86,11 @@ export function useTokensStudioOAuth() {
         const projectData = await fetchProjectDataRest(oauthTokens.accessToken, apiBaseUrl, context.id, context.branch || 'main');
         if (projectData) {
           dispatch.tokenState.setEditProhibited(true);
+          dispatch.tokenState.setServerResolverContext({
+            projectId: context.id,
+            changeSetId: projectData.changeSetId,
+            apiBaseUrl,
+          });
           if (projectData.hasExceededPaginationLimit) {
             notifyToUI('Maximum limit of 10,000 tokens reached. Some tokens may be missing.', { error: true });
           }
@@ -259,6 +264,11 @@ export function useTokensStudioOAuth() {
           const stringifiedRemoteTokens = JSON.stringify(compact([newTokens, alignedNewThemes, TokenFormat.format]), null, 2);
           dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
           dispatch.tokenState.setEditProhibited(true);
+          dispatch.tokenState.setServerResolverContext({
+            projectId,
+            changeSetId: projectData.changeSetId,
+            apiBaseUrl,
+          });
 
           dispatch.uiState.setLastError(null);
 

--- a/packages/tokens-studio-for-figma/src/app/store/remoteTokens.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/remoteTokens.tsx
@@ -14,7 +14,7 @@ import { useADO } from './providers/ado';
 import useFile from '@/app/store/providers/file';
 import { BackgroundJobs } from '@/constants/BackgroundJobs';
 import {
-  activeTabSelector, apiSelector, themesListSelector, tokensSelector,
+  activeTabSelector, apiSelector, themesListSelector, tokensSelector, activeThemeSelector, usedTokenSetSelector,
 } from '@/selectors';
 import { ThemeObject, UsedTokenSetsMap } from '@/types';
 import { AsyncMessageTypes } from '@/types/AsyncMessages';
@@ -52,6 +52,8 @@ export default function useRemoteTokens() {
   const tokens = useSelector(tokensSelector);
   const themes = useSelector(themesListSelector);
   const activeTab = useSelector(activeTabSelector);
+  const currentActiveTheme = useSelector(activeThemeSelector);
+  const currentUsedTokenSet = useSelector(usedTokenSetSelector);
   const { showPullDialog, closePullDialog, showPullDialogError } = usePullDialog();
 
   const { setStorageType } = useStorage();
@@ -111,8 +113,8 @@ export default function useRemoteTokens() {
   const pullTokens = useCallback(
     async ({
       context = api,
-      usedTokenSet,
-      activeTheme,
+      usedTokenSet = currentUsedTokenSet,
+      activeTheme = currentActiveTheme,
       collapsedTokenSets,
       updateLocalTokens = false,
       skipConfirmation = false,
@@ -323,6 +325,8 @@ export default function useRemoteTokens() {
       tokens,
       themes,
       activeTab,
+      currentActiveTheme,
+      currentUsedTokenSet,
       dispatch,
       api,
       pullTokensFromGenericVersionedStorage,

--- a/packages/tokens-studio-for-figma/src/app/store/updateSources.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/updateSources.tsx
@@ -178,11 +178,7 @@ export default async function updateTokensOnSources({
     ? mergeServerResolvedTokens(locallyResolved, serverResolvedTokens)
     : null;
 
-  if (locallyResolved && serverResolvedTokens && Object.keys(serverResolvedTokens).length > 0) {
-    console.log(`[gRPC Resolver] Merged ${Object.keys(serverResolvedTokens).length} server-resolved values into ${locallyResolved.length} local tokens ✓`);
-  } else if (locallyResolved) {
-    console.log('[gRPC Resolver] Using local TokenResolver only (no server delta available)');
-  }
+
 
   const tokensSize = (compressedTokens.length / 1024) * 2; // UTF-16 uses 2 bytes per character
   const themesSize = (compressedThemes.length / 1024) * 2;

--- a/packages/tokens-studio-for-figma/src/app/store/updateSources.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/updateSources.tsx
@@ -51,8 +51,8 @@ type UpdateTokensOnSourcesPayload = {
   tokenFormat: TokenFormatOptions
   tokensSize: number
   themesSize: number
-  /** Pre-resolved tokens from the Studio server (gRPC resolver). When present, skip local resolution. */
-  serverResolvedTokens?: ResolveTokenValuesResult[] | null;
+  /** Flat map of tokenName → resolved value from the Studio gRPC server (theme delta only). */
+  serverResolvedTokens?: Record<string, string> | null;
 };
 
 async function updateRemoteTokens({
@@ -166,10 +166,24 @@ export default async function updateTokensOnSources({
     });
   }
 
-  // When server-resolved tokens are available (OAuth + gRPC resolver responded),
-  // use them directly. Otherwise fall back to the local TypeScript resolver.
-  const mergedTokens = serverResolvedTokens
-    ?? (tokens ? defaultTokenResolver.setTokens(mergeTokenGroups(tokens, usedTokenSet)) : null);
+  // Always run local resolution to get the complete token list.
+  const locallyResolved = tokens
+    ? defaultTokenResolver.setTokens(mergeTokenGroups(tokens, usedTokenSet))
+    : null;
+
+  // If the server returned theme-specific overrides, merge them on top.
+  // The server delta takes precedence for the tokens it resolved; all other
+  // tokens retain their locally-resolved values.
+  let mergedTokens = locallyResolved;
+  if (locallyResolved && serverResolvedTokens && Object.keys(serverResolvedTokens).length > 0) {
+    mergedTokens = locallyResolved.map((token) => {
+      const serverValue = serverResolvedTokens[token.name];
+      return serverValue !== undefined ? { ...token, value: serverValue } : token;
+    }) as typeof locallyResolved;
+    console.log(`[gRPC Resolver] Merged ${Object.keys(serverResolvedTokens).length} server-resolved values into ${locallyResolved.length} local tokens ✓`);
+  } else {
+    console.log('[gRPC Resolver] Using local TokenResolver only (no server delta available)');
+  }
 
   const tokensSize = (compressedTokens.length / 1024) * 2; // UTF-16 uses 2 bytes per character
   const themesSize = (compressedThemes.length / 1024) * 2;

--- a/packages/tokens-studio-for-figma/src/app/store/updateSources.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/updateSources.tsx
@@ -1,5 +1,5 @@
 import { startTransaction } from '@sentry/react';
-import { mergeTokenGroups } from '@/utils/tokenHelpers';
+import { mergeTokenGroups, mergeServerResolvedTokens } from '@/utils/tokenHelpers';
 
 import { Dispatch } from '@/app/store';
 import { notifyToUI } from '../../plugin/notifiers';
@@ -174,14 +174,13 @@ export default async function updateTokensOnSources({
   // If the server returned theme-specific overrides, merge them on top.
   // The server delta takes precedence for the tokens it resolved; all other
   // tokens retain their locally-resolved values.
-  let mergedTokens = locallyResolved;
+  const mergedTokens = locallyResolved
+    ? mergeServerResolvedTokens(locallyResolved, serverResolvedTokens)
+    : null;
+
   if (locallyResolved && serverResolvedTokens && Object.keys(serverResolvedTokens).length > 0) {
-    mergedTokens = locallyResolved.map((token) => {
-      const serverValue = serverResolvedTokens[token.name];
-      return serverValue !== undefined ? { ...token, value: serverValue } : token;
-    }) as typeof locallyResolved;
     console.log(`[gRPC Resolver] Merged ${Object.keys(serverResolvedTokens).length} server-resolved values into ${locallyResolved.length} local tokens ✓`);
-  } else {
+  } else if (locallyResolved) {
     console.log('[gRPC Resolver] Using local TokenResolver only (no server delta available)');
   }
 

--- a/packages/tokens-studio-for-figma/src/app/store/updateSources.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/updateSources.tsx
@@ -1,5 +1,6 @@
 import { startTransaction } from '@sentry/react';
 import { mergeTokenGroups } from '@/utils/tokenHelpers';
+import type { ResolveTokenValuesResult } from '@/utils/tokenHelpers';
 import { Dispatch } from '@/app/store';
 import { notifyToUI } from '../../plugin/notifiers';
 import { updateJSONBinTokens } from './providers/jsonbin';
@@ -50,6 +51,8 @@ type UpdateTokensOnSourcesPayload = {
   tokenFormat: TokenFormatOptions
   tokensSize: number
   themesSize: number
+  /** Pre-resolved tokens from the Studio server (gRPC resolver). When present, skip local resolution. */
+  serverResolvedTokens?: ResolveTokenValuesResult[] | null;
 };
 
 async function updateRemoteTokens({
@@ -148,6 +151,7 @@ export default async function updateTokensOnSources({
   tokenFormat,
   compressedTokens,
   compressedThemes,
+  serverResolvedTokens,
 }: UpdateTokensOnSourcesPayload) {
   if (tokenValues && !isLocal && shouldUpdateRemote && !editProhibited) {
     updateRemoteTokens({
@@ -162,9 +166,10 @@ export default async function updateTokensOnSources({
     });
   }
 
-  const mergedTokens = tokens
-    ? defaultTokenResolver.setTokens(mergeTokenGroups(tokens, usedTokenSet))
-    : null;
+  // When server-resolved tokens are available (OAuth + gRPC resolver responded),
+  // use them directly. Otherwise fall back to the local TypeScript resolver.
+  const mergedTokens = serverResolvedTokens
+    ?? (tokens ? defaultTokenResolver.setTokens(mergeTokenGroups(tokens, usedTokenSet)) : null);
 
   const tokensSize = (compressedTokens.length / 1024) * 2; // UTF-16 uses 2 bytes per character
   const themesSize = (compressedThemes.length / 1024) * 2;

--- a/packages/tokens-studio-for-figma/src/app/store/updateSources.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/updateSources.tsx
@@ -1,6 +1,6 @@
 import { startTransaction } from '@sentry/react';
 import { mergeTokenGroups } from '@/utils/tokenHelpers';
-import type { ResolveTokenValuesResult } from '@/utils/tokenHelpers';
+
 import { Dispatch } from '@/app/store';
 import { notifyToUI } from '../../plugin/notifiers';
 import { updateJSONBinTokens } from './providers/jsonbin';

--- a/packages/tokens-studio-for-figma/src/app/store/useTokens.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/useTokens.tsx
@@ -3,7 +3,9 @@ import { useCallback, useMemo, useContext } from 'react';
 import { AnyTokenList, SingleToken, TokenToRename } from '@/types/tokens';
 import stringifyTokens from '@/utils/stringifyTokens';
 import formatTokens from '@/utils/formatTokens';
-import { getEnabledTokenSets, getOverallConfig, mergeTokenGroups } from '@/utils/tokenHelpers';
+import {
+  getEnabledTokenSets, getOverallConfig, mergeTokenGroups, mergeServerResolvedTokens,
+} from '@/utils/tokenHelpers';
 import useConfirm from '../hooks/useConfirm';
 import { Properties } from '@/constants/Properties';
 import { track } from '@/utils/analytics';
@@ -350,6 +352,8 @@ export default function useTokens() {
     [activeTokenSet, tokens, confirm, handleBulkRemap, dispatch.tokenState, settings],
   );
 
+  const serverResolvedTokens = useSelector((state: RootState) => state.tokenState.serverResolvedTokens);
+
   // Asks user which styles to create, then calls Figma with all tokens to create styles
   const createStylesFromSelectedTokenSets = useCallback(
     async (selectedSets: ExportTokenSet[]) => {
@@ -377,7 +381,10 @@ export default function useTokens() {
 
       const tokensToResolve = mergeTokenGroups(tokens, selectedSetsMap);
 
-      const resolved = defaultTokenResolver.setTokens(tokensToResolve);
+      const resolved = mergeServerResolvedTokens(
+        defaultTokenResolver.setTokens(tokensToResolve),
+        serverResolvedTokens,
+      );
       const withoutSourceTokens = resolved.filter(
         (token) => !token.internal__Parent || enabledTokenSets.includes(token.internal__Parent), // filter out SOURCE tokens
       );
@@ -420,7 +427,7 @@ export default function useTokens() {
 
       dispatch.uiState.completeJob(BackgroundJobs.UI_CREATE_STYLES);
     },
-    [tokens, settings, dispatch.uiState],
+    [tokens, settings, dispatch.uiState, serverResolvedTokens],
   );
 
   const createStylesFromSelectedThemes = useCallback(
@@ -459,7 +466,10 @@ export default function useTokens() {
 
           if (enabledTokenSets.length > 0) {
             const tokensToResolve = mergeTokenGroups(tokens, selectedSets, overallConfig);
-            const allTokens = defaultTokenResolver.setTokens(tokensToResolve);
+            const allTokens = mergeServerResolvedTokens(
+              defaultTokenResolver.setTokens(tokensToResolve),
+              serverResolvedTokens,
+            );
 
             const tokensFromEnabledSets = allTokens.filter(
               (token) => !token.internal__Parent || enabledTokenSets.includes(token.internal__Parent), // only use enabled sets
@@ -530,7 +540,7 @@ export default function useTokens() {
 
       dispatch.uiState.completeJob(BackgroundJobs.UI_CREATE_STYLES);
     },
-    [dispatch.tokenState, tokens, settings, themes, dispatch.uiState],
+    [dispatch.tokenState, tokens, settings, themes, dispatch.uiState, serverResolvedTokens],
   );
 
   const renameStylesFromTokens = useCallback(

--- a/packages/tokens-studio-for-figma/src/plugin/generateTokensToCreate.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/generateTokensToCreate.ts
@@ -11,21 +11,33 @@ export function generateTokensToCreate({
   filterByTokenSet,
   overallConfig = {},
   themeTokenResolver,
+  preResolvedTokens,
 }: {
   theme: ThemeObject;
   tokens: Record<string, AnyTokenList>;
   filterByTokenSet?: string;
   overallConfig?: UsedTokenSetsMap;
   themeTokenResolver?: TokenResolver;
+  /**
+   * Optional pre-resolved tokens from the Studio server (gRPC resolver).
+   * When provided, skips local mergeTokenGroups + TokenResolver entirely
+   * so resolved values match exactly what the Studio web app shows.
+   */
+  preResolvedTokens?: ResolveTokenValuesResult[];
 }): { tokensToCreate: ResolveTokenValuesResult[]; resolvedTokens: ResolveTokenValuesResult[] } {
-  // Big O(resolveTokenValues * mergeTokenGroups)
   const enabledTokenSets = Object.entries(theme.selectedTokenSets)
     .filter(([name, status]) => status === TokenSetStatus.ENABLED && (!filterByTokenSet || name === filterByTokenSet))
     .map(([tokenSet]) => tokenSet);
-  // Create a separate TokenResolver instance for this theme to avoid interference
-  // when multiple themes are processed concurrently (if not provided)
-  const resolver = themeTokenResolver || new TokenResolver([]);
-  const resolved = resolver.setTokens(mergeTokenGroups(tokens, theme.selectedTokenSets, overallConfig));
+
+  // Use server-resolved tokens when available to guarantee consistency with the Studio app.
+  // Otherwise fall back to local resolution.
+  const resolved: ResolveTokenValuesResult[] = preResolvedTokens
+    ?? (() => {
+      const resolver = themeTokenResolver || new TokenResolver([]);
+      return resolver.setTokens(mergeTokenGroups(tokens, theme.selectedTokenSets, overallConfig));
+    })();
+
+  // Big O(resolveTokenValues * mergeTokenGroups) — only applies for local resolution path
   const tokensToCreate = resolved.filter(
     (token) => ((!token.internal__Parent || enabledTokenSets.includes(token.internal__Parent)) && tokenTypesToCreateVariable.includes(token.type)), // filter out SOURCE tokens
   );

--- a/packages/tokens-studio-for-figma/src/utils/__tests__/mergeServerResolvedTokens.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/__tests__/mergeServerResolvedTokens.test.ts
@@ -1,0 +1,49 @@
+import { mergeServerResolvedTokens, ResolveTokenValuesResult } from '../tokenHelpers';
+import { TokenTypes } from '@/constants/TokenTypes';
+
+describe('mergeServerResolvedTokens', () => {
+  const localTokens: ResolveTokenValuesResult[] = [
+    {
+      name: 'color.primary',
+      value: 'lighten(#000000, 0.2)',
+      type: TokenTypes.COLOR,
+    },
+    {
+      name: 'spacing.medium',
+      value: '16px',
+      type: TokenTypes.SPACING,
+    },
+  ] as ResolveTokenValuesResult[];
+
+  it('should return local tokens if no server resolved tokens are provided', () => {
+    expect(mergeServerResolvedTokens(localTokens, null)).toEqual(localTokens);
+    expect(mergeServerResolvedTokens(localTokens, {})).toEqual(localTokens);
+  });
+
+  it('should merge server resolved tokens into local tokens', () => {
+    const serverDelta = {
+      'color.primary': '#333333',
+    };
+    const expected = [
+      {
+        name: 'color.primary',
+        value: '#333333',
+        type: TokenTypes.COLOR,
+        failedToResolve: false,
+      },
+      {
+        name: 'spacing.medium',
+        value: '16px',
+        type: TokenTypes.SPACING,
+      },
+    ];
+    expect(mergeServerResolvedTokens(localTokens, serverDelta)).toEqual(expected);
+  });
+
+  it('should handle tokens not present in the server delta', () => {
+    const serverDelta = {
+      'other.token': 'foo',
+    };
+    expect(mergeServerResolvedTokens(localTokens, serverDelta)).toEqual(localTokens);
+  });
+});

--- a/packages/tokens-studio-for-figma/src/utils/tokenHelpers.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokenHelpers.ts
@@ -90,3 +90,31 @@ export function mergeTokenGroups(
     return mergedTokens;
   }, [] as SingleToken[]);
 }
+/**
+ * Merges server-side resolved tokens (gRPC delta) on top of locally-resolved tokens.
+ * Only tokens present in the server delta are updated; others retain their local values.
+ *
+ * @param locallyResolved - List of tokens resolved by the local TokenResolver
+ * @param serverResolvedTokens - Flat map of { tokenName: "resolvedValue" } from the Studio server
+ */
+export function mergeServerResolvedTokens(
+  locallyResolved: ResolveTokenValuesResult[],
+  serverResolvedTokens?: Record<string, string> | null,
+): ResolveTokenValuesResult[] {
+  if (!locallyResolved || !serverResolvedTokens || Object.keys(serverResolvedTokens).length === 0) {
+    return locallyResolved;
+  }
+
+  return locallyResolved.map((token) => {
+    const serverValue = serverResolvedTokens[token.name];
+    if (serverValue !== undefined) {
+      return {
+        ...token,
+        value: serverValue,
+        // Since we got a value from the server, it's considered successfully resolved
+        failedToResolve: false,
+      } as ResolveTokenValuesResult;
+    }
+    return token;
+  });
+}

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchProjectDataRest.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchProjectDataRest.ts
@@ -30,6 +30,8 @@ export type ProjectData = {
   tokenSets: Record<string, { isDynamic: boolean }>;
   tokenSetOrder: string[];
   hasExceededPaginationLimit?: boolean;
+  /** The change_set_id for the resolved branch — used for server-side token resolution */
+  changeSetId: string;
 };
 
 function transformTokenValue(token: any): unknown {
@@ -274,6 +276,7 @@ export async function fetchProjectDataRest(
       tokenSets: tokenSetsMap,
       tokenSetOrder,
       hasExceededPaginationLimit,
+      changeSetId,
     };
   } catch (error) {
     console.error('Error fetching project data from REST API:', error);

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchServerResolvedTokens.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchServerResolvedTokens.test.ts
@@ -1,0 +1,139 @@
+import { TokenTypes } from '@/constants/TokenTypes';
+import { AnyTokenList } from '@/types/tokens';
+import { fetchServerResolvedTokens } from './fetchServerResolvedTokens';
+
+// Mock global fetch
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+const BASE_OPTIONS = {
+  apiBaseUrl: 'https://api.tokens.studio',
+  projectId: 'proj-123',
+  changeSetId: 'cs-456',
+  authToken: 'test-token',
+  themeSelections: { Mode: 'Dark' },
+};
+
+// Typed fixture matching AnyTokenList element requirements
+const RAW_TOKENS: Record<string, AnyTokenList> = {
+  'core/colors': [
+    {
+      name: 'color.primary', value: '{core.red.500}', type: TokenTypes.COLOR,
+    },
+    {
+      name: 'core.red.500', value: '#FF0000', type: TokenTypes.COLOR,
+    },
+  ] as AnyTokenList,
+};
+
+describe('fetchServerResolvedTokens', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  it('returns null on a 4xx response', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404, statusText: 'Not Found' });
+
+    const result = await fetchServerResolvedTokens(BASE_OPTIONS, RAW_TOKENS);
+    expect(result).toBeNull();
+  });
+
+  it('returns null on a 5xx response', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500, statusText: 'Internal Server Error' });
+
+    const result = await fetchServerResolvedTokens(BASE_OPTIONS, RAW_TOKENS);
+    expect(result).toBeNull();
+  });
+
+  it('returns null on a network error', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Network failure'));
+
+    const result = await fetchServerResolvedTokens(BASE_OPTIONS, RAW_TOKENS);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when server response is not an object', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => null,
+    });
+
+    const result = await fetchServerResolvedTokens(BASE_OPTIONS, RAW_TOKENS);
+    expect(result).toBeNull();
+  });
+
+  it('maps flat server response { tokenName: resolvedValue } to ResolveTokenValuesResult[]', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        'color.primary': '#FF0000',
+        'color.secondary': '#0000FF',
+      }),
+    });
+
+    const result = await fetchServerResolvedTokens(BASE_OPTIONS, RAW_TOKENS);
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(2);
+
+    const primary = result!.find((t) => t.name === 'color.primary');
+    expect(primary).toBeDefined();
+    expect(primary!.value).toBe('#FF0000');
+    expect(primary!.failedToResolve).toBe(false);
+    expect(primary!.type).toBe(TokenTypes.COLOR);
+  });
+
+  it('maps nested { data: { tokens: {...} } } server response shape', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: {
+          tokens: {
+            'color.primary': '#FF0000',
+          },
+        },
+      }),
+    });
+
+    const result = await fetchServerResolvedTokens(BASE_OPTIONS, RAW_TOKENS);
+    expect(result).toHaveLength(1);
+    expect(result![0].name).toBe('color.primary');
+    expect(result![0].value).toBe('#FF0000');
+  });
+
+  it('sets rawValue to the original alias reference', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ 'color.primary': '#FF0000' }),
+    });
+
+    const result = await fetchServerResolvedTokens(BASE_OPTIONS, RAW_TOKENS);
+    const primary = result!.find((t) => t.name === 'color.primary');
+    expect(primary!.rawValue).toBe('{core.red.500}');
+  });
+
+  it('sends POST request with correct URL, auth header, and body', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({}),
+    });
+
+    await fetchServerResolvedTokens(BASE_OPTIONS, RAW_TOKENS);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.tokens.studio/api/v1/projects/proj-123/resolved_tokens',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer test-token',
+          'Content-Type': 'application/json',
+        }),
+        body: JSON.stringify({
+          change_set_id: 'cs-456',
+          theme_selections: { Mode: 'Dark' },
+        }),
+      }),
+    );
+  });
+});

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchServerResolvedTokens.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchServerResolvedTokens.test.ts
@@ -17,6 +17,7 @@ describe('fetchServerResolvedTokens', () => {
     jest.clearAllMocks();
     jest.spyOn(console, 'log').mockImplementation(() => {});
     jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(Date, 'now').mockReturnValue(1777406477644);
   });
 
   it('returns null on a 4xx response', async () => {
@@ -87,13 +88,18 @@ describe('fetchServerResolvedTokens', () => {
 
     await fetchServerResolvedTokens(BASE_OPTIONS);
 
-    const expectedParams = new URLSearchParams({ change_set_id: 'cs-456', Mode: 'Dark' });
+    const expectedParams = new URLSearchParams({ 
+      change_set_id: 'cs-456', 
+      t: '1777406477644',
+      Mode: 'Dark',
+    });
     expect(mockFetch).toHaveBeenCalledWith(
       `https://api.tokens.studio/api/v1/projects/proj-123/resolved_tokens?${expectedParams.toString()}`,
       expect.objectContaining({
         method: 'GET',
         headers: expect.objectContaining({
           Authorization: 'Bearer test-token',
+          'Content-Type': 'application/json',
         }),
       }),
     );

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchServerResolvedTokens.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchServerResolvedTokens.test.ts
@@ -1,5 +1,3 @@
-import { TokenTypes } from '@/constants/TokenTypes';
-import { AnyTokenList } from '@/types/tokens';
 import { fetchServerResolvedTokens } from './fetchServerResolvedTokens';
 
 // Mock global fetch
@@ -14,18 +12,6 @@ const BASE_OPTIONS = {
   themeSelections: { Mode: 'Dark' },
 };
 
-// Typed fixture matching AnyTokenList element requirements
-const RAW_TOKENS: Record<string, AnyTokenList> = {
-  'core/colors': [
-    {
-      name: 'color.primary', value: '{core.red.500}', type: TokenTypes.COLOR,
-    },
-    {
-      name: 'core.red.500', value: '#FF0000', type: TokenTypes.COLOR,
-    },
-  ] as AnyTokenList,
-};
-
 describe('fetchServerResolvedTokens', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -36,104 +22,98 @@ describe('fetchServerResolvedTokens', () => {
   it('returns null on a 4xx response', async () => {
     mockFetch.mockResolvedValueOnce({ ok: false, status: 404, statusText: 'Not Found' });
 
-    const result = await fetchServerResolvedTokens(BASE_OPTIONS, RAW_TOKENS);
+    const result = await fetchServerResolvedTokens(BASE_OPTIONS);
     expect(result).toBeNull();
   });
 
   it('returns null on a 5xx response', async () => {
     mockFetch.mockResolvedValueOnce({ ok: false, status: 500, statusText: 'Internal Server Error' });
 
-    const result = await fetchServerResolvedTokens(BASE_OPTIONS, RAW_TOKENS);
+    const result = await fetchServerResolvedTokens(BASE_OPTIONS);
     expect(result).toBeNull();
   });
 
   it('returns null on a network error', async () => {
     mockFetch.mockRejectedValueOnce(new Error('Network failure'));
 
-    const result = await fetchServerResolvedTokens(BASE_OPTIONS, RAW_TOKENS);
+    const result = await fetchServerResolvedTokens(BASE_OPTIONS);
     expect(result).toBeNull();
   });
 
-  it('returns null when server response is not an object', async () => {
+  it('returns null when response data is not a plain object', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: async () => null,
+      json: async () => ({ data: null }),
     });
 
-    const result = await fetchServerResolvedTokens(BASE_OPTIONS, RAW_TOKENS);
+    const result = await fetchServerResolvedTokens(BASE_OPTIONS);
     expect(result).toBeNull();
   });
 
-  it('maps flat server response { tokenName: resolvedValue } to ResolveTokenValuesResult[]', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        'color.primary': '#FF0000',
-        'color.secondary': '#0000FF',
-      }),
-    });
-
-    const result = await fetchServerResolvedTokens(BASE_OPTIONS, RAW_TOKENS);
-    expect(result).not.toBeNull();
-    expect(result).toHaveLength(2);
-
-    const primary = result!.find((t) => t.name === 'color.primary');
-    expect(primary).toBeDefined();
-    expect(primary!.value).toBe('#FF0000');
-    expect(primary!.failedToResolve).toBe(false);
-    expect(primary!.type).toBe(TokenTypes.COLOR);
-  });
-
-  it('maps nested { data: { tokens: {...} } } server response shape', async () => {
+  it('extracts flat map from { data: { tokenName: value } } response shape', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({
         data: {
-          tokens: {
-            'color.primary': '#FF0000',
-          },
+          'color.primary': '#FF0000',
+          'color.secondary': '#0000FF',
         },
+        meta: { resolved: ['color.primary', 'color.secondary'], unresolved: [], errors: {} },
       }),
     });
 
-    const result = await fetchServerResolvedTokens(BASE_OPTIONS, RAW_TOKENS);
-    expect(result).toHaveLength(1);
-    expect(result![0].name).toBe('color.primary');
-    expect(result![0].value).toBe('#FF0000');
+    const result = await fetchServerResolvedTokens(BASE_OPTIONS);
+    expect(result).not.toBeNull();
+    expect(result!['color.primary']).toBe('#FF0000');
+    expect(result!['color.secondary']).toBe('#0000FF');
+    expect(Object.keys(result!)).toHaveLength(2);
   });
 
-  it('sets rawValue to the original alias reference', async () => {
+  it('returns null when data is missing', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ 'color.primary': '#FF0000' }),
+      json: async () => ({ meta: { resolved: [] } }),
     });
 
-    const result = await fetchServerResolvedTokens(BASE_OPTIONS, RAW_TOKENS);
-    const primary = result!.find((t) => t.name === 'color.primary');
-    expect(primary!.rawValue).toBe('{core.red.500}');
+    const result = await fetchServerResolvedTokens(BASE_OPTIONS);
+    expect(result).toBeNull();
   });
 
-  it('sends POST request with correct URL, auth header, and body', async () => {
+  it('sends GET request with correct URL, auth header, and query params', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: async () => ({}),
+      json: async () => ({ data: {} }),
     });
 
-    await fetchServerResolvedTokens(BASE_OPTIONS, RAW_TOKENS);
+    await fetchServerResolvedTokens(BASE_OPTIONS);
 
+    const expectedParams = new URLSearchParams({ change_set_id: 'cs-456', Mode: 'Dark' });
     expect(mockFetch).toHaveBeenCalledWith(
-      'https://api.tokens.studio/api/v1/projects/proj-123/resolved_tokens',
+      `https://api.tokens.studio/api/v1/projects/proj-123/resolved_tokens?${expectedParams.toString()}`,
       expect.objectContaining({
-        method: 'POST',
+        method: 'GET',
         headers: expect.objectContaining({
           Authorization: 'Bearer test-token',
-          'Content-Type': 'application/json',
-        }),
-        body: JSON.stringify({
-          change_set_id: 'cs-456',
-          theme_selections: { Mode: 'Dark' },
         }),
       }),
     );
+  });
+
+  it('encodes multiple theme selections as separate query params', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: {} }),
+    });
+
+    await fetchServerResolvedTokens({
+      ...BASE_OPTIONS,
+      themeSelections: { foundation: 'base', 'color-scheme': 'blue' },
+    });
+
+    const [calledUrl] = mockFetch.mock.calls[0];
+    const url = new URL(calledUrl);
+    expect(url.searchParams.get('foundation')).toBe('base');
+    expect(url.searchParams.get('color-scheme')).toBe('blue');
+    expect(url.searchParams.get('change_set_id')).toBe('cs-456');
   });
 });

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchServerResolvedTokens.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchServerResolvedTokens.test.ts
@@ -131,4 +131,21 @@ describe('fetchServerResolvedTokens', () => {
     expect(url.searchParams.get('color-scheme')).toBe('blue');
     expect(url.searchParams.get('change_set_id')).toBe('cs-456');
   });
+
+  it('encodes activeSets as repeated query params', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: {} }),
+    });
+
+    await fetchServerResolvedTokens({
+      ...BASE_OPTIONS,
+      activeSets: ['global', 'theme', 'core'],
+    });
+
+    const [calledUrl] = mockFetch.mock.calls[0];
+    const url = new URL(calledUrl);
+    const sets = url.searchParams.getAll('set');
+    expect(sets).toEqual(['global', 'theme', 'core']);
+  });
 });

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchServerResolvedTokens.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchServerResolvedTokens.test.ts
@@ -1,6 +1,7 @@
 import { fetchServerResolvedTokens } from './fetchServerResolvedTokens';
 
 // Mock global fetch
+const originalFetch = global.fetch;
 const mockFetch = jest.fn();
 global.fetch = mockFetch;
 
@@ -18,6 +19,14 @@ describe('fetchServerResolvedTokens', () => {
     jest.spyOn(console, 'log').mockImplementation(() => {});
     jest.spyOn(console, 'warn').mockImplementation(() => {});
     jest.spyOn(Date, 'now').mockReturnValue(1777406477644);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
   });
 
   it('returns null on a 4xx response', async () => {

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchServerResolvedTokens.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchServerResolvedTokens.ts
@@ -1,5 +1,3 @@
-import { AnyTokenList } from '@/types/tokens';
-
 export interface ServerResolveOptions {
   apiBaseUrl: string;
   projectId: string;
@@ -24,11 +22,9 @@ export interface ServerResolveOptions {
  * Returns null on any error so callers fall back to local resolution silently.
  *
  * @param options  - Connection context and theme selections
- * @param _rawTokens - Unused; kept for API compatibility during transition
  */
 export async function fetchServerResolvedTokens(
   options: ServerResolveOptions,
-  _rawTokens?: Record<string, AnyTokenList>,
 ): Promise<Record<string, string> | null> {
   const {
     apiBaseUrl, projectId, changeSetId, authToken, themeSelections, activeSets,

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchServerResolvedTokens.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchServerResolvedTokens.ts
@@ -7,6 +7,8 @@ export interface ServerResolveOptions {
   authToken: string;
   /** { [themeGroupName]: themeOptionName } — maps active theme selections to server format */
   themeSelections: Record<string, string>;
+  /** Array of active token set names */
+  activeSets?: string[];
 }
 
 /**
@@ -29,7 +31,7 @@ export async function fetchServerResolvedTokens(
   _rawTokens?: Record<string, AnyTokenList>,
 ): Promise<Record<string, string> | null> {
   const {
-    apiBaseUrl, projectId, changeSetId, authToken, themeSelections,
+    apiBaseUrl, projectId, changeSetId, authToken, themeSelections, activeSets,
   } = options;
 
   try {
@@ -38,6 +40,9 @@ export async function fetchServerResolvedTokens(
     const params = new URLSearchParams({ change_set_id: changeSetId });
     Object.entries(themeSelections).forEach(([group, option]) => {
       params.set(group, option);
+    });
+    activeSets?.forEach((set) => {
+      params.append('set', set);
     });
 
     const response = await fetch(

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchServerResolvedTokens.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchServerResolvedTokens.ts
@@ -1,0 +1,112 @@
+import { AnyTokenList } from '@/types/tokens';
+import { ResolveTokenValuesResult } from '@/utils/tokenHelpers';
+
+export interface ServerResolveOptions {
+  apiBaseUrl: string;
+  projectId: string;
+  changeSetId: string;
+  authToken: string;
+  /** { [themeGroupName]: themeOptionName } — maps active theme selections to server format */
+  themeSelections: Record<string, string>;
+}
+
+/**
+ * Response shape from the Studio server's resolved_tokens endpoint.
+ * The server returns a flat map of token name → resolved value.
+ * Exact shape may include `data.tokens` or be a flat object — we normalise both.
+ */
+interface ServerResolvedTokensResponse {
+  data?: {
+    tokens?: Record<string, unknown>;
+    [key: string]: unknown;
+  };
+  tokens?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+/**
+ * Fetches server-side resolved tokens from the Studio gRPC-backed REST endpoint.
+ *
+ * The Studio server runs a Go gRPC resolver behind the scenes and exposes it via:
+ *   POST /api/v1/projects/:project_id/resolved_tokens
+ *
+ * Returns null on any error so callers can fall back to local resolution.
+ *
+ * @param options - Connection context and theme selections
+ * @param rawTokens - The raw (unresolved) token sets from Redux state, used to
+ *                    enrich the server's flat value map with type/metadata that
+ *                    are not present in the server response.
+ */
+export async function fetchServerResolvedTokens(
+  options: ServerResolveOptions,
+  rawTokens: Record<string, AnyTokenList>,
+): Promise<ResolveTokenValuesResult[] | null> {
+  const {
+    apiBaseUrl, projectId, changeSetId, authToken, themeSelections,
+  } = options;
+
+  try {
+    const response = await fetch(
+      `${apiBaseUrl}/api/v1/projects/${projectId}/resolved_tokens`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${authToken}`,
+        },
+        body: JSON.stringify({
+          change_set_id: changeSetId,
+          theme_selections: themeSelections,
+        }),
+      },
+    );
+
+    if (!response.ok) {
+      console.warn(
+        `[ServerResolver] Server returned ${response.status} ${response.statusText} — falling back to local resolver`,
+      );
+      return null;
+    }
+
+    const json: ServerResolvedTokensResponse = await response.json();
+
+    // Normalise: server may return { data: { tokens: {...} } } or { tokens: {...} } or a flat map
+    const flatMap: Record<string, unknown> = (json.data?.tokens ?? json.tokens ?? json) as Record<string, unknown>;
+
+    if (!flatMap || typeof flatMap !== 'object') {
+      console.warn('[ServerResolver] Unexpected response shape — falling back to local resolver');
+      return null;
+    }
+
+    // Build a quick lookup: tokenName → raw token (for type + metadata)
+    const rawTokenByName = new Map<string, { type: string; [key: string]: unknown }>();
+    Object.values(rawTokens).forEach((set) => {
+      set.forEach((token) => {
+        if (token.name && !rawTokenByName.has(token.name)) {
+          rawTokenByName.set(token.name, token as { type: string; [key: string]: unknown });
+        }
+      });
+    });
+
+    // Convert flat map { tokenName: resolvedValue } → ResolveTokenValuesResult[]
+    const resolved: ResolveTokenValuesResult[] = Object.entries(flatMap).map(([name, value]) => {
+      const rawToken = rawTokenByName.get(name);
+      return {
+        // Spread the original raw token to preserve name, type, description, $extensions, etc.
+        ...(rawToken ?? {}),
+        name,
+        value,
+        // rawValue is the original alias/value before resolution
+        rawValue: rawToken?.value ?? value,
+        // Mark as successfully resolved
+        failedToResolve: false,
+      } as unknown as ResolveTokenValuesResult;
+    });
+
+    console.log(`[ServerResolver] Received ${resolved.length} resolved tokens from server`);
+    return resolved;
+  } catch (error) {
+    console.warn('[ServerResolver] Network error — falling back to local resolver:', error);
+    return null;
+  }
+}

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchServerResolvedTokens.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchServerResolvedTokens.ts
@@ -60,9 +60,7 @@ export async function fetchServerResolvedTokens(
     );
 
     if (!response.ok) {
-      console.warn(
-        `[ServerResolver] Server returned ${response.status} ${response.statusText} — falling back to local resolver`,
-      );
+
       return null;
     }
 
@@ -76,14 +74,14 @@ export async function fetchServerResolvedTokens(
     );
 
     if (!flatMap) {
-      console.warn('[ServerResolver] Unexpected response shape — falling back to local resolver');
+
       return null;
     }
 
-    console.log(`[ServerResolver] Received ${Object.keys(flatMap).length} theme-resolved tokens from server`);
+
     return flatMap;
   } catch (error) {
-    console.warn('[ServerResolver] Network error — falling back to local resolver:', error);
+
     return null;
   }
 }

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchServerResolvedTokens.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchServerResolvedTokens.ts
@@ -37,7 +37,10 @@ export async function fetchServerResolvedTokens(
   try {
     // Build query string: change_set_id + each theme selection as a flat param
     // e.g. ?change_set_id=abc&color-scheme=blue&foundation=base
-    const params = new URLSearchParams({ change_set_id: changeSetId });
+    const params = new URLSearchParams({ 
+      change_set_id: changeSetId,
+      t: Date.now().toString(), // Cache buster
+    });
     Object.entries(themeSelections).forEach(([group, option]) => {
       params.set(group, option);
     });

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchServerResolvedTokens.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchServerResolvedTokens.ts
@@ -1,5 +1,4 @@
 import { AnyTokenList } from '@/types/tokens';
-import { ResolveTokenValuesResult } from '@/utils/tokenHelpers';
 
 export interface ServerResolveOptions {
   apiBaseUrl: string;
@@ -11,53 +10,44 @@ export interface ServerResolveOptions {
 }
 
 /**
- * Response shape from the Studio server's resolved_tokens endpoint.
- * The server returns a flat map of token name → resolved value.
- * Exact shape may include `data.tokens` or be a flat object — we normalise both.
- */
-interface ServerResolvedTokensResponse {
-  data?: {
-    tokens?: Record<string, unknown>;
-    [key: string]: unknown;
-  };
-  tokens?: Record<string, unknown>;
-  [key: string]: unknown;
-}
-
-/**
  * Fetches server-side resolved tokens from the Studio gRPC-backed REST endpoint.
  *
- * The Studio server runs a Go gRPC resolver behind the scenes and exposes it via:
- *   POST /api/v1/projects/:project_id/resolved_tokens
+ *   GET /api/v1/projects/:project_id/resolved_tokens
+ *       ?change_set_id=<id>&<themeGroup>=<themeName>&...
  *
- * Returns null on any error so callers can fall back to local resolution.
+ * The server returns a flat delta: only the tokens whose values are affected by the
+ * active theme selections. These are merged on top of the locally-resolved full list
+ * in `updateSources.tsx`.
  *
- * @param options - Connection context and theme selections
- * @param rawTokens - The raw (unresolved) token sets from Redux state, used to
- *                    enrich the server's flat value map with type/metadata that
- *                    are not present in the server response.
+ * Returns null on any error so callers fall back to local resolution silently.
+ *
+ * @param options  - Connection context and theme selections
+ * @param _rawTokens - Unused; kept for API compatibility during transition
  */
 export async function fetchServerResolvedTokens(
   options: ServerResolveOptions,
-  rawTokens: Record<string, AnyTokenList>,
-): Promise<ResolveTokenValuesResult[] | null> {
+  _rawTokens?: Record<string, AnyTokenList>,
+): Promise<Record<string, string> | null> {
   const {
     apiBaseUrl, projectId, changeSetId, authToken, themeSelections,
   } = options;
 
   try {
+    // Build query string: change_set_id + each theme selection as a flat param
+    // e.g. ?change_set_id=abc&color-scheme=blue&foundation=base
+    const params = new URLSearchParams({ change_set_id: changeSetId });
+    Object.entries(themeSelections).forEach(([group, option]) => {
+      params.set(group, option);
+    });
+
     const response = await fetch(
-      `${apiBaseUrl}/api/v1/projects/${projectId}/resolved_tokens`,
+      `${apiBaseUrl}/api/v1/projects/${projectId}/resolved_tokens?${params.toString()}`,
       {
-        method: 'POST',
+        method: 'GET',
         headers: {
-          'Content-Type': 'application/json',
           Authorization: `Bearer ${authToken}`,
+          'Content-Type': 'application/json',
         },
-        body: JSON.stringify({
-          change_set_id: changeSetId,
-          theme_selections: themeSelections,
-        }),
       },
     );
 
@@ -68,43 +58,22 @@ export async function fetchServerResolvedTokens(
       return null;
     }
 
-    const json: ServerResolvedTokensResponse = await response.json();
+    const json = await response.json();
 
-    // Normalise: server may return { data: { tokens: {...} } } or { tokens: {...} } or a flat map
-    const flatMap: Record<string, unknown> = (json.data?.tokens ?? json.tokens ?? json) as Record<string, unknown>;
+    // Server returns: { data: { "token.name": "value", ... }, meta: { ... } }
+    const flatMap: Record<string, string> | null = (
+      json?.data && typeof json.data === 'object' && !Array.isArray(json.data)
+        ? json.data
+        : null
+    );
 
-    if (!flatMap || typeof flatMap !== 'object') {
+    if (!flatMap) {
       console.warn('[ServerResolver] Unexpected response shape — falling back to local resolver');
       return null;
     }
 
-    // Build a quick lookup: tokenName → raw token (for type + metadata)
-    const rawTokenByName = new Map<string, { type: string; [key: string]: unknown }>();
-    Object.values(rawTokens).forEach((set) => {
-      set.forEach((token) => {
-        if (token.name && !rawTokenByName.has(token.name)) {
-          rawTokenByName.set(token.name, token as { type: string; [key: string]: unknown });
-        }
-      });
-    });
-
-    // Convert flat map { tokenName: resolvedValue } → ResolveTokenValuesResult[]
-    const resolved: ResolveTokenValuesResult[] = Object.entries(flatMap).map(([name, value]) => {
-      const rawToken = rawTokenByName.get(name);
-      return {
-        // Spread the original raw token to preserve name, type, description, $extensions, etc.
-        ...(rawToken ?? {}),
-        name,
-        value,
-        // rawValue is the original alias/value before resolution
-        rawValue: rawToken?.value ?? value,
-        // Mark as successfully resolved
-        failedToResolve: false,
-      } as unknown as ResolveTokenValuesResult;
-    });
-
-    console.log(`[ServerResolver] Received ${resolved.length} resolved tokens from server`);
-    return resolved;
+    console.log(`[ServerResolver] Received ${Object.keys(flatMap).length} theme-resolved tokens from server`);
+    return flatMap;
   } catch (error) {
     console.warn('[ServerResolver] Network error — falling back to local resolver:', error);
     return null;


### PR DESCRIPTION
…PC API

<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

This PR implements real-time server-side token resolution using the Tokens Studio gRPC API, enhancing how OAuth tokens are managed and resolved within the Figma plugin.

### What does this pull request do?

<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->

- Introduces a server-side gRPC integration for OAuth token resolution

### Testing this change

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

- Ensure the gRPC server is running and accessible by the plugin
- Import tokens from studio using studio only functions(like lighten, darken, clamp, etc)
- See if they are being correctly resolved in the plugin
- Follow in-repo instructions for configuring OAuth and testing resolution flows

### Additional Notes (if any)

<!--
  Add any other context or screenshots about the pull request
-->