### PR TITLE
Fix typography Resolution and Application whilst using Tokens Studio OAuth

### DIFF
--- a/.changeset/heavy-shoes-tickle.md
+++ b/.changeset/heavy-shoes-tickle.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fixed two issues affecting typography tokens for Tokens Studio OAuth users: typography tokens referencing server-resolved values were not resolving correctly, and even when resolved they did not visually update text layers on apply (font, size, line height and other properties were silently dropped until a manual pull).

--- a/.changeset/heavy-shoes-tickle.md
+++ b/.changeset/heavy-shoes-tickle.md
@@ -2,4 +2,4 @@
 "@tokens-studio/figma-plugin": patch
 ---
 
-Fixed two issues affecting typography tokens for Tokens Studio OAuth users: typography tokens referencing server-resolved values were not resolving correctly, and even when resolved they did not visually update text layers on apply (font, size, line height and other properties were silently dropped until a manual pull).
+Fixed two issues affecting typography tokens for Studio platform users: typography tokens referencing server-resolved values were not resolving correctly, and even when resolved they did not visually update text layers on apply (font, size, line height and other properties were silently dropped until a manual pull).

--- a/packages/tokens-studio-for-figma/src/plugin/dtcgUnitToCssUnit.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/dtcgUnitToCssUnit.test.ts
@@ -1,0 +1,24 @@
+import { dtcgUnitToCssUnit } from './dtcgUnitToCssUnit';
+
+describe('dtcgUnitToCssUnit', () => {
+  it('converts PIXELS to px', () => {
+    expect(dtcgUnitToCssUnit('PIXELS')).toBe('px');
+  });
+
+  it('converts PERCENT to %', () => {
+    expect(dtcgUnitToCssUnit('PERCENT')).toBe('%');
+  });
+
+  it('passes through arbitrary string units unchanged', () => {
+    expect(dtcgUnitToCssUnit('em')).toBe('em');
+    expect(dtcgUnitToCssUnit('rem')).toBe('rem');
+    expect(dtcgUnitToCssUnit('px')).toBe('px');
+  });
+
+  it('returns empty string for non-string values', () => {
+    expect(dtcgUnitToCssUnit(undefined)).toBe('');
+    expect(dtcgUnitToCssUnit(null)).toBe('');
+    expect(dtcgUnitToCssUnit(42)).toBe('');
+    expect(dtcgUnitToCssUnit({})).toBe('');
+  });
+});

--- a/packages/tokens-studio-for-figma/src/plugin/dtcgUnitToCssUnit.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/dtcgUnitToCssUnit.ts
@@ -1,0 +1,5 @@
+export function dtcgUnitToCssUnit(unit: unknown): string {
+  if (unit === 'PIXELS') return 'px';
+  if (unit === 'PERCENT') return '%';
+  return typeof unit === 'string' ? unit : '';
+}

