### PR TITLE
fix: stop stripping first segment of token set names to preserve fold…

### DIFF
--- a/.changeset/young-eggs-perform.md
+++ b/.changeset/young-eggs-perform.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fixed an issue where token set folder structure was lost when pulling tokens from new Studio OAuth.

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchProjectDataRest.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchProjectDataRest.ts
@@ -137,11 +137,6 @@ export async function fetchProjectDataRest(
     if (tokenSetsData.data && Array.isArray(tokenSetsData.data)) {
       tokenSetsData.data.forEach((item: any) => {
         let setName = item.attributes?.name || item.id;
-        // Strip the root directory prefix if it exists (e.g. "florian-tokens/component/btn" -> "component/btn")
-        const slashIndex = setName.indexOf('/');
-        if (slashIndex > 0) {
-          setName = setName.substring(slashIndex + 1);
-        }
 
         tokenSets.push({
           id: item.id,


### PR DESCRIPTION
…er hierarchy

### Why does this PR exist?

Closes #0000 <!-- link the related issue -->

Prior to this change, the logic for handling token set names was aggressively stripping the first segment, which inadvertently removed important context needed for distinguishing or properly folding token sets—especially in cases where hierarchical naming is required (for example, "colors/base/primary" becoming "base/primary"). This broke expected organization, grouping, and in some scenarios, caused UI confusion or data mapping issues.

### What does this pull request do?

This PR updates the logic to stop stripping the first segment of token set names, ensuring that the full context of each token set is preserved. With this fix:
- Token set names are now kept fully intact.
- Hierarchical or namespaced token sets (e.g., "theme/dark/typography") are accurately handled, retaining all parent folders.
- The folding/collapse mechanism in the UI now works as expected, since the correct structure is available for grouping.
- This prevents accidental merging or loss of token set grouping and improves the user experience when working with complex or nested token sets.

No other unrelated parts of the codebase are affected by this change.

### Testing this change

To test this PR:
1. Open the plugin and inspect your tokens panel with nested/grouped token sets (e.g., "theme/dark/colors", "theme/dark/typography").
2. Verify that the full names—including the first segment—are displayed and preserved.
3. Ensure that folding/collapse functionality in the UI works according to the original hierarchy.
4. Create and rename token sets with multi-segment names to confirm that all segments persist after changes.
5. Confirm that no unintended side effects impact existing tokens or sets.

(If available, add a link to a deploy preview / review instance here.)

### Additional Notes (if any)
