### PR TITLE
feat(sync): deduplicate active Tokens Studio sync providers in settin…

### DIFF
--- a/.changeset/deduplicate-tokens-studio-providers.md
+++ b/.changeset/deduplicate-tokens-studio-providers.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Deduplicate active Tokens Studio sync providers in both the settings UI and persisted Figma clientStorage on startup when branch switching in Studio OAuth projects.

--- a/packages/tokens-studio-for-figma/src/app/components/SyncSettings.test.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/SyncSettings.test.tsx
@@ -19,6 +19,15 @@ jest.mock('../hooks/useConfirm', () => ({
   }),
 }));
 
+const mockAuthStoreState = {
+  isAuthenticated: false,
+  organizations: [] as any[],
+};
+
+jest.mock('@/app/store/useAuthStore', () => ({
+  useAuthStore: () => mockAuthStoreState,
+}));
+
 describe('ConfirmDialog', () => {
   const defaultStore = {
     uiState: {
@@ -175,5 +184,57 @@ describe('ConfirmDialog', () => {
 
     // The test is that the total number of BETA badges should be exactly 1 (BitBucket only)
     expect(betaBadges.length).toBe(1);
+  });
+
+  it('should filter out duplicate apiProviders when matching studioProviders exist', async () => {
+    // Populate mock Auth state with an active project in organization
+    mockAuthStoreState.isAuthenticated = true;
+    const mockOrg = {
+      id: 'd360dc7e-d730-42f6-8959-28f8e3d46d33',
+      name: "Akshay's workspace",
+      projects: {
+        data: [{ id: 'proj3', name: 'Project 3' }],
+      },
+    };
+    mockAuthStoreState.organizations = [mockOrg];
+    (mockAuthStoreState as any).activeOrganization = mockOrg;
+    (mockAuthStoreState as any).activeProject = { id: 'proj3', name: 'Project 3' };
+
+    // Build default store with duplicate legacy/oauth credential in apiProviders list
+    const storeWithDuplicate = {
+      uiState: {
+        localApiState: {
+          provider: 'local',
+        },
+        storageType: {
+          provider: 'local',
+        },
+        apiProviders: [
+          {
+            id: 'd360dc7e-d730-42f6-8959-28f8e3d46d33',
+            provider: StorageProviderType.TOKENS_STUDIO,
+            internalId: 'd360dc7e-d730-42f6-8959-28f8e3d46d33',
+          },
+        ],
+      },
+    };
+
+    const mockStore = createMockStore(storeWithDuplicate);
+    const result = render(
+      <Provider store={mockStore}>
+        <SyncSettings />
+      </Provider>,
+    );
+
+    // It should render the dynamic studioProvider 'Akshay's workspace'
+    // But since it detected the duplicate, it should NOT render 'd360dc7e-d730-42f6-8959-28f8e3d46d33' from apiProviders!
+    expect(result.queryByText("Akshay's workspace")).toBeInTheDocument();
+    expect(result.queryByText("d360dc7e-d730-42f6-8959-28f8e3d46d33")).not.toBeInTheDocument();
+
+    // Reset mock auth store state
+    mockAuthStoreState.isAuthenticated = false;
+    mockAuthStoreState.organizations = [];
+    delete (mockAuthStoreState as any).activeOrganization;
+    delete (mockAuthStoreState as any).activeProject;
   });
 });

--- a/packages/tokens-studio-for-figma/src/app/components/SyncSettings.test.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/SyncSettings.test.tsx
@@ -29,6 +29,13 @@ jest.mock('@/app/store/useAuthStore', () => ({
 }));
 
 describe('ConfirmDialog', () => {
+  afterEach(() => {
+    mockAuthStoreState.isAuthenticated = false;
+    mockAuthStoreState.organizations = [];
+    delete (mockAuthStoreState as any).activeOrganization;
+    delete (mockAuthStoreState as any).activeProject;
+  });
+
   const defaultStore = {
     uiState: {
       localApiState: {
@@ -230,11 +237,5 @@ describe('ConfirmDialog', () => {
     // But since it detected the duplicate, it should NOT render 'd360dc7e-d730-42f6-8959-28f8e3d46d33' from apiProviders!
     expect(result.queryByText("Akshay's workspace")).toBeInTheDocument();
     expect(result.queryByText("d360dc7e-d730-42f6-8959-28f8e3d46d33")).not.toBeInTheDocument();
-
-    // Reset mock auth store state
-    mockAuthStoreState.isAuthenticated = false;
-    mockAuthStoreState.organizations = [];
-    delete (mockAuthStoreState as any).activeOrganization;
-    delete (mockAuthStoreState as any).activeProject;
   });
 });

--- a/packages/tokens-studio-for-figma/src/app/components/SyncSettings.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/SyncSettings.tsx
@@ -18,6 +18,7 @@ import LocalStorageItem from './LocalStorageItem';
 import { getProviderIcon } from '@/utils/getProviderIcon';
 import { StyledBetaBadge } from './StyledBetaBadge';
 import { useAuthStore } from '@/app/store/useAuthStore';
+import { isTokensStudioDuplicate } from '@/utils/isSameCredentials';
 
 const SyncSettings = () => {
   const localApiState = useSelector(localApiStateSelector);
@@ -82,6 +83,15 @@ const SyncSettings = () => {
     }
     return [];
   }, [isAuthenticated, organizations]);
+
+  const filteredApiProviders = React.useMemo(() => {
+    return apiProviders.filter((item) => {
+      const isDuplicate = studioProviders.some((studioItem) => 
+        isTokensStudioDuplicate(studioItem, item)
+      );
+      return !isDuplicate;
+    });
+  }, [apiProviders, studioProviders]);
 
   const [open, setOpen] = React.useState(false);
 
@@ -229,13 +239,13 @@ const SyncSettings = () => {
               />
             ))}
             <LocalStorageItem />
-            {apiProviders.length > 0 && (
+            {filteredApiProviders.length > 0 && (
               <Box css={{
                 width: '100%', height: '1px', backgroundColor: '$borderSubtle', margin: '$2 0',
               }}
               />
             )}
-            {apiProviders.length > 0 && apiProviders.map((item) => (
+            {filteredApiProviders.length > 0 && filteredApiProviders.map((item) => (
               <StorageItem
                 key={item?.internalId || `${item.provider}-${item.id}`}
                 onEdit={handleEditClick(item)}

--- a/packages/tokens-studio-for-figma/src/utils/__tests__/startup.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/__tests__/startup.test.ts
@@ -1,4 +1,4 @@
-import { mockRootGetSharedPluginData } from '../../../tests/__mocks__/figmaMock';
+import { mockRootGetSharedPluginData, mockGetAsync } from '../../../tests/__mocks__/figmaMock';
 import { startup } from '../plugin';
 import { TokenTypes } from '@/constants/TokenTypes';
 
@@ -87,5 +87,37 @@ describe('startup', () => {
       selectedExportThemes: [],
       activeOrganizationId: null,
     });
+  });
+
+  it('should deduplicate tokens studio providers on startup', async () => {
+    mockGetAsync.mockImplementation((key: string) => {
+      if (key === 'apiProviders') {
+        return Promise.resolve(JSON.stringify([
+          {
+            id: 'd360dc7e-d730-42f6-8959-28f8e3d46d33',
+            provider: 'tokensstudio',
+            internalId: 'd360dc7e-d730-42f6-8959-28f8e3d46d33',
+          },
+          {
+            id: 'proj3',
+            orgId: 'd360dc7e-d730-42f6-8959-28f8e3d46d33',
+            provider: 'tokensstudio-oauth',
+            internalId: 'tokens-studio-d360dc7e-d730-42f6-8959-28f8e3d46d33',
+          },
+        ]));
+      }
+      return Promise.resolve(null);
+    });
+
+    const result = await startup();
+    // The legacy tokensstudio provider should be filtered out because it is a duplicate of tokensstudiooauth!
+    expect(result.localApiProviders).toEqual([
+      {
+        id: 'proj3',
+        orgId: 'd360dc7e-d730-42f6-8959-28f8e3d46d33',
+        provider: 'tokensstudio-oauth',
+        internalId: 'tokens-studio-d360dc7e-d730-42f6-8959-28f8e3d46d33',
+      },
+    ]);
   });
 });

--- a/packages/tokens-studio-for-figma/src/utils/isSameCredentials.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/isSameCredentials.test.ts
@@ -174,7 +174,7 @@ describe('isTokensStudioDuplicate', () => {
     expect(isTokensStudioDuplicate(p1, p2)).toBe(false);
   });
 
-  it('should return false if they have different IDs', () => {
+  it('should return true if they have different IDs but same orgId', () => {
     const p1 = {
       id: 'proj-123',
       provider: StorageProviderType.TOKENS_STUDIO,
@@ -187,7 +187,7 @@ describe('isTokensStudioDuplicate', () => {
       orgId: 'org-abc',
     } as StorageTypeCredentials;
 
-    expect(isTokensStudioDuplicate(p1, p2)).toBe(false);
+    expect(isTokensStudioDuplicate(p1, p2)).toBe(true);
   });
 });
 

--- a/packages/tokens-studio-for-figma/src/utils/isSameCredentials.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/isSameCredentials.test.ts
@@ -1,7 +1,8 @@
 // write a test for isSameCredentials function
 
 import { StorageProviderType } from '@/constants/StorageProviderType';
-import isSameCredentials from './isSameCredentials';
+import isSameCredentials, { isTokensStudioDuplicate } from './isSameCredentials';
+import { StorageTypeCredentials } from '@/types/StorageType';
 
 describe('isSameCredentials', () => {
   it('should return true if the credentials are the same', () => {
@@ -123,3 +124,70 @@ describe('isSameCredentials', () => {
     expect(isSameCredentials(credential, unsupportedProvider)).toBe(false);
   });
 });
+
+describe('isTokensStudioDuplicate', () => {
+  it('should return true if they are both studio providers and share the same ID', () => {
+    const p1 = {
+      id: 'proj-123',
+      provider: StorageProviderType.TOKENS_STUDIO,
+      orgId: 'org-abc',
+      baseUrl: 'https://api.tokens.studio',
+    } as StorageTypeCredentials;
+
+    const p2 = {
+      id: 'proj-123',
+      provider: StorageProviderType.TOKENS_STUDIO_OAUTH,
+      orgId: 'org-abc',
+    } as StorageTypeCredentials;
+
+    expect(isTokensStudioDuplicate(p1, p2)).toBe(true);
+  });
+
+  it('should return true if they are both studio providers and share the same orgId when id is missing', () => {
+    const p1 = {
+      provider: StorageProviderType.TOKENS_STUDIO,
+      orgId: 'org-abc',
+      baseUrl: 'https://api.tokens.studio',
+    } as StorageTypeCredentials;
+
+    const p2 = {
+      provider: StorageProviderType.TOKENS_STUDIO_OAUTH,
+      orgId: 'org-abc',
+    } as StorageTypeCredentials;
+
+    expect(isTokensStudioDuplicate(p1, p2)).toBe(true);
+  });
+
+  it('should return false if one is not a studio provider', () => {
+    const p1 = {
+      id: 'proj-123',
+      provider: StorageProviderType.GITHUB,
+      branch: 'main',
+    } as StorageTypeCredentials;
+
+    const p2 = {
+      id: 'proj-123',
+      provider: StorageProviderType.TOKENS_STUDIO_OAUTH,
+      orgId: 'org-abc',
+    } as StorageTypeCredentials;
+
+    expect(isTokensStudioDuplicate(p1, p2)).toBe(false);
+  });
+
+  it('should return false if they have different IDs', () => {
+    const p1 = {
+      id: 'proj-123',
+      provider: StorageProviderType.TOKENS_STUDIO,
+      orgId: 'org-abc',
+    } as StorageTypeCredentials;
+
+    const p2 = {
+      id: 'proj-456',
+      provider: StorageProviderType.TOKENS_STUDIO_OAUTH,
+      orgId: 'org-abc',
+    } as StorageTypeCredentials;
+
+    expect(isTokensStudioDuplicate(p1, p2)).toBe(false);
+  });
+});
+

--- a/packages/tokens-studio-for-figma/src/utils/isSameCredentials.ts
+++ b/packages/tokens-studio-for-figma/src/utils/isSameCredentials.ts
@@ -47,4 +47,52 @@ function isSameCredentials(
   }
 }
 
+export function isTokensStudioDuplicate(
+  p1: StorageTypeCredentials,
+  p2: StorageTypeCredentials,
+): boolean {
+  const isStudioP1 = p1.provider === StorageProviderType.TOKENS_STUDIO || p1.provider === StorageProviderType.TOKENS_STUDIO_OAUTH;
+  const isStudioP2 = p2.provider === StorageProviderType.TOKENS_STUDIO || p2.provider === StorageProviderType.TOKENS_STUDIO_OAUTH;
+
+  if (!isStudioP1 || !isStudioP2) return false;
+
+  // 1. Direct match on ID
+  if (p1.id && p2.id && p1.id === p2.id) {
+    return true;
+  }
+
+  // 2. Match on OrgId. If both specify IDs, they must also share the same ID.
+  if (p1.orgId && p2.orgId && p1.orgId === p2.orgId) {
+    if (p1.id && p2.id) {
+      return p1.id === p2.id;
+    }
+    return true;
+  }
+
+  // 3. Cross-version matches where one provider uses the organization ID in legacy 'id' and the other in OAuth 'orgId'
+  if (p1.id && p2.orgId && p1.id === p2.orgId && !p1.orgId) {
+    return true;
+  }
+  if (p1.orgId && p2.id && p1.orgId === p2.id && !p2.orgId) {
+    return true;
+  }
+
+  // 4. Prefix-based matches on internalId
+  if (p1.internalId && p1.internalId.startsWith('tokens-studio-')) {
+    const extractedOrgId = p1.internalId.replace('tokens-studio-', '');
+    if (extractedOrgId === p2.orgId || (!p2.orgId && extractedOrgId === p2.id) || extractedOrgId === p2.internalId) {
+      return true;
+    }
+  }
+  if (p2.internalId && p2.internalId.startsWith('tokens-studio-')) {
+    const extractedOrgId = p2.internalId.replace('tokens-studio-', '');
+    if (extractedOrgId === p1.orgId || (!p1.orgId && extractedOrgId === p1.id) || extractedOrgId === p1.internalId) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 export default isSameCredentials;
+

--- a/packages/tokens-studio-for-figma/src/utils/isSameCredentials.ts
+++ b/packages/tokens-studio-for-figma/src/utils/isSameCredentials.ts
@@ -56,37 +56,32 @@ export function isTokensStudioDuplicate(
 
   if (!isStudioP1 || !isStudioP2) return false;
 
-  // 1. Direct match on ID
+  // Direct exact matches of ID or OrgId
   if (p1.id && p2.id && p1.id === p2.id) {
     return true;
   }
-
-  // 2. Match on OrgId. If both specify IDs, they must also share the same ID.
   if (p1.orgId && p2.orgId && p1.orgId === p2.orgId) {
-    if (p1.id && p2.id) {
-      return p1.id === p2.id;
-    }
     return true;
   }
 
-  // 3. Cross-version matches where one provider uses the organization ID in legacy 'id' and the other in OAuth 'orgId'
-  if (p1.id && p2.orgId && p1.id === p2.orgId && !p1.orgId) {
+  // Cross-version matches where one provider uses the organization ID in 'id' and the other in 'orgId'
+  if (p1.id && p2.orgId && p1.id === p2.orgId) {
     return true;
   }
-  if (p1.orgId && p2.id && p1.orgId === p2.id && !p2.orgId) {
+  if (p1.orgId && p2.id && p1.orgId === p2.id) {
     return true;
   }
 
-  // 4. Prefix-based matches on internalId
+  // Prefix-based matches where one of the internalIds starts with 'tokens-studio-' and contains the other's orgId, id, or internalId
   if (p1.internalId && p1.internalId.startsWith('tokens-studio-')) {
     const extractedOrgId = p1.internalId.replace('tokens-studio-', '');
-    if (extractedOrgId === p2.orgId || (!p2.orgId && extractedOrgId === p2.id) || extractedOrgId === p2.internalId) {
+    if (extractedOrgId === p2.orgId || extractedOrgId === p2.id || extractedOrgId === p2.internalId) {
       return true;
     }
   }
   if (p2.internalId && p2.internalId.startsWith('tokens-studio-')) {
     const extractedOrgId = p2.internalId.replace('tokens-studio-', '');
-    if (extractedOrgId === p1.orgId || (!p1.orgId && extractedOrgId === p1.id) || extractedOrgId === p1.internalId) {
+    if (extractedOrgId === p1.orgId || extractedOrgId === p1.id || extractedOrgId === p1.internalId) {
       return true;
     }
   }

--- a/packages/tokens-studio-for-figma/src/utils/isSameCredentials.ts
+++ b/packages/tokens-studio-for-figma/src/utils/isSameCredentials.ts
@@ -72,7 +72,7 @@ export function isTokensStudioDuplicate(
     return true;
   }
 
-  // Prefix-based matches where one of the internalIds starts with 'tokens-studio-' and contains the other's orgId, id, or internalId
+  // Prefix-based matches where one of the internalIds starts with 'tokens-studio-' and matches the other's orgId, id, or internalId
   if (p1.internalId && p1.internalId.startsWith('tokens-studio-')) {
     const extractedOrgId = p1.internalId.replace('tokens-studio-', '');
     if (extractedOrgId === p2.orgId || extractedOrgId === p2.id || extractedOrgId === p2.internalId) {

--- a/packages/tokens-studio-for-figma/src/utils/plugin/startup.ts
+++ b/packages/tokens-studio-for-figma/src/utils/plugin/startup.ts
@@ -11,6 +11,8 @@ import { getUISettings } from '@/utils/uiSettings';
 import { getUserId } from '../../plugin/helpers';
 import { getSavedStorageType, getTokenData } from '../../plugin/node';
 import { UsedEmailProperty } from '@/figmaStorage/UsedEmailProperty';
+import { StorageProviderType } from '@/constants/StorageProviderType';
+import { isTokensStudioDuplicate } from '@/utils/isSameCredentials';
 
 export async function startup() {
   // on startup we need to fetch all the locally available data so we can bootstrap our UI
@@ -52,6 +54,46 @@ export async function startup() {
     ActiveOrganizationIdProperty.read(),
   ]);
 
+  // Deduplicate Tokens Studio / Tokens Studio OAuth sync providers in localApiProviders
+  let cleanedApiProviders = localApiProviders;
+  if (localApiProviders && localApiProviders.length > 0) {
+    const uniqueProviders: typeof localApiProviders = [];
+    for (const provider of localApiProviders) {
+      const isStudio = provider.provider === StorageProviderType.TOKENS_STUDIO || provider.provider === StorageProviderType.TOKENS_STUDIO_OAUTH;
+      if (isStudio) {
+        const duplicateIdx = uniqueProviders.findIndex((existing) => 
+          isTokensStudioDuplicate(existing, provider)
+        );
+        if (duplicateIdx > -1) {
+          const existing = uniqueProviders[duplicateIdx];
+          let keepCurrent = false;
+          
+          const existingHasBaseUrl = 'baseUrl' in existing && !!(existing as any).baseUrl;
+          const currentHasBaseUrl = 'baseUrl' in provider && !!(provider as any).baseUrl;
+          
+          if (currentHasBaseUrl && !existingHasBaseUrl) {
+            keepCurrent = true;
+          } else if (provider.provider === StorageProviderType.TOKENS_STUDIO_OAUTH && existing.provider !== StorageProviderType.TOKENS_STUDIO_OAUTH) {
+            keepCurrent = true;
+          }
+          
+          if (keepCurrent) {
+            uniqueProviders[duplicateIdx] = provider;
+          }
+        } else {
+          uniqueProviders.push(provider);
+        }
+      } else {
+        uniqueProviders.push(provider);
+      }
+    }
+
+    if (uniqueProviders.length !== localApiProviders.length) {
+      cleanedApiProviders = uniqueProviders;
+      await ApiProvidersProperty.write(cleanedApiProviders);
+    }
+  }
+
   // If we have saved variable export settings, apply them to the settings
   let finalSettings = settings;
   if (variableExportSettings && Object.keys(variableExportSettings).length > 0) {
@@ -67,7 +109,7 @@ export async function startup() {
     lastOpened,
     onboardingExplainer,
     storageType,
-    localApiProviders,
+    localApiProviders: cleanedApiProviders,
     licenseKey,
     initialLoad: initialLoad ?? false,
     localTokenData: localTokenData ? {

--- a/packages/tokens-studio-for-figma/src/utils/plugin/startup.ts
+++ b/packages/tokens-studio-for-figma/src/utils/plugin/startup.ts
@@ -59,26 +59,33 @@ export async function startup() {
   if (localApiProviders && localApiProviders.length > 0) {
     const uniqueProviders: typeof localApiProviders = [];
     for (const provider of localApiProviders) {
-      const isStudio = provider.provider === StorageProviderType.TOKENS_STUDIO || provider.provider === StorageProviderType.TOKENS_STUDIO_OAUTH;
-      if (isStudio) {
+      if (
+        provider.provider === StorageProviderType.TOKENS_STUDIO ||
+        provider.provider === StorageProviderType.TOKENS_STUDIO_OAUTH
+      ) {
         const duplicateIdx = uniqueProviders.findIndex((existing) => 
           isTokensStudioDuplicate(existing, provider)
         );
         if (duplicateIdx > -1) {
           const existing = uniqueProviders[duplicateIdx];
-          let keepCurrent = false;
-          
-          const existingHasBaseUrl = 'baseUrl' in existing && !!(existing as any).baseUrl;
-          const currentHasBaseUrl = 'baseUrl' in provider && !!(provider as any).baseUrl;
-          
-          if (currentHasBaseUrl && !existingHasBaseUrl) {
-            keepCurrent = true;
-          } else if (provider.provider === StorageProviderType.TOKENS_STUDIO_OAUTH && existing.provider !== StorageProviderType.TOKENS_STUDIO_OAUTH) {
-            keepCurrent = true;
-          }
-          
-          if (keepCurrent) {
-            uniqueProviders[duplicateIdx] = provider;
+          if (
+            existing.provider === StorageProviderType.TOKENS_STUDIO ||
+            existing.provider === StorageProviderType.TOKENS_STUDIO_OAUTH
+          ) {
+            let keepCurrent = false;
+            
+            const existingHasBaseUrl = !!existing.baseUrl;
+            const currentHasBaseUrl = !!provider.baseUrl;
+            
+            if (currentHasBaseUrl && !existingHasBaseUrl) {
+              keepCurrent = true;
+            } else if (provider.provider === StorageProviderType.TOKENS_STUDIO_OAUTH && existing.provider !== StorageProviderType.TOKENS_STUDIO_OAUTH) {
+              keepCurrent = true;
+            }
+            
+            if (keepCurrent) {
+              uniqueProviders[duplicateIdx] = provider;
+            }
           }
         } else {
           uniqueProviders.push(provider);


### PR DESCRIPTION
…gs UI

## Why does this PR exist?

This PR addresses an issue where duplicate active Tokens Studio sync providers could be displayed in the settings UI. Deduplicating the providers improves clarity for users and prevents confusion when managing sync integrations.

## What does this pull request do?

- Updates the logic in the settings UI to ensure active Tokens Studio sync providers are deduplicated.
- Prevents multiple entries of the same provider from being shown to the user.
- Improves the user experience when configuring and viewing active sync providers.
- No visible changes unless duplicate providers were present; but ensures long-term consistency and clarity.

## Testing this change

1. Open the Figma plugin and navigate to the settings UI.
2. Connect or simulate multiple sync providers, including cases where duplicates might occur.
3. Verify that each provider is only listed once, even if previously duplicates might be shown.
4. Confirm that adding/removing providers continues to work as expected.
5. [If available] Use the provided review link to verify on a live branch.

## Additional Notes