--- a/packages/tokens-studio-for-figma/src/plugin/normalizeTypographyPropertyValue.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/normalizeTypographyPropertyValue.test.ts
@@ -1,0 +1,53 @@
+import { normalizeTypographyPropertyValue } from './normalizeTypographyPropertyValue';
+
+describe('normalizeTypographyPropertyValue', () => {
+  describe('DTCG dimension objects', () => {
+    it('converts { value, unit } objects to CSS strings', () => {
+      expect(normalizeTypographyPropertyValue('fontSize', { value: 24, unit: 'px' })).toBe('24px');
+      expect(normalizeTypographyPropertyValue('lineHeight', { value: 150, unit: '%' })).toBe('150%');
+    });
+
+    it('handles DTCG enum units (PIXELS, PERCENT)', () => {
+      expect(normalizeTypographyPropertyValue('fontSize', { value: 16, unit: 'PIXELS' })).toBe('16px');
+      expect(normalizeTypographyPropertyValue('lineHeight', { value: 120, unit: 'PERCENT' })).toBe('120%');
+    });
+
+    it('handles dimension objects with no unit', () => {
+      expect(normalizeTypographyPropertyValue('fontSize', { value: 16 })).toBe('16');
+    });
+  });
+
+  describe('JSON-array font families', () => {
+    it('converts JSON array string to comma-separated font family for fontFamily key', () => {
+      expect(normalizeTypographyPropertyValue('fontFamily', '["Comic","Sans","MS"]')).toBe('Comic, Sans, MS');
+    });
+
+    it('converts JSON array string to comma-separated font family for fontFamilies key', () => {
+      expect(normalizeTypographyPropertyValue('fontFamilies', '["Inter","system-ui"]')).toBe('Inter, system-ui');
+    });
+
+    it('leaves plain font family strings unchanged', () => {
+      expect(normalizeTypographyPropertyValue('fontFamily', 'Inter')).toBe('Inter');
+    });
+
+    it('does not parse JSON arrays for non-fontFamily keys', () => {
+      const value = '["not","a","font"]';
+      expect(normalizeTypographyPropertyValue('fontSize', value)).toBe(value);
+    });
+  });
+
+  describe('passthrough', () => {
+    it('returns plain strings unchanged', () => {
+      expect(normalizeTypographyPropertyValue('fontWeight', 'Bold')).toBe('Bold');
+      expect(normalizeTypographyPropertyValue('fontSize', '16px')).toBe('16px');
+    });
+
+    it('returns numbers unchanged', () => {
+      expect(normalizeTypographyPropertyValue('fontSize', 16)).toBe(16);
+    });
+
+    it('returns undefined unchanged', () => {
+      expect(normalizeTypographyPropertyValue('fontSize', undefined)).toBeUndefined();
+    });
+  });
+});

--- a/packages/tokens-studio-for-figma/src/plugin/normalizeTypographyPropertyValue.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/normalizeTypographyPropertyValue.ts
@@ -1,0 +1,18 @@
+import { tryParseJson } from '@/utils/tryParseJson';
+import { dtcgUnitToCssUnit } from './dtcgUnitToCssUnit';
+
+// Resolved typography values can arrive in formats the raw-apply path can't consume:
+//  - DTCG dimension objects like { value: 24, unit: 'px' } (from variable/local resolution)
+//  - JSON-array font families like '["Comic","Sans","MS"]' (from server resolution)
+// transformValue/setFontStyleOnTarget expect plain strings (e.g. '24px', 'Comic, Sans, MS'),
+// so we normalize here. parseFloat on a raw object yields NaN, which throws when assigned.
+export function normalizeTypographyPropertyValue(key: string, raw: any): any {
+  if (raw && typeof raw === 'object' && !Array.isArray(raw) && 'value' in raw) {
+    return `${raw.value}${dtcgUnitToCssUnit(raw.unit)}`;
+  }
+  if ((key === 'fontFamily' || key === 'fontFamilies') && typeof raw === 'string' && raw.trim().startsWith('[')) {
+    const parsed = tryParseJson<unknown[]>(raw);
+    if (Array.isArray(parsed)) return parsed.map((f) => String(f)).join(', ');
+  }
+  return raw;
+}

--- a/packages/tokens-studio-for-figma/src/plugin/tryApplyTypographyCompositeVariable.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/tryApplyTypographyCompositeVariable.ts
@@ -9,6 +9,32 @@ import { ApplyVariablesStylesOrRawValues } from '@/constants/ApplyVariablesStyle
 // Cache to track font loading promises to prevent race conditions in Promise.all
 const fontLoadingPromises = new Map<string, Promise<void>>();
 
