### PR TITLE
use server-resolved tokens for Figma variable export

### DIFF
--- a/.changeset/lemon-socks-develop.md
+++ b/.changeset/lemon-socks-develop.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fixed an issue where tokens using complex modifiers (such as `set_alpha`) were incorrectly exported as white or caused errors in Figma variables. This update ensures that the accurately resolved values visible in the Studio UI are correctly preserved during the export process for Tokens Studio OAuth users.

--- a/packages/tokens-studio-for-figma/src/app/store/useTokens.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/useTokens.tsx
@@ -19,7 +19,9 @@ import {
   uiStateSelector,
   updateModeSelector,
   themesListSelector,
+  storageTypeSelector,
 } from '@/selectors';
+import { StorageProviderType } from '@/constants/StorageProviderType';
 import { TokenSetStatus } from '@/constants/TokenSetStatus';
 import { TokenTypes } from '@/constants/TokenTypes';
 import { isEqual } from '@/utils/isEqual';
@@ -64,6 +66,7 @@ export default function useTokens() {
   const updateMode = useSelector(updateModeSelector);
   const tokens = useSelector(tokensSelector);
   const themes = useSelector(themesListSelector);
+  const storageType = useSelector(storageTypeSelector);
   const settings = useSelector(settingsStateSelector, isEqual);
   const storeTokenIdInJsonEditor = useSelector(storeTokenIdInJsonEditorSelector);
   const { confirm } = useConfirm<ConfirmResult>();
@@ -640,11 +643,12 @@ export default function useTokens() {
         type: AsyncMessageTypes.CREATE_LOCAL_VARIABLES,
         tokens: multiValueFilteredTokens,
         settings,
+        serverResolvedTokens: storageType.provider === StorageProviderType.TOKENS_STUDIO_OAUTH ? serverResolvedTokens : null,
       }),
     );
     dispatch.tokenState.assignVariableIdsToTheme(createVariableResult.variableIds);
     dispatch.uiState.completeJob(BackgroundJobs.UI_CREATEVARIABLES);
-  }, [dispatch.tokenState, dispatch.uiState, tokens, settings]);
+  }, [dispatch.tokenState, dispatch.uiState, tokens, settings, serverResolvedTokens, storageType]);
 
   const createVariablesFromSets = useCallback(
     async (selectedSets: ExportTokenSet[]) => {
@@ -685,12 +689,13 @@ export default function useTokens() {
           tokens,
           settings,
           selectedSets,
+          serverResolvedTokens: storageType.provider === StorageProviderType.TOKENS_STUDIO_OAUTH ? serverResolvedTokens : null,
         }),
       );
       dispatch.uiState.completeJob(BackgroundJobs.UI_CREATEVARIABLES);
       Promise.resolve();
     },
-    [dispatch.uiState, tokens, settings],
+    [dispatch.uiState, tokens, settings, serverResolvedTokens, storageType],
   );
 
   const createVariablesFromThemes = useCallback(
@@ -732,13 +737,14 @@ export default function useTokens() {
           tokens,
           settings,
           selectedThemes,
+          serverResolvedTokens: storageType.provider === StorageProviderType.TOKENS_STUDIO_OAUTH ? serverResolvedTokens : null,
         }),
       );
       dispatch.tokenState.assignVariableIdsToTheme(createVariableResult.variableIds);
       dispatch.uiState.completeJob(BackgroundJobs.UI_CREATEVARIABLES);
       Promise.resolve();
     },