+function dtcgUnitToCssUnit(unit: unknown): string {
+  if (unit === 'PIXELS') return 'px';
+  if (unit === 'PERCENT') return '%';
+  return typeof unit === 'string' ? unit : '';
+}
+
+// Resolved typography values can arrive in formats the raw-apply path can't consume:
+//  - DTCG dimension objects like { value: 24, unit: 'px' } (from variable/local resolution)
+//  - JSON-array font families like '["Comic","Sans","MS"]' (from server resolution)
+// transformValue/setFontStyleOnTarget expect plain strings (e.g. '24px', 'Comic, Sans, MS'),
+// so we normalize here. parseFloat on a raw object yields NaN, which throws when assigned.
+function normalizeTypographyPropertyValue(key: string, raw: any): any {
+  if (raw && typeof raw === 'object' && !Array.isArray(raw) && 'value' in raw) {
+    return `${raw.value}${dtcgUnitToCssUnit(raw.unit)}`;
+  }
+  if ((key === 'fontFamily' || key === 'fontFamilies') && typeof raw === 'string' && raw.trim().startsWith('[')) {
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) return parsed.map((f) => String(f)).join(', ');
+    } catch {
+      // Not valid JSON — fall through and use the original string.
+    }
+  }
+  return raw;
+}
+
 export async function tryApplyTypographyCompositeVariable({
   target, value, baseFontSize, resolvedValue,
 }: {
@@ -26,9 +52,13 @@ export async function tryApplyTypographyCompositeVariable({
 
   if (typeof value === 'string') return;
 
+  const normalizedValue = Object.fromEntries(
+    Object.entries(value).map(([key, val]) => [key, normalizeTypographyPropertyValue(key, val)]),
+  ) as typeof value;
+
   try {
     // We iterate over all keys of the typography object and apply variables if available, otherwise we apply the value directly
-    for (const [originalKey, val] of Object.entries(value).filter(([_, keyValue]) => typeof keyValue !== 'undefined')) {
+    for (const [originalKey, val] of Object.entries(normalizedValue).filter(([_, keyValue]) => typeof keyValue !== 'undefined')) {
       if (typeof val === 'undefined') return;
       let successfullyAppliedVariable = false;
       if (resolvedValue[originalKey]?.toString().startsWith('{') && resolvedValue[originalKey].toString().endsWith('}') && shouldCreateStylesWithVariables) {
@@ -72,19 +102,24 @@ export async function tryApplyTypographyCompositeVariable({
           }
         }
       }
-      // If there's no variable we apply the value directly
+      // If there's no variable we apply the value directly. Each property is applied
+      // independently so a single malformed value can't abort the whole typography apply.
       if (!successfullyAppliedVariable) {
-        // First we set font family and weight without variables, we do this because to apply those values we need their combination
-        if (originalKey === 'fontFamily' || originalKey === 'fontWeight') {
-          if ('fontName' in target && ('fontWeight' in value || 'fontFamily' in value)) {
-            setFontStyleOnTarget({ target, value: { fontFamily: value.fontFamily, fontWeight: value.fontWeight }, baseFontSize });
+        try {
+          // First we set font family and weight without variables, we do this because to apply those values we need their combination
+          if (originalKey === 'fontFamily' || originalKey === 'fontWeight') {
+            if ('fontName' in target && ('fontWeight' in normalizedValue || 'fontFamily' in normalizedValue)) {
+              await setFontStyleOnTarget({ target, value: { fontFamily: normalizedValue.fontFamily, fontWeight: normalizedValue.fontWeight }, baseFontSize });
+            }
+          } else {
+            if (target.fontName !== figma.mixed) await figma.loadFontAsync(target.fontName);
+            const transformedValue = transformValue(normalizedValue[originalKey], originalKey, baseFontSize);
+            if (transformedValue !== null && !(typeof transformedValue === 'number' && Number.isNaN(transformedValue))) {
+              target[originalKey] = transformedValue;
+            }
           }
-        } else {
-          if (target.fontName !== figma.mixed) await figma.loadFontAsync(target.fontName);
-          const transformedValue = transformValue(value[originalKey], originalKey, baseFontSize);
-          if (transformedValue !== null) {
-            target[originalKey] = transformedValue;
-          }
+        } catch (e) {
+          console.error('unable to apply typography property', originalKey, normalizedValue[originalKey], e);
         }
       }
     }

--- a/packages/tokens-studio-for-figma/src/plugin/tryApplyTypographyCompositeVariable.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/tryApplyTypographyCompositeVariable.ts
@@ -3,34 +3,12 @@ import { defaultTokenValueRetriever } from './TokenValueRetriever';
 import { setFontStyleOnTarget } from './setFontStyleOnTarget';
 import { ResolvedTypographyObject } from './ResolvedTypographyObject';
 import { transformTypographyKeyToFigmaVariable } from './transformTypographyKeyToFigmaVariable';
+import { normalizeTypographyPropertyValue } from './normalizeTypographyPropertyValue';
 import { SingleTypographyToken } from '@/types/tokens';
 import { ApplyVariablesStylesOrRawValues } from '@/constants/ApplyVariablesStyleOrder';
-import { tryParseJson } from '@/utils/tryParseJson';
 
 // Cache to track font loading promises to prevent race conditions in Promise.all
 const fontLoadingPromises = new Map<string, Promise<void>>();
-
-function dtcgUnitToCssUnit(unit: unknown): string {
-  if (unit === 'PIXELS') return 'px';
-  if (unit === 'PERCENT') return '%';
-  return typeof unit === 'string' ? unit : '';
-}
-
-// Resolved typography values can arrive in formats the raw-apply path can't consume:
-//  - DTCG dimension objects like { value: 24, unit: 'px' } (from variable/local resolution)
-//  - JSON-array font families like '["Comic","Sans","MS"]' (from server resolution)
-// transformValue/setFontStyleOnTarget expect plain strings (e.g. '24px', 'Comic, Sans, MS'),
-// so we normalize here. parseFloat on a raw object yields NaN, which throws when assigned.
-function normalizeTypographyPropertyValue(key: string, raw: any): any {
-  if (raw && typeof raw === 'object' && !Array.isArray(raw) && 'value' in raw) {
-    return `${raw.value}${dtcgUnitToCssUnit(raw.unit)}`;
-  }
-  if ((key === 'fontFamily' || key === 'fontFamilies') && typeof raw === 'string' && raw.trim().startsWith('[')) {
-    const parsed = tryParseJson<unknown[]>(raw);
-    if (Array.isArray(parsed)) return parsed.map((f) => String(f)).join(', ');
-  }
-  return raw;
-}
 
 export async function tryApplyTypographyCompositeVariable({
   target, value, baseFontSize, resolvedValue,

--- a/packages/tokens-studio-for-figma/src/plugin/tryApplyTypographyCompositeVariable.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/tryApplyTypographyCompositeVariable.ts
@@ -5,6 +5,7 @@ import { ResolvedTypographyObject } from './ResolvedTypographyObject';
 import { transformTypographyKeyToFigmaVariable } from './transformTypographyKeyToFigmaVariable';
 import { SingleTypographyToken } from '@/types/tokens';
 import { ApplyVariablesStylesOrRawValues } from '@/constants/ApplyVariablesStyleOrder';
+import { tryParseJson } from '@/utils/tryParseJson';
 
 // Cache to track font loading promises to prevent race conditions in Promise.all
 const fontLoadingPromises = new Map<string, Promise<void>>();
@@ -25,12 +26,8 @@ function normalizeTypographyPropertyValue(key: string, raw: any): any {
     return `${raw.value}${dtcgUnitToCssUnit(raw.unit)}`;
   }
   if ((key === 'fontFamily' || key === 'fontFamilies') && typeof raw === 'string' && raw.trim().startsWith('[')) {
-    try {
-      const parsed = JSON.parse(raw);
-      if (Array.isArray(parsed)) return parsed.map((f) => String(f)).join(', ');
-    } catch {
-      // Not valid JSON — fall through and use the original string.
-    }
+    const parsed = tryParseJson<unknown[]>(raw);
+    if (Array.isArray(parsed)) return parsed.map((f) => String(f)).join(', ');
   }
   return raw;
 }
@@ -58,8 +55,7 @@ export async function tryApplyTypographyCompositeVariable({
 
   try {
     // We iterate over all keys of the typography object and apply variables if available, otherwise we apply the value directly
-    for (const [originalKey, val] of Object.entries(normalizedValue).filter(([_, keyValue]) => typeof keyValue !== 'undefined')) {
-      if (typeof val === 'undefined') return;
+    for (const [originalKey] of Object.entries(normalizedValue).filter(([_, keyValue]) => typeof keyValue !== 'undefined')) {
       let successfullyAppliedVariable = false;
       if (resolvedValue[originalKey]?.toString().startsWith('{') && resolvedValue[originalKey].toString().endsWith('}') && shouldCreateStylesWithVariables) {
         const variableToApply = await defaultTokenValueRetriever.getVariableReference(resolvedValue[originalKey].toString().slice(1, -1));

--- a/packages/tokens-studio-for-figma/src/utils/tokenHelpers.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokenHelpers.ts
@@ -109,9 +109,26 @@ export function mergeServerResolvedTokens(
   const firstPass = locallyResolved.map((token) => {
     const serverValue = serverResolvedTokens[token.name];
     if (serverValue !== undefined) {
+      // Composite tokens (typography, border, shadow) come back from the server as a
+      // JSON-stringified object. Their local value is an object, so we must parse the
+      // string back into an object — otherwise downstream code reads properties off a
+      // string (e.g. `value.fontFamily`) and gets `undefined`, silently dropping the apply.
+      let nextValue: SingleToken['value'] = serverValue;
+      if (
+        typeof serverValue === 'string'
+        && typeof token.value === 'object'
+        && token.value !== null
+        && (serverValue.startsWith('{') || serverValue.startsWith('['))
+      ) {
+        try {
+          nextValue = JSON.parse(serverValue);
+        } catch {
+          // Not valid JSON — keep the raw string.
+        }
+      }
       return {
         ...token,
-        value: serverValue,
+        value: nextValue,
         failedToResolve: false,
       } as ResolveTokenValuesResult;
     }

--- a/packages/tokens-studio-for-figma/src/utils/tokenHelpers.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokenHelpers.ts
@@ -3,6 +3,7 @@ import { SingleToken } from '@/types/tokens';
 import { ThemeObject, UsedTokenSetsMap } from '@/types';
 import { TokenSetStatus } from '@/constants/TokenSetStatus';
 import { getTokenSetsOrder } from './getTokenSetsOrder';
+import { tryParseJson } from './tryParseJson';
 
 export type ResolveTokenValuesResult = SingleToken<
 true,
@@ -120,11 +121,7 @@ export function mergeServerResolvedTokens(
         && token.value !== null
         && (serverValue.startsWith('{') || serverValue.startsWith('['))
       ) {
-        try {
-          nextValue = JSON.parse(serverValue);
-        } catch {
-          // Not valid JSON — keep the raw string.
-        }
+        nextValue = tryParseJson(serverValue) ?? serverValue;
       }
       return {
         ...token,
@@ -135,11 +132,13 @@ export function mergeServerResolvedTokens(
     return token;
   });
 
-  // Second pass: re-resolve composite tokens (typography, border, shadow) whose
-  // individual properties reference atomic tokens that were updated in the server delta.
+  // Second pass: re-resolve composite tokens (typography, border) whose individual
+  // properties reference atomic tokens that were updated in the server delta.
   // Without this step, e.g. a typography token referencing {fontFamily.brand} keeps its
   // locally-resolved (possibly stale or unresolved) value even after fontFamily.brand is
   // updated by the server.
+  // Note: array-valued tokens (e.g. multi-layer shadow) are not re-resolved here because
+  // nested reference matching inside array elements is not yet implemented.
   return firstPass.map((token) => {
     const rawValue = token.resolvedValueWithReferences;
     if (!rawValue || typeof rawValue !== 'object' || Array.isArray(rawValue)) {

--- a/packages/tokens-studio-for-figma/src/utils/tokenHelpers.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokenHelpers.ts
@@ -105,16 +105,52 @@ export function mergeServerResolvedTokens(
     return locallyResolved;
   }
 
-  return locallyResolved.map((token) => {
+  // First pass: update tokens that are directly named in the server delta.
+  const firstPass = locallyResolved.map((token) => {
     const serverValue = serverResolvedTokens[token.name];
     if (serverValue !== undefined) {
       return {
         ...token,
         value: serverValue,
-        // Since we got a value from the server, it's considered successfully resolved
         failedToResolve: false,
       } as ResolveTokenValuesResult;
     }
     return token;
+  });
+
+  // Second pass: re-resolve composite tokens (typography, border, shadow) whose
+  // individual properties reference atomic tokens that were updated in the server delta.
+  // Without this step, e.g. a typography token referencing {fontFamily.brand} keeps its
+  // locally-resolved (possibly stale or unresolved) value even after fontFamily.brand is
+  // updated by the server.
+  return firstPass.map((token) => {
+    const rawValue = token.resolvedValueWithReferences;
+    if (!rawValue || typeof rawValue !== 'object' || Array.isArray(rawValue)) {
+      return token;
+    }
+
+    let needsUpdate = false;
+    const currentValue: Record<string, unknown> = typeof token.value === 'object' && token.value !== null && !Array.isArray(token.value)
+      ? { ...(token.value as Record<string, unknown>) }
+      : {};
+
+    for (const [key, val] of Object.entries(rawValue as Record<string, unknown>)) {
+      // Match simple {tokenName} references (no nesting)
+      if (typeof val === 'string' && val.startsWith('{') && val.endsWith('}') && !val.slice(1, -1).includes('{')) {
+        const refName = val.slice(1, -1);
+        const serverValue = serverResolvedTokens[refName];
+        if (serverValue !== undefined) {
+          currentValue[key] = serverValue;
+          needsUpdate = true;
+        }
+      }
+    }
+
+    if (!needsUpdate) return token;
+    return {
+      ...token,
+      value: currentValue,
+      failedToResolve: false,
+    } as ResolveTokenValuesResult;
   });
 }


### PR DESCRIPTION
### Why does this PR exist?

Typography tokens were broken in two ways for Tokens Studio OAuth sync users: they weren't resolving correctly in the UI, and even when they appeared resolved, applying them to a text layer in Figma had no visual effect until the user manually clicked "Pull from studio OAuth sync."

### What does this pull request do?

**Fix 1 — Typography token resolution** (`tokenHelpers.ts`)

Added a second pass to `mergeServerResolvedTokens` that re-resolves composite tokens (typography, border, shadow) whose individual properties reference atomic tokens updated in the server delta. Previously, only tokens directly named in the delta were updated; composite tokens referencing those atoms kept stale locally-resolved values.

**Fix 2 — Typography token application** (`tokenHelpers.ts` + `tryApplyTypographyCompositeVariable.ts`)

The OAuth server returns composite tokens as JSON-stringified strings in the resolution delta. `mergeServerResolvedTokens` was blindly assigning this string to `.value`, clobbering the object. Downstream code then read `.fontFamily` off a string → `undefined` for every property → nothing applied.

Additionally, resolved values can arrive in formats the apply path can't consume: DTCG dimension objects (`{value: 24, unit: 'px'}`) from local variable resolution, and JSON-array font families (`'["Comic","Sans","MS"]'`) from the server. `parseFloat({...})` on a dimension object produces NaN, assigning NaN to a node throws, and the single outer `try/catch` was silently aborting the entire property loop.

Changes:
- Parse server's JSON-stringified composite value back to an object when the local `.value` is an object type
- Normalize DTCG dimension objects → `'24px'` / `'100%'` and JSON-array font families → `'Comic, Sans, MS'` before applying
- Wrap each property application in its own `try/catch` so one malformed value can't abort the rest
- Add a NaN guard before assigning transformed numeric values to the node

**Why pull always worked:** the Pull button's `setTokenData` reducer sets `serverResolvedTokens: null`, so `mergeServerResolvedTokens` returns locally-resolved object values untouched — the JSON-string clobber never occurred.

### Testing this change

1. Connect a Figma file to a Tokens Studio OAuth project with typography tokens that reference other tokens (e.g. `fontFamily` referencing `fontFamily.brand`)
2. Select a text layer and apply a typography token — it should visually update immediately without needing to pull
3. Verify tokens with DTCG-format dimension sub-values and multi-family font stacks also apply correctly
4. Confirm the pull flow still works as before

### Additional Notes (if any)

Root cause was specific to Tokens Studio OAuth sync — for all other storage providers `serverResolvedTokens` is null and `mergeServerResolvedTokens` is a no-op, so they were unaffected.