-    [dispatch.tokenState, dispatch.uiState, tokens, settings],
+    [dispatch.tokenState, dispatch.uiState, tokens, settings, serverResolvedTokens, storageType],
   );
 
   const renameVariablesFromToken = useCallback(

--- a/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/createLocalVariables.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/createLocalVariables.ts
@@ -4,7 +4,7 @@ import createLocalVariablesInPlugin from '../createLocalVariablesInPlugin';
 
 // This function is used to create variables based on themes
 export const createLocalVariables: AsyncMessageChannelHandlers[AsyncMessageTypes.CREATE_LOCAL_VARIABLES] = async (msg) => {
-  const result = await createLocalVariablesInPlugin(msg.tokens, msg.settings, msg.selectedThemes);
+  const result = await createLocalVariablesInPlugin(msg.tokens, msg.settings, msg.selectedThemes, msg.serverResolvedTokens);
   return {
     variableIds: result.allVariableCollectionIds,
     totalVariables: result.totalVariables,

--- a/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/createLocalVariablesWithoutModes.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/createLocalVariablesWithoutModes.ts
@@ -4,7 +4,7 @@ import createLocalVariablesWithoutModesInPlugin from '../createLocalVariablesWit
 
 // This function is used to create variables based on token sets, without the use of themes
 export const createLocalVariablesWithoutModes: AsyncMessageChannelHandlers[AsyncMessageTypes.CREATE_LOCAL_VARIABLES_WITHOUT_MODES] = async (msg) => {
-  const result = await createLocalVariablesWithoutModesInPlugin(msg.tokens, msg.settings, msg.selectedSets);
+  const result = await createLocalVariablesWithoutModesInPlugin(msg.tokens, msg.settings, msg.selectedSets, msg.serverResolvedTokens);
   return {
     variableIds: result.allVariableCollectionIds,
     totalVariables: result.totalVariables,

--- a/packages/tokens-studio-for-figma/src/plugin/createLocalVariablesInPlugin.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/createLocalVariablesInPlugin.ts
@@ -31,7 +31,7 @@ export type LocalVariableInfo = {
 * - Then goes on to update variables for each theme
 * - There's another step that we perform where we check if any variables need to be using references to other variables. This is a second step, as we need to have all variables created first before we can reference them.
 * */
-export default async function createLocalVariablesInPlugin(tokens: Record<string, AnyTokenList>, settings: SettingsState, selectedThemes?: string[]) {
+export default async function createLocalVariablesInPlugin(tokens: Record<string, AnyTokenList>, settings: SettingsState, selectedThemes?: string[], serverResolvedTokens?: Record<string, string> | null) {
   // Big O (n * m * x): (n: amount of themes, m: amount of variableCollections, x: amount of modes)
   const themeInfo = await AsyncMessageChannel.PluginInstance.message({
     type: AsyncMessageTypes.GET_THEME_INFO,
@@ -62,7 +62,9 @@ export default async function createLocalVariablesInPlugin(tokens: Record<string
 
     // Calculate total number of variables for progress tracking
     const totalVariableTokens = selectedThemeObjects.reduce((total, theme) => {
-      const { tokensToCreate } = generateTokensToCreate({ theme, tokens, overallConfig });
+      const { tokensToCreate } = generateTokensToCreate({
+        theme, tokens, overallConfig, serverResolvedTokens,
+      });
       const variableTokenCount = tokensToCreate.filter((token) => checkIfTokenCanCreateVariable(token, settings)).length;
       return total + variableTokenCount;
     }, 0);
@@ -109,7 +111,9 @@ export default async function createLocalVariablesInPlugin(tokens: Record<string
      * 2. If a platform is missing in the current mode AND doesn't exist anywhere, we safely remove it from Figma (Orphan Purging).
      */
     selectedThemeObjects.forEach((theme) => {
-      const { tokensToCreate } = generateTokensToCreate({ theme, tokens, overallConfig });
+      const { tokensToCreate } = generateTokensToCreate({
+        theme, tokens, overallConfig, serverResolvedTokens,
+      });
       tokensToCreate.forEach((token) => {
         const figmaExtensions = token.$extensions?.['com.figma'] as FigmaExtensions;
         if (figmaExtensions?.codeSyntax) {
@@ -141,6 +145,7 @@ export default async function createLocalVariablesInPlugin(tokens: Record<string
           progressTracker: globalProgressTracker,
           metadataUpdateTracker,
           providedPlatformsByVariable,
+          serverResolvedTokens,
         });
 
         figmaVariablesAfterCreate += allVariableObj.removedVariables.length;

--- a/packages/tokens-studio-for-figma/src/plugin/createLocalVariablesWithoutModesInPlugin.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/createLocalVariablesWithoutModesInPlugin.ts
@@ -28,7 +28,7 @@ import { ProgressTracker } from './ProgressTracker';
 * - There's another step that we perform where we check if any variables need to be using references to other variables. This is a second step, as we need to have all variables created first before we can reference them.
 * - TODO: Likely a good idea to merge this with createLocalVariablesInPlugin to reduce duplication
 * */
-export default async function createLocalVariablesWithoutModesInPlugin(tokens: Record<string, AnyTokenList>, settings: SettingsState, selectedSets: ExportTokenSet[]) {
+export default async function createLocalVariablesWithoutModesInPlugin(tokens: Record<string, AnyTokenList>, settings: SettingsState, selectedSets: ExportTokenSet[], serverResolvedTokens?: Record<string, string> | null) {
   // Big O (n * m * x): (n: amount of themes, m: amount of variableCollections, x: amount of modes)
   const allVariableCollectionIds: Record<string, LocalVariableInfo> = {};
   let referenceVariableCandidates: ReferenceVariableType[] = [];
@@ -69,7 +69,7 @@ export default async function createLocalVariablesWithoutModesInPlugin(tokens: R
       if (set.status === TokenSetStatus.ENABLED) {
         const theme = { id: '123', name: set.set, selectedTokenSets: { [set.set]: set.status } };
         const { tokensToCreate } = generateTokensToCreate({
-          theme, tokens, overallConfig, filterByTokenSet: set.set,
+          theme, tokens, overallConfig, filterByTokenSet: set.set, serverResolvedTokens,
         });
         const variableTokenCount = tokensToCreate.filter((token) => checkIfTokenCanCreateVariable(token, settings)).length;
         return total + variableTokenCount;
@@ -117,6 +117,7 @@ export default async function createLocalVariablesWithoutModesInPlugin(tokens: R
             settings,
             filterByTokenSet: set.set,
             progressTracker: globalProgressTracker,
+            serverResolvedTokens,
           });
           figmaVariablesAfterCreate += allVariableObj.removedVariables.length;
           if (Object.keys(allVariableObj.variableIds).length > 0) {

--- a/packages/tokens-studio-for-figma/src/plugin/generateTokensToCreate.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/generateTokensToCreate.ts
@@ -3,7 +3,17 @@ import { tokenTypesToCreateVariable } from '@/constants/VariableTypes';
 import { ThemeObject, UsedTokenSetsMap } from '@/types';
 import { AnyTokenList } from '@/types/tokens';
 import { TokenResolver } from '@/utils/TokenResolver';
-import { mergeTokenGroups, ResolveTokenValuesResult } from '@/utils/tokenHelpers';
+import { mergeTokenGroups, ResolveTokenValuesResult, mergeServerResolvedTokens } from '@/utils/tokenHelpers';
+
+export type GenerateTokensToCreatePayload = {
+  theme: ThemeObject;
+  tokens: Record<string, AnyTokenList>;
+  filterByTokenSet?: string;
+  overallConfig?: UsedTokenSetsMap;
+  themeTokenResolver?: TokenResolver;
+  preResolvedTokens?: ResolveTokenValuesResult[];
+  serverResolvedTokens?: Record<string, string> | null;
+};
 
 export function generateTokensToCreate({
   theme,
@@ -12,19 +22,8 @@ export function generateTokensToCreate({
   overallConfig = {},
   themeTokenResolver,
   preResolvedTokens,
-}: {
-  theme: ThemeObject;
-  tokens: Record<string, AnyTokenList>;
-  filterByTokenSet?: string;
-  overallConfig?: UsedTokenSetsMap;
-  themeTokenResolver?: TokenResolver;
-  /**
-   * Optional pre-resolved tokens from the Studio server (gRPC resolver).
-   * When provided, skips local mergeTokenGroups + TokenResolver entirely
-   * so resolved values match exactly what the Studio web app shows.
-   */
-  preResolvedTokens?: ResolveTokenValuesResult[];
-}): { tokensToCreate: ResolveTokenValuesResult[]; resolvedTokens: ResolveTokenValuesResult[] } {
+  serverResolvedTokens,
+}: GenerateTokensToCreatePayload): { tokensToCreate: ResolveTokenValuesResult[]; resolvedTokens: ResolveTokenValuesResult[] } {
   const enabledTokenSets = Object.entries(theme.selectedTokenSets)
     .filter(([name, status]) => status === TokenSetStatus.ENABLED && (!filterByTokenSet || name === filterByTokenSet))
     .map(([tokenSet]) => tokenSet);
@@ -34,7 +33,8 @@ export function generateTokensToCreate({
   const resolved: ResolveTokenValuesResult[] = preResolvedTokens
     ?? (() => {
       const resolver = themeTokenResolver || new TokenResolver([]);
-      return resolver.setTokens(mergeTokenGroups(tokens, theme.selectedTokenSets, overallConfig));
+      const locallyResolved = resolver.setTokens(mergeTokenGroups(tokens, theme.selectedTokenSets, overallConfig));
+      return mergeServerResolvedTokens(locallyResolved, serverResolvedTokens);
     })();
 
   // Big O(resolveTokenValues * mergeTokenGroups) — only applies for local resolution path

--- a/packages/tokens-studio-for-figma/src/plugin/updateVariables.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/updateVariables.ts
@@ -21,6 +21,7 @@ export type CreateVariableTypes = {
   progressTracker?: ProgressTracker | null;
   metadataUpdateTracker?: Record<string, boolean>;
   providedPlatformsByVariable?: Record<string, Set<string>>;
+  serverResolvedTokens?: Record<string, string> | null;
 };
 
 export type VariableToken = SingleToken<true, { path: string; variableId: string }>;
@@ -36,6 +37,7 @@ export default async function updateVariables({
   progressTracker,
   metadataUpdateTracker,
   providedPlatformsByVariable,
+  serverResolvedTokens,
 }: CreateVariableTypes) {
   // Create a separate TokenResolver instance for this theme to avoid interference
   // when multiple themes are processed concurrently
@@ -47,6 +49,7 @@ export default async function updateVariables({
     filterByTokenSet,
     overallConfig,
     themeTokenResolver,
+    serverResolvedTokens,
   });
 
   // Resolve the base font size for this specific theme using the same resolved tokens

--- a/packages/tokens-studio-for-figma/src/types/AsyncMessages.ts
+++ b/packages/tokens-studio-for-figma/src/types/AsyncMessages.ts
@@ -336,6 +336,7 @@ export type CreateLocalVariablesAsyncMessage = AsyncMessage<AsyncMessageTypes.CR
   tokens: Record<string, AnyTokenList>;
   settings: SettingsState,
   selectedThemes?: string[]
+  serverResolvedTokens?: Record<string, string> | null;
 }>;
 export type CreateLocalVariablesAsyncMessageResult = AsyncMessage<AsyncMessageTypes.CREATE_LOCAL_VARIABLES, {
   variableIds: Record<string, LocalVariableInfo>
@@ -346,6 +347,7 @@ export type CreateLocalVariablesWithoutModesAsyncMessage = AsyncMessage<AsyncMes
   tokens: Record<string, AnyTokenList>;
   settings: SettingsState,
   selectedSets: ExportTokenSet[]
+  serverResolvedTokens?: Record<string, string> | null;
 }>;
 export type CreateLocalVariablesWithoutModesAsyncMessageResult = AsyncMessage<AsyncMessageTypes.CREATE_LOCAL_VARIABLES_WITHOUT_MODES, {
   variableIds: Record<string, LocalVariableInfo>


### PR DESCRIPTION
### Why does this PR exist?

Closes 

Tokens using complex modifiers like `set_alpha` were failing to export correctly to Figma variables, often resulting in `#FFFFFF` or parsing errors. This occurred because the plugin's local `TokenResolver` lacks support for the string-based modifier syntax used by the gRPC resolver. By utilizing the server-resolved tokens already available in the UI, we can ensure that the exported values match the expected UI output.

### What does this pull request do?

This PR updates the Figma variable export pipeline to optionally use pre-resolved token values provided by the gRPC service:

- **UI Integration**: Updated `useTokens.tsx` to pass `serverResolvedTokens` from the Redux state to the plugin during variable creation.
- **Message Protocol**: Enhanced `AsyncMessages` to include `serverResolvedTokens` in `CREATE_LOCAL_VARIABLES` and `CREATE_LOCAL_VARIABLES_WITHOUT_MODES` payloads.
- **Plugin Resolution**: Updated `generateTokensToCreate.ts` to merge server-resolved values on top of locally resolved ones.
- **Provider Safeguard**: Implemented logic to only apply `serverResolvedTokens` when the active storage provider is `TOKENS_STUDIO_OAUTH`, preventing unexpected behavior for other providers.
- **Architecture**: Refactored `generateTokensToCreate` for better type safety and cleaner parameter handling.

### Testing this change

1. Connect to a Tokens Studio OAuth provider.
2. Create or use a token with a `set_alpha` modifier (e.g., `set_alpha({brand.primary}, 0.5)`).
3. Export the tokens to Figma variables.
4. Verify that the variable in Figma has the correct hex value (including alpha) instead of white or failing to update.
5. Verify that exporting from a non-OAuth provider (e.g., Local or GitHub) still works as expected using local resolution.

### Additional Notes (if any)