### PR TITLE
fix pull variables and styles back to studio

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/store/models/effects/tokenState/createMultipleTokens.ts
+++ b/packages/tokens-studio-for-figma/src/app/store/models/effects/tokenState/createMultipleTokens.ts
@@ -29,10 +29,13 @@ export function createMultipleTokens(dispatch: RematchDispatch<RootModel>) {
       tokensBySet[token.parent].push(token);
     });
 
+    const allTokensToCreate: Array<{ name: string; value: any; type: string; description?: string; token_set_id: string }> = [];
+
     for (const [setName, tokens] of Object.entries(tokensBySet)) {
       const setMeta = store.getState().tokenState.tokenSetMetadata[setName] as any;
 
       if (setMeta?.fromVariableImport) {
+        // These tokens were already written by setTokensFromVariables — skip to avoid duplicates.
         // Clear the ephemeral flag so future imports into this set are not skipped.
         dispatch.tokenState.setTokenSetMetadata({
           ...store.getState().tokenState.tokenSetMetadata,
@@ -60,22 +63,26 @@ export function createMultipleTokens(dispatch: RematchDispatch<RootModel>) {
         }
 
         if (tokenSetId) {
-          for (const token of tokens) {
-            // eslint-disable-next-line no-await-in-loop
-            await pushToTokensStudioOAuth({
-              context: context as any,
-              action: 'CREATE_TOKEN',
-              data: {
-                name: token.name,
-                value: token.value,
-                type: token.type,
-                description: token.description,
-                token_set_id: tokenSetId,
-              },
+          tokens.forEach((token) => {
+            allTokensToCreate.push({
+              name: token.name,
+              value: token.value,
+              type: token.type,
+              description: token.description,
+              token_set_id: tokenSetId!,
             });
-          }
+          });
         }
       }
+    }
+
+    // Batch-create all tokens in a single request.
+    if (allTokensToCreate.length > 0) {
+      await pushToTokensStudioOAuth({
+        context: context as any,
+        action: 'BATCH_CREATE_TOKENS',
+        data: allTokensToCreate,
+      });
     }
   };
 }

--- a/packages/tokens-studio-for-figma/src/app/store/models/effects/tokenState/createMultipleTokens.ts
+++ b/packages/tokens-studio-for-figma/src/app/store/models/effects/tokenState/createMultipleTokens.ts
@@ -32,10 +32,13 @@ export function createMultipleTokens(dispatch: RematchDispatch<RootModel>) {
     for (const [setName, tokens] of Object.entries(tokensBySet)) {
       const setMeta = store.getState().tokenState.tokenSetMetadata[setName] as any;
 
-      // If the set was written by setTokensFromVariables during this same import session its
-      // tokens are already on Studio — skip to avoid duplicates. Pre-existing sets (from a
-      // pull) do NOT carry fromVariableImport, so we still write their tokens.
-      if (!setMeta?.fromVariableImport) {
+      if (setMeta?.fromVariableImport) {
+        // Clear the ephemeral flag so future imports into this set are not skipped.
+        dispatch.tokenState.setTokenSetMetadata({
+          ...store.getState().tokenState.tokenSetMetadata,
+          [setName]: { id: setMeta.id, isDynamic: setMeta.isDynamic },
+        });
+      } else {
         // Resolve or create the server ID for this token set.
         let tokenSetId: string | undefined = setMeta?.id;
 

--- a/packages/tokens-studio-for-figma/src/app/store/models/effects/tokenState/createMultipleTokens.ts
+++ b/packages/tokens-studio-for-figma/src/app/store/models/effects/tokenState/createMultipleTokens.ts
@@ -1,0 +1,78 @@
+import type { RematchDispatch } from '@rematch/core';
+import type { RootModel } from '@/types/RootModel';
+import { StorageProviderType } from '@/constants/StorageProviderType';
+import { pushToTokensStudioOAuth } from '../../../providers/tokens-studio/tokensStudioOAuth';
+import { store } from '@/app/store';
+import type { CreateSingleTokenData } from '@/app/store/useManageTokens';
+
+// Fires when the user clicks "Import All" in ImportedTokensDialog (via importMultipleTokens).
+// For Tokens Studio OAuth projects this writes the confirmed tokens to the REST API.
+//
+// Variable import tokens are skipped here — setTokensFromVariables already wrote them and
+// recorded their set IDs in tokenSetMetadata. Only sets with no tracked server ID are created.
+export function createMultipleTokens(dispatch: RematchDispatch<RootModel>) {
+  return async (payload: CreateSingleTokenData[], _rootState: any): Promise<void> => {
+    const currentState = store.getState();
+    if (currentState?.uiState?.api?.provider !== StorageProviderType.TOKENS_STUDIO_OAUTH) return;
+
+    const context = currentState.uiState.api;
+    const hasChangeSetId = !!(context as any)?.changeSetId;
+    if (!hasChangeSetId) return;
+    if (!payload || payload.length === 0) return;
+
+    // Group tokens by their parent set
+    const tokensBySet: Record<string, CreateSingleTokenData[]> = {};
+    payload.forEach((token) => {
+      if (!tokensBySet[token.parent]) {
+        tokensBySet[token.parent] = [];
+      }
+      tokensBySet[token.parent].push(token);
+    });
+
+    for (const [setName, tokens] of Object.entries(tokensBySet)) {
+      const setMeta = store.getState().tokenState.tokenSetMetadata[setName] as any;
+
+      // If the set was written by setTokensFromVariables during this same import session its
+      // tokens are already on Studio — skip to avoid duplicates. Pre-existing sets (from a
+      // pull) do NOT carry fromVariableImport, so we still write their tokens.
+      if (!setMeta?.fromVariableImport) {
+        // Resolve or create the server ID for this token set.
+        let tokenSetId: string | undefined = setMeta?.id;
+
+        if (!tokenSetId) {
+          // eslint-disable-next-line no-await-in-loop
+          const setResult = await pushToTokensStudioOAuth({
+            context: context as any,
+            action: 'CREATE_TOKEN_SET',
+            data: { name: setName },
+          });
+
+          if (setResult?.data?.id) {
+            tokenSetId = setResult.data.id;
+            dispatch.tokenState.setTokenSetMetadata({
+              ...store.getState().tokenState.tokenSetMetadata,
+              [setName]: { id: tokenSetId, isDynamic: false },
+            });
+          }
+        }
+
+        if (tokenSetId) {
+          for (const token of tokens) {
+            // eslint-disable-next-line no-await-in-loop
+            await pushToTokensStudioOAuth({
+              context: context as any,
+              action: 'CREATE_TOKEN',
+              data: {
+                name: token.name,
+                value: token.value,
+                type: token.type,
+                description: token.description,
+                token_set_id: tokenSetId,
+              },
+            });
+          }
+        }
+      }
+    }
+  };
+}

--- a/packages/tokens-studio-for-figma/src/app/store/models/effects/tokenState/index.ts
+++ b/packages/tokens-studio-for-figma/src/app/store/models/effects/tokenState/index.ts
@@ -17,5 +17,7 @@ export * from './renameVariableNamesToThemes';
 export * from './removeVariableNamesFromThemes';
 export * from './setThemesFromVariables';
 export * from './setTokensFromVariables';
+export * from './setTokensFromStyles';
+export * from './createMultipleTokens';
 export * from './disconnectVariableFromTheme';
 export * from './disconnectStyleFromTheme';

--- a/packages/tokens-studio-for-figma/src/app/store/models/effects/tokenState/index.ts
+++ b/packages/tokens-studio-for-figma/src/app/store/models/effects/tokenState/index.ts
@@ -16,5 +16,6 @@ export * from './renameVariableIdsToTheme';
 export * from './renameVariableNamesToThemes';
 export * from './removeVariableNamesFromThemes';
 export * from './setThemesFromVariables';
+export * from './setTokensFromVariables';
 export * from './disconnectVariableFromTheme';
 export * from './disconnectStyleFromTheme';

--- a/packages/tokens-studio-for-figma/src/app/store/models/effects/tokenState/setThemesFromVariables.ts
+++ b/packages/tokens-studio-for-figma/src/app/store/models/effects/tokenState/setThemesFromVariables.ts
@@ -17,6 +17,9 @@ export function setThemesFromVariables(dispatch: RematchDispatch<RootModel>) {
     // We need to push the updated themes to Studio OAuth.
     const currentState = store.getState();
     if (currentState?.uiState?.api?.provider === StorageProviderType.TOKENS_STUDIO_OAUTH) {
+      const hasChangeSetId = !!(currentState.uiState.api as any)?.changeSetId;
+      if (!hasChangeSetId) return;
+
       // If new tokens are also being imported at the same time, setTokensFromVariables will push
       // themes after token sets are created (so selected_token_sets can include server IDs).
       // Skip here to avoid pushing themes before token set IDs are available.

--- a/packages/tokens-studio-for-figma/src/app/store/models/effects/tokenState/setThemesFromVariables.ts
+++ b/packages/tokens-studio-for-figma/src/app/store/models/effects/tokenState/setThemesFromVariables.ts
@@ -17,15 +17,27 @@ export function setThemesFromVariables(dispatch: RematchDispatch<RootModel>) {
     // We need to push the updated themes to Studio OAuth.
     const currentState = store.getState();
     if (currentState?.uiState?.api?.provider === StorageProviderType.TOKENS_STUDIO_OAUTH) {
-      const { importedThemes } = currentState.tokenState;
-      const themesToPush = [
-        ...(importedThemes?.newThemes || []),
-        ...(importedThemes?.updatedThemes || []),
-      ];
+      // If new tokens are also being imported at the same time, setTokensFromVariables will push
+      // themes after token sets are created (so selected_token_sets can include server IDs).
+      // Skip here to avoid pushing themes before token set IDs are available.
+      const hasNewTokens = (currentState.tokenState.importedTokens?.newTokens || []).some((t) => t.parent != null);
+      if (hasNewTokens) return;
 
-      themesToPush.forEach((theme) => {
-        pushThemeToTokensStudioOAuth(theme, currentState, dispatch);
-      });
+      const { importedThemes } = currentState.tokenState;
+      // newThemes have locally-generated name-based IDs (e.g. "core-primitives") assigned by
+      // pullVariables.ts — not server UUIDs. Strip the id so pushThemeToTokensStudioOAuth
+      // picks CREATE_THEME (POST) instead of UPDATE_THEME (PATCH → 404).
+      const newThemesToPush = (importedThemes?.newThemes || []).map((t) => ({ ...t, id: undefined }));
+      const updatedThemesToPush = importedThemes?.updatedThemes || [];
+
+      // Push sequentially so that a shared theme group is only created once.
+      // Concurrent pushes would both see groupId=null and create duplicate groups.
+      (async () => {
+        for (const theme of [...newThemesToPush, ...updatedThemesToPush]) {
+          // eslint-disable-next-line no-await-in-loop
+          await pushThemeToTokensStudioOAuth(theme, currentState, dispatch);
+        }
+      })();
     }
   };
 }

--- a/packages/tokens-studio-for-figma/src/app/store/models/effects/tokenState/setTokensFromStyles.ts
+++ b/packages/tokens-studio-for-figma/src/app/store/models/effects/tokenState/setTokensFromStyles.ts
@@ -1,0 +1,12 @@
+import type { RematchDispatch } from '@rematch/core';
+import type { RootModel } from '@/types/RootModel';
+import type { SetTokensFromStylesPayload } from '@/types/payloads';
+
+// The reducer for setTokensFromStyles populates importedTokens.newTokens, which causes the
+// ImportedTokensDialog to appear. Studio OAuth write-back happens after the user confirms
+// via the dialog — see the createMultipleTokens effect.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function setTokensFromStyles(_dispatch: RematchDispatch<RootModel>) {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  return (_payload: SetTokensFromStylesPayload, _rootState: any): void => {};
+}

--- a/packages/tokens-studio-for-figma/src/app/store/models/effects/tokenState/setTokensFromVariables.ts
+++ b/packages/tokens-studio-for-figma/src/app/store/models/effects/tokenState/setTokensFromVariables.ts
@@ -56,19 +56,22 @@ export function setTokensFromVariables(dispatch: RematchDispatch<RootModel>) {
           }
         }
 
-        // Create each token in this set
-        for (const token of tokens) {
-          await pushToTokensStudioOAuth({
-            context: context as any,
-            action: 'CREATE_TOKEN',
-            data: {
-              name: token.name,
-              value: token.value,
-              type: token.type,
-              description: token.description,
-              token_set_id: tokenSetId,
-            },
-          });
+        // Only create tokens when we have a valid set ID — avoids REST calls with undefined token_set_id.
+        if (tokenSetId) {
+          for (const token of tokens) {
+            // eslint-disable-next-line no-await-in-loop
+            await pushToTokensStudioOAuth({
+              context: context as any,
+              action: 'CREATE_TOKEN',
+              data: {
+                name: token.name,
+                value: token.value,
+                type: token.type,
+                description: token.description,
+                token_set_id: tokenSetId,
+              },
+            });
+          }
         }
       }
     }
@@ -83,7 +86,7 @@ export function setTokensFromVariables(dispatch: RematchDispatch<RootModel>) {
     // sending theme options before token sets exist on the server.
     const stateAfterSets = store.getState();
     const { importedThemes } = stateAfterSets.tokenState;
-    if (importedThemes) {
+    if (hasChangeSetId && importedThemes) {
       const newThemesToPush = (importedThemes.newThemes || []).map((t: any) => ({ ...t, id: undefined }));
       const updatedThemesToPush = importedThemes.updatedThemes || [];
       // Push themes sequentially so that a shared theme group (e.g. "appearances") is only created

--- a/packages/tokens-studio-for-figma/src/app/store/models/effects/tokenState/setTokensFromVariables.ts
+++ b/packages/tokens-studio-for-figma/src/app/store/models/effects/tokenState/setTokensFromVariables.ts
@@ -29,14 +29,15 @@ export function setTokensFromVariables(dispatch: RematchDispatch<RootModel>) {
         tokensBySet[parent].push(token);
       });
 
-      // For each new token set, create it on the server first, then create its tokens.
-      // We process sets sequentially to ensure each set ID is available before creating tokens.
+      // Create token sets sequentially (no batch API), then batch-create all their tokens in one call.
+      const allTokensToCreate: Array<{ name: string; value: any; type: string; description?: string; token_set_id: string }> = [];
+
       for (const [setName, tokens] of Object.entries(tokensBySet)) {
         const existingSetId = (currentState.tokenState.tokenSetMetadata[setName] as any)?.id;
-
         let tokenSetId = existingSetId;
 
         if (!tokenSetId) {
+          // eslint-disable-next-line no-await-in-loop
           const setResult = await pushToTokensStudioOAuth({
             context: context as any,
             action: 'CREATE_TOKEN_SET',
@@ -45,10 +46,8 @@ export function setTokensFromVariables(dispatch: RematchDispatch<RootModel>) {
 
           if (setResult?.data?.id) {
             tokenSetId = setResult.data.id;
-            // Track the server ID so createMultipleTokens (fired when user confirms in the
-            // ImportedTokensDialog) knows this set was already written and can skip it.
-            // Mark fromVariableImport so createMultipleTokens (fired when user confirms in the
-            // dialog) knows these tokens were already written and skips them.
+            // Mark fromVariableImport so createMultipleTokens skips these sets when the user
+            // confirms in the ImportedTokensDialog, avoiding duplicate writes.
             dispatch.tokenState.setTokenSetMetadata({
               ...store.getState().tokenState.tokenSetMetadata,
               [setName]: { id: tokenSetId, isDynamic: false, fromVariableImport: true } as any,
@@ -56,23 +55,26 @@ export function setTokensFromVariables(dispatch: RematchDispatch<RootModel>) {
           }
         }
 
-        // Only create tokens when we have a valid set ID — avoids REST calls with undefined token_set_id.
         if (tokenSetId) {
-          for (const token of tokens) {
-            // eslint-disable-next-line no-await-in-loop
-            await pushToTokensStudioOAuth({
-              context: context as any,
-              action: 'CREATE_TOKEN',
-              data: {
-                name: token.name,
-                value: token.value,
-                type: token.type,
-                description: token.description,
-                token_set_id: tokenSetId,
-              },
+          tokens.forEach((token) => {
+            allTokensToCreate.push({
+              name: token.name,
+              value: token.value,
+              type: token.type,
+              description: token.description,
+              token_set_id: tokenSetId,
             });
-          }
+          });
         }
+      }
+
+      // Batch-create all tokens in a single request.
+      if (allTokensToCreate.length > 0) {
+        await pushToTokensStudioOAuth({
+          context: context as any,
+          action: 'BATCH_CREATE_TOKENS',
+          data: allTokensToCreate,
+        });
       }
     }
 

--- a/packages/tokens-studio-for-figma/src/app/store/models/effects/tokenState/setTokensFromVariables.ts
+++ b/packages/tokens-studio-for-figma/src/app/store/models/effects/tokenState/setTokensFromVariables.ts
@@ -33,10 +33,19 @@ export function setTokensFromVariables(dispatch: RematchDispatch<RootModel>) {
       const allTokensToCreate: Array<{ name: string; value: any; type: string; description?: string; token_set_id: string }> = [];
 
       for (const [setName, tokens] of Object.entries(tokensBySet)) {
-        const existingSetId = (currentState.tokenState.tokenSetMetadata[setName] as any)?.id;
-        let tokenSetId = existingSetId;
+        const existingMeta = store.getState().tokenState.tokenSetMetadata[setName] as any;
+        let tokenSetId = existingMeta?.id;
 
-        if (!tokenSetId) {
+        if (tokenSetId) {
+          // Set already exists on the server — mark it so createMultipleTokens skips it when
+          // the user confirms in ImportedTokensDialog, avoiding duplicate token writes.
+          if (!existingMeta?.fromVariableImport) {
+            dispatch.tokenState.setTokenSetMetadata({
+              ...store.getState().tokenState.tokenSetMetadata,
+              [setName]: { ...existingMeta, fromVariableImport: true } as any,
+            });
+          }
+        } else {
           // eslint-disable-next-line no-await-in-loop
           const setResult = await pushToTokensStudioOAuth({
             context: context as any,

--- a/packages/tokens-studio-for-figma/src/app/store/models/effects/tokenState/setTokensFromVariables.ts
+++ b/packages/tokens-studio-for-figma/src/app/store/models/effects/tokenState/setTokensFromVariables.ts
@@ -1,0 +1,92 @@
+import type { RematchDispatch } from '@rematch/core';
+import type { RootModel } from '@/types/RootModel';
+import { StorageProviderType } from '@/constants/StorageProviderType';
+import { pushToTokensStudioOAuth } from '../../../providers/tokens-studio/tokensStudioOAuth';
+import { pushThemeToTokensStudioOAuth } from './utils/pushThemeToTokensStudioOAuth';
+import { store } from '@/app/store';
+import type { SetTokensFromVariablesPayload } from '@/types/payloads';
+
+export function setTokensFromVariables(dispatch: RematchDispatch<RootModel>) {
+  return async (_payload: SetTokensFromVariablesPayload, _rootState: any): Promise<void> => {
+    const currentState = store.getState();
+    if (currentState?.uiState?.api?.provider !== StorageProviderType.TOKENS_STUDIO_OAUTH) return;
+
+    const context = currentState.uiState.api;
+    const hasChangeSetId = !!(context as any)?.changeSetId;
+    const { importedTokens } = currentState.tokenState;
+    const newTokens = (importedTokens?.newTokens || []).filter((t) => t.parent != null);
+
+    // Only create token sets and tokens if changeSetId is present — the REST API requires it.
+    // changeSetId is populated after pulling from the REST API for a specific branch.
+    if (hasChangeSetId && newTokens.length > 0) {
+      // Group new tokens by their parent set name
+      const tokensBySet: Record<string, typeof newTokens> = {};
+      newTokens.forEach((token) => {
+        const parent = token.parent!;
+        if (!tokensBySet[parent]) {
+          tokensBySet[parent] = [];
+        }
+        tokensBySet[parent].push(token);
+      });
+
+      // For each new token set, create it on the server first, then create its tokens.
+      // We process sets sequentially to ensure each set ID is available before creating tokens.
+      for (const [setName, tokens] of Object.entries(tokensBySet)) {
+        const existingSetId = (currentState.tokenState.tokenSetMetadata[setName] as any)?.id;
+
+        let tokenSetId = existingSetId;
+
+        if (!tokenSetId) {
+          // Create the token set and capture the server-assigned ID.
+          // We don't update tokenSetMetadata here because pushThemeToTokensStudioOAuth reads from
+          // remoteData.metadata.tokenSetsData (populated on pull), not tokenSetMetadata.
+          const setResult = await pushToTokensStudioOAuth({
+            context: context as any,
+            action: 'CREATE_TOKEN_SET',
+            data: { name: setName },
+          });
+
+          if (setResult?.data?.id) {
+            tokenSetId = setResult.data.id;
+          }
+        }
+
+        // Create each token in this set
+        for (const token of tokens) {
+          await pushToTokensStudioOAuth({
+            context: context as any,
+            action: 'CREATE_TOKEN',
+            data: {
+              name: token.name,
+              value: token.value,
+              type: token.type,
+              description: token.description,
+              token_set_id: tokenSetId,
+            },
+          });
+        }
+      }
+    }
+
+    // Yield the event loop before reading importedThemes. When hasChangeSetId is false there are
+    // no awaits above, so without this yield the effect runs synchronously and reads importedThemes
+    // before setThemesFromVariables (dispatched next in Initiator.tsx) has populated it.
+    await Promise.resolve();
+
+    // Push themes after token sets are created (so selected_token_sets are ready).
+    // setThemesFromVariables skips this when new tokens are present to avoid
+    // sending theme options before token sets exist on the server.
+    const stateAfterSets = store.getState();
+    const { importedThemes } = stateAfterSets.tokenState;
+    if (importedThemes) {
+      const newThemesToPush = (importedThemes.newThemes || []).map((t: any) => ({ ...t, id: undefined }));
+      const updatedThemesToPush = importedThemes.updatedThemes || [];
+      // Push themes sequentially so that a shared theme group (e.g. "appearances") is only created
+      // once — concurrent pushes would both see groupId=null and create duplicate groups.
+      for (const theme of [...newThemesToPush, ...updatedThemesToPush]) {
+        // eslint-disable-next-line no-await-in-loop
+        await pushThemeToTokensStudioOAuth(theme, stateAfterSets, dispatch);
+      }
+    }
+  };
+}

--- a/packages/tokens-studio-for-figma/src/app/store/models/effects/tokenState/setTokensFromVariables.ts
+++ b/packages/tokens-studio-for-figma/src/app/store/models/effects/tokenState/setTokensFromVariables.ts
@@ -37,9 +37,6 @@ export function setTokensFromVariables(dispatch: RematchDispatch<RootModel>) {
         let tokenSetId = existingSetId;
 
         if (!tokenSetId) {
-          // Create the token set and capture the server-assigned ID.
-          // We don't update tokenSetMetadata here because pushThemeToTokensStudioOAuth reads from
-          // remoteData.metadata.tokenSetsData (populated on pull), not tokenSetMetadata.
           const setResult = await pushToTokensStudioOAuth({
             context: context as any,
             action: 'CREATE_TOKEN_SET',
@@ -48,6 +45,14 @@ export function setTokensFromVariables(dispatch: RematchDispatch<RootModel>) {
 
           if (setResult?.data?.id) {
             tokenSetId = setResult.data.id;
+            // Track the server ID so createMultipleTokens (fired when user confirms in the
+            // ImportedTokensDialog) knows this set was already written and can skip it.
+            // Mark fromVariableImport so createMultipleTokens (fired when user confirms in the
+            // dialog) knows these tokens were already written and skips them.
+            dispatch.tokenState.setTokenSetMetadata({
+              ...store.getState().tokenState.tokenSetMetadata,
+              [setName]: { id: tokenSetId, isDynamic: false, fromVariableImport: true } as any,
+            });
           }
         }
 

--- a/packages/tokens-studio-for-figma/src/app/store/models/tokenState.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/models/tokenState.tsx
@@ -263,13 +263,24 @@ export const tokenState = createModel<RootModel>()({
       ...state,
       renamedCollections,
     }),
-    resetImportedTokens: (state) => ({
-      ...state,
-      importedTokens: {
-        newTokens: [],
-        updatedTokens: [],
-      },
-    }),
+    resetImportedTokens: (state) => {
+      // Strip the ephemeral fromVariableImport flag from all sets so a future style import
+      // targeting the same set names is not silently skipped.
+      const cleanedMetadata = Object.fromEntries(
+        Object.entries(state.tokenSetMetadata).map(([key, meta]) => {
+          const { fromVariableImport, ...rest } = meta as any;
+          return [key, rest];
+        }),
+      );
+      return {
+        ...state,
+        importedTokens: {
+          newTokens: [],
+          updatedTokens: [],
+        },
+        tokenSetMetadata: cleanedMetadata,
+      };
+    },
     setJSONData(state, payload) {
       const parsedTokens = parseJson(payload);
       parseTokenValues(parsedTokens, true);

--- a/packages/tokens-studio-for-figma/src/app/store/models/tokenState.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/models/tokenState.tsx
@@ -267,7 +267,7 @@ export const tokenState = createModel<RootModel>()({
       // Strip the ephemeral fromVariableImport flag from all sets so a future style import
       // targeting the same set names is not silently skipped.
       const cleanedMetadata = Object.fromEntries(
-        Object.entries(state.tokenSetMetadata).map(([key, meta]) => {
+        Object.entries(state.tokenSetMetadata || {}).map(([key, meta]) => {
           const { fromVariableImport, ...rest } = meta as any;
           return [key, rest];
         }),

--- a/packages/tokens-studio-for-figma/src/app/store/providers/tokens-studio/tokensStudioOAuth.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/tokens-studio/tokensStudioOAuth.tsx
@@ -38,6 +38,7 @@ import {
   createThemeOptionRest,
   updateThemeOptionRest,
   deleteThemeOptionRest,
+  batchCreateTokensRest,
 } from '../../../../utils/tokensStudio/restApi';
 
 type TokensStudioOAuthCredentials = Extract<StorageTypeCredentials, { provider: StorageProviderType.TOKENS_STUDIO_OAUTH }>;
@@ -50,6 +51,7 @@ interface PushToTokensStudioOAuth {
 }
 
 const ACTION_LABELS: Record<string, string> = {
+  BATCH_CREATE_TOKENS: 'Created tokens',
   CREATE_TOKEN: 'Created token',
   EDIT_TOKEN: 'Updated token',
   DELETE_TOKEN: 'Deleted token',
@@ -76,6 +78,11 @@ export const pushToTokensStudioOAuth = async ({
 
   try {
     switch (action) {
+      case 'BATCH_CREATE_TOKENS':
+        if (changeSetId) {
+          result = await batchCreateTokensRest(oauthTokens.accessToken, apiBaseUrl, projectId, data, changeSetId);
+        }
+        break;
       case 'CREATE_TOKEN':
         result = await createTokenRest(oauthTokens.accessToken, apiBaseUrl, projectId, data, branch, changeSetId);
         break;

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/__tests__/restApi.int.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/__tests__/restApi.int.test.ts
@@ -180,22 +180,27 @@ describe('Tokens Studio REST API Integration', () => {
     let tokenId = '';
     let themeGroupId = '';
     let themeOptionId = '';
+    let primitiveName = '';
+    let semanticName = '';
 
     it('creates token sets for imported variable collections', async () => {
       if (skipIntegration) return;
 
+      // Use unique names to avoid collisions with pre-existing sets or failed prior runs.
+      primitiveName = `import-primitives-${Date.now()}`;
       const primitiveResult = await createTokenSetRest(authToken, API_BASE_URL, projectId, {
-        name: 'import-primitives',
+        name: primitiveName,
         type: 'global',
         order_index: 0,
       }, undefined, changeSetId);
       expect(primitiveResult.data).toBeDefined();
       expect(primitiveResult.data.id).toBeDefined();
-      expect(primitiveResult.data.attributes.name).toBe('import-primitives');
+      expect(primitiveResult.data.attributes.name).toBe(primitiveName);
       primitiveSetId = primitiveResult.data.id;
 
+      semanticName = `import-semantic-${Date.now()}`;
       const semanticResult = await createTokenSetRest(authToken, API_BASE_URL, projectId, {
-        name: 'import-semantic',
+        name: semanticName,
         type: 'global',
         order_index: 1,
       }, undefined, changeSetId);
@@ -293,20 +298,23 @@ describe('Tokens Studio REST API Integration', () => {
   // No themes are involved — styles have no collection/mode concept.
   describe('Import Styles Flow', () => {
     let styleSetId = '';
+    let styleSetName = '';
     let colorTokenId = '';
     let typographyTokenId = '';
 
     it('creates a token set for the active set (styles have no parent)', async () => {
       if (skipIntegration) return;
 
+      // Use a unique name to avoid collisions with pre-existing sets or failed prior runs.
+      styleSetName = `import-styles-${Date.now()}`;
       const result = await createTokenSetRest(authToken, API_BASE_URL, projectId, {
-        name: 'global',
+        name: styleSetName,
         type: 'global',
         order_index: 0,
       }, undefined, changeSetId);
       expect(result.data).toBeDefined();
       expect(result.data.id).toBeDefined();
-      expect(result.data.attributes.name).toBe('global');
+      expect(result.data.attributes.name).toBe(styleSetName);
       styleSetId = result.data.id;
     });
 
@@ -343,7 +351,7 @@ describe('Tokens Studio REST API Integration', () => {
       typographyTokenId = result.data.id;
     });
 
-    it('creates a second token set when the active set already exists (reuse path)', async () => {
+    it('creates an additional token when the active set already exists (reuse path)', async () => {
       if (skipIntegration) return;
 
       // Simulates createMultipleTokens reusing an existing set ID instead of re-creating it.

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/__tests__/restApi.int.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/__tests__/restApi.int.test.ts
@@ -287,6 +287,94 @@ describe('Tokens Studio REST API Integration', () => {
     });
   });
 
+  // Simulates the write-back that happens when a user imports Figma styles into a project and
+  // confirms via the ImportedTokensDialog. The sequence mirrors createMultipleTokens.ts:
+  // create the active token set (if absent) → create each confirmed style token inside it.
+  // No themes are involved — styles have no collection/mode concept.
+  describe('Import Styles Flow', () => {
+    let styleSetId = '';
+    let colorTokenId = '';
+    let typographyTokenId = '';
+
+    it('creates a token set for the active set (styles have no parent)', async () => {
+      if (skipIntegration) return;
+
+      const result = await createTokenSetRest(authToken, API_BASE_URL, projectId, {
+        name: 'global',
+        type: 'global',
+        order_index: 0,
+      }, undefined, changeSetId);
+      expect(result.data).toBeDefined();
+      expect(result.data.id).toBeDefined();
+      expect(result.data.attributes.name).toBe('global');
+      styleSetId = result.data.id;
+    });
+
+    it('creates a color token from an imported style', async () => {
+      if (skipIntegration) return;
+
+      const result = await createTokenRest(authToken, API_BASE_URL, projectId, {
+        name: 'color.primary',
+        value: '#0D99FF',
+        type: 'color',
+        token_set_id: styleSetId,
+        description: 'Imported from Figma color style',
+      }, undefined, changeSetId);
+      expect(result.data).toBeDefined();
+      expect(result.data.id).toBeDefined();
+      expect(result.data.attributes.name).toBe('color.primary');
+      expect(result.data.attributes.value).toBe('#0D99FF');
+      colorTokenId = result.data.id;
+    });
+
+    it('creates a typography token from an imported style', async () => {
+      if (skipIntegration) return;
+
+      const result = await createTokenRest(authToken, API_BASE_URL, projectId, {
+        name: 'typography.heading',
+        value: { fontFamily: 'Inter', fontWeight: '700', fontSize: '32' },
+        type: 'typography',
+        token_set_id: styleSetId,
+        description: 'Imported from Figma text style',
+      }, undefined, changeSetId);
+      expect(result.data).toBeDefined();
+      expect(result.data.id).toBeDefined();
+      expect(result.data.attributes.name).toBe('typography.heading');
+      typographyTokenId = result.data.id;
+    });
+
+    it('creates a second token set when the active set already exists (reuse path)', async () => {
+      if (skipIntegration) return;
+
+      // Simulates createMultipleTokens reusing an existing set ID instead of re-creating it.
+      // The set already has styleSetId — we just create another token in it directly.
+      const result = await createTokenRest(authToken, API_BASE_URL, projectId, {
+        name: 'color.secondary',
+        value: '#FF6250',
+        type: 'color',
+        token_set_id: styleSetId,
+      }, undefined, changeSetId);
+      expect(result.data).toBeDefined();
+      expect(result.data.attributes.name).toBe('color.secondary');
+
+      // Clean up the extra token inline
+      await deleteTokenRest(authToken, API_BASE_URL, projectId, result.data.id, undefined, changeSetId);
+    });
+
+    // Clean up in reverse dependency order
+    it('deletes the imported style tokens', async () => {
+      if (skipIntegration) return;
+      await deleteTokenRest(authToken, API_BASE_URL, projectId, colorTokenId, undefined, changeSetId);
+      await deleteTokenRest(authToken, API_BASE_URL, projectId, typographyTokenId, undefined, changeSetId);
+    });
+
+    it('deletes the style token set', async () => {
+      if (skipIntegration) return;
+      const result = await deleteTokenSetRest(authToken, API_BASE_URL, projectId, styleSetId, undefined, changeSetId);
+      expect(result).toBeDefined();
+    });
+  });
+
   describe('Theme Groups', () => {
     let themeGroupId = '';
 

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/__tests__/restApi.int.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/__tests__/restApi.int.test.ts
@@ -2,6 +2,7 @@
 import {
   createTokenSetRest, updateTokenSetRest, deleteTokenSetRest,
   createTokenRest, updateTokenRest, deleteTokenRest,
+  batchCreateTokensRest,
   createThemeGroupRest, updateThemeGroupRest, deleteThemeGroupRest,
   createThemeOptionRest, updateThemeOptionRest, deleteThemeOptionRest,
 } from '../restApi';
@@ -177,7 +178,6 @@ describe('Tokens Studio REST API Integration', () => {
   describe('Import Variables Flow', () => {
     let primitiveSetId = '';
     let semanticSetId = '';
-    let tokenId = '';
     let themeGroupId = '';
     let themeOptionId = '';
     let primitiveName = '';
@@ -209,21 +209,17 @@ describe('Tokens Studio REST API Integration', () => {
       semanticSetId = semanticResult.data.id;
     });
 
-    it('creates tokens inside the imported token sets', async () => {
+    it('batch-creates tokens across both imported token sets in one request', async () => {
       if (skipIntegration) return;
 
-      const result = await createTokenRest(authToken, API_BASE_URL, projectId, {
-        name: 'color.brand',
-        value: '#7B61FF',
-        type: 'color',
-        token_set_id: primitiveSetId,
-        description: 'Imported from Figma variable',
-      }, undefined, changeSetId);
+      const result = await batchCreateTokensRest(authToken, API_BASE_URL, projectId, [
+        { name: 'color.brand', value: '#7B61FF', type: 'color', token_set_id: primitiveSetId, description: 'Imported from Figma variable' },
+        { name: 'spacing.sm', value: '8', type: 'dimension', token_set_id: primitiveSetId },
+        { name: 'color.bg', value: '{color.brand}', type: 'color', token_set_id: semanticSetId },
+      ], changeSetId);
       expect(result.data).toBeDefined();
-      expect(result.data.id).toBeDefined();
-      expect(result.data.attributes.name).toBe('color.brand');
-      expect(result.data.attributes.value).toBe('#7B61FF');
-      tokenId = result.data.id;
+      expect(result.data.created_count).toBe(3);
+      expect(result.data.requested_count).toBe(3);
     });
 
     it('creates a theme group for an imported variable collection', async () => {
@@ -279,12 +275,6 @@ describe('Tokens Studio REST API Integration', () => {
       expect(result).toBeDefined();
     });
 
-    it('deletes the imported token', async () => {
-      if (skipIntegration) return;
-      const result = await deleteTokenRest(authToken, API_BASE_URL, projectId, tokenId, undefined, changeSetId);
-      expect(result).toBeDefined();
-    });
-
     it('deletes the imported token sets', async () => {
       if (skipIntegration) return;
       await deleteTokenSetRest(authToken, API_BASE_URL, projectId, primitiveSetId, undefined, changeSetId);
@@ -294,13 +284,11 @@ describe('Tokens Studio REST API Integration', () => {
 
   // Simulates the write-back that happens when a user imports Figma styles into a project and
   // confirms via the ImportedTokensDialog. The sequence mirrors createMultipleTokens.ts:
-  // create the active token set (if absent) → create each confirmed style token inside it.
+  // create the active token set (if absent) → batch-create all confirmed style tokens in one call.
   // No themes are involved — styles have no collection/mode concept.
   describe('Import Styles Flow', () => {
     let styleSetId = '';
     let styleSetName = '';
-    let colorTokenId = '';
-    let typographyTokenId = '';
 
     it('creates a token set for the active set (styles have no parent)', async () => {
       if (skipIntegration) return;
@@ -318,62 +306,28 @@ describe('Tokens Studio REST API Integration', () => {
       styleSetId = result.data.id;
     });
 
-    it('creates a color token from an imported style', async () => {
+    it('batch-creates all confirmed style tokens in one request', async () => {
       if (skipIntegration) return;
 
-      const result = await createTokenRest(authToken, API_BASE_URL, projectId, {
-        name: 'color.primary',
-        value: '#0D99FF',
-        type: 'color',
-        token_set_id: styleSetId,
-        description: 'Imported from Figma color style',
-      }, undefined, changeSetId);
+      const result = await batchCreateTokensRest(authToken, API_BASE_URL, projectId, [
+        { name: 'color.primary', value: '#0D99FF', type: 'color', token_set_id: styleSetId, description: 'Imported from Figma color style' },
+        { name: 'typography.heading', value: { fontFamily: 'Inter', fontWeight: '700', fontSize: '32' }, type: 'typography', token_set_id: styleSetId, description: 'Imported from Figma text style' },
+        { name: 'spacing.md', value: '16', type: 'dimension', token_set_id: styleSetId },
+      ], changeSetId);
       expect(result.data).toBeDefined();
-      expect(result.data.id).toBeDefined();
-      expect(result.data.attributes.name).toBe('color.primary');
-      expect(result.data.attributes.value).toBe('#0D99FF');
-      colorTokenId = result.data.id;
+      expect(result.data.created_count).toBe(3);
+      expect(result.data.requested_count).toBe(3);
     });
 
-    it('creates a typography token from an imported style', async () => {
+    it('batch-creates tokens into an existing set (reuse path — set already has a server ID)', async () => {
       if (skipIntegration) return;
 
-      const result = await createTokenRest(authToken, API_BASE_URL, projectId, {
-        name: 'typography.heading',
-        value: { fontFamily: 'Inter', fontWeight: '700', fontSize: '32' },
-        type: 'typography',
-        token_set_id: styleSetId,
-        description: 'Imported from Figma text style',
-      }, undefined, changeSetId);
+      // Simulates createMultipleTokens reusing an existing set ID rather than re-creating it.
+      const result = await batchCreateTokensRest(authToken, API_BASE_URL, projectId, [
+        { name: 'color.secondary', value: '#FF6250', type: 'color', token_set_id: styleSetId },
+      ], changeSetId);
       expect(result.data).toBeDefined();
-      expect(result.data.id).toBeDefined();
-      expect(result.data.attributes.name).toBe('typography.heading');
-      typographyTokenId = result.data.id;
-    });
-
-    it('creates an additional token when the active set already exists (reuse path)', async () => {
-      if (skipIntegration) return;
-
-      // Simulates createMultipleTokens reusing an existing set ID instead of re-creating it.
-      // The set already has styleSetId — we just create another token in it directly.
-      const result = await createTokenRest(authToken, API_BASE_URL, projectId, {
-        name: 'color.secondary',
-        value: '#FF6250',
-        type: 'color',
-        token_set_id: styleSetId,
-      }, undefined, changeSetId);
-      expect(result.data).toBeDefined();
-      expect(result.data.attributes.name).toBe('color.secondary');
-
-      // Clean up the extra token inline
-      await deleteTokenRest(authToken, API_BASE_URL, projectId, result.data.id, undefined, changeSetId);
-    });
-
-    // Clean up in reverse dependency order
-    it('deletes the imported style tokens', async () => {
-      if (skipIntegration) return;
-      await deleteTokenRest(authToken, API_BASE_URL, projectId, colorTokenId, undefined, changeSetId);
-      await deleteTokenRest(authToken, API_BASE_URL, projectId, typographyTokenId, undefined, changeSetId);
+      expect(result.data.created_count).toBe(1);
     });
 
     it('deletes the style token set', async () => {

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/__tests__/restApi.int.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/__tests__/restApi.int.test.ts
@@ -3,6 +3,7 @@ import {
   createTokenSetRest, updateTokenSetRest, deleteTokenSetRest,
   createTokenRest, updateTokenRest, deleteTokenRest,
   createThemeGroupRest, updateThemeGroupRest, deleteThemeGroupRest,
+  createThemeOptionRest, updateThemeOptionRest, deleteThemeOptionRest,
 } from '../restApi';
 import { parseBranchesFromResponse } from '../fetchBranchesListRest';
 
@@ -167,6 +168,122 @@ describe('Tokens Studio REST API Integration', () => {
       if (skipIntegration) return;
       const result = await deleteTokenRest(authToken, API_BASE_URL, projectId, tokenId, undefined, changeSetId);
       expect(result).toBeDefined();
+    });
+  });
+
+  // Simulates the write-back that happens when a user imports Figma variables into an empty project.
+  // The sequence mirrors setTokensFromVariables.ts: create token sets → create tokens → create
+  // theme group → create theme options referencing the token sets.
+  describe('Import Variables Flow', () => {
+    let primitiveSetId = '';
+    let semanticSetId = '';
+    let tokenId = '';
+    let themeGroupId = '';
+    let themeOptionId = '';
+
+    it('creates token sets for imported variable collections', async () => {
+      if (skipIntegration) return;
+
+      const primitiveResult = await createTokenSetRest(authToken, API_BASE_URL, projectId, {
+        name: 'import-primitives',
+        type: 'global',
+        order_index: 0,
+      }, undefined, changeSetId);
+      expect(primitiveResult.data).toBeDefined();
+      expect(primitiveResult.data.id).toBeDefined();
+      expect(primitiveResult.data.attributes.name).toBe('import-primitives');
+      primitiveSetId = primitiveResult.data.id;
+
+      const semanticResult = await createTokenSetRest(authToken, API_BASE_URL, projectId, {
+        name: 'import-semantic',
+        type: 'global',
+        order_index: 1,
+      }, undefined, changeSetId);
+      expect(semanticResult.data).toBeDefined();
+      expect(semanticResult.data.id).toBeDefined();
+      semanticSetId = semanticResult.data.id;
+    });
+
+    it('creates tokens inside the imported token sets', async () => {
+      if (skipIntegration) return;
+
+      const result = await createTokenRest(authToken, API_BASE_URL, projectId, {
+        name: 'color.brand',
+        value: '#7B61FF',
+        type: 'color',
+        token_set_id: primitiveSetId,
+        description: 'Imported from Figma variable',
+      }, undefined, changeSetId);
+      expect(result.data).toBeDefined();
+      expect(result.data.id).toBeDefined();
+      expect(result.data.attributes.name).toBe('color.brand');
+      expect(result.data.attributes.value).toBe('#7B61FF');
+      tokenId = result.data.id;
+    });
+
+    it('creates a theme group for an imported variable collection', async () => {
+      if (skipIntegration) return;
+
+      const result = await createThemeGroupRest(authToken, API_BASE_URL, projectId, {
+        name: 'Mode',
+        options: [],
+      }, undefined, changeSetId);
+      expect(result.data).toBeDefined();
+      expect(result.data.id).toBeDefined();
+      expect(result.data.attributes.name).toBe('Mode');
+      themeGroupId = result.data.id;
+    });
+
+    it('creates a theme option referencing the imported token sets', async () => {
+      if (skipIntegration) return;
+
+      const result = await createThemeOptionRest(authToken, API_BASE_URL, projectId, {
+        name: 'Light',
+        theme_group_id: themeGroupId,
+        selected_token_sets: {
+          [primitiveSetId]: 'enabled',
+          [semanticSetId]: 'enabled',
+        },
+      }, undefined, changeSetId);
+      expect(result.data).toBeDefined();
+      expect(result.data.id).toBeDefined();
+      expect(result.data.attributes.name).toBe('Light');
+      themeOptionId = result.data.id;
+    });
+
+    it('updates a theme option (e.g. adding a second mode)', async () => {
+      if (skipIntegration) return;
+
+      const result = await updateThemeOptionRest(authToken, API_BASE_URL, projectId, themeOptionId, {
+        name: 'Light Mode',
+      }, undefined, changeSetId);
+      expect(result.data).toBeDefined();
+      expect(result.data.attributes.name).toBe('Light Mode');
+    });
+
+    // Clean up in reverse dependency order
+    it('deletes the theme option', async () => {
+      if (skipIntegration) return;
+      const result = await deleteThemeOptionRest(authToken, API_BASE_URL, projectId, themeOptionId, undefined, changeSetId);
+      expect(result).toBeDefined();
+    });
+
+    it('deletes the theme group', async () => {
+      if (skipIntegration) return;
+      const result = await deleteThemeGroupRest(authToken, API_BASE_URL, projectId, themeGroupId, undefined, changeSetId);
+      expect(result).toBeDefined();
+    });
+
+    it('deletes the imported token', async () => {
+      if (skipIntegration) return;
+      const result = await deleteTokenRest(authToken, API_BASE_URL, projectId, tokenId, undefined, changeSetId);
+      expect(result).toBeDefined();
+    });
+
+    it('deletes the imported token sets', async () => {
+      if (skipIntegration) return;
+      await deleteTokenSetRest(authToken, API_BASE_URL, projectId, primitiveSetId, undefined, changeSetId);
+      await deleteTokenSetRest(authToken, API_BASE_URL, projectId, semanticSetId, undefined, changeSetId);
     });
   });
 

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/__tests__/restApi.int.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/__tests__/restApi.int.test.ts
@@ -242,8 +242,8 @@ describe('Tokens Studio REST API Integration', () => {
         name: 'Light',
         theme_group_id: themeGroupId,
         selected_token_sets: {
-          [primitiveSetId]: 'enabled',
-          [semanticSetId]: 'enabled',
+          [primitiveName]: 'enabled',
+          [semanticName]: 'enabled',
         },
       }, undefined, changeSetId);
       expect(result.data).toBeDefined();

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/__tests__/restApi.int.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/__tests__/restApi.int.test.ts
@@ -182,6 +182,7 @@ describe('Tokens Studio REST API Integration', () => {
     let themeOptionId = '';
     let primitiveName = '';
     let semanticName = '';
+    let themeGroupName = '';
 
     it('creates token sets for imported variable collections', async () => {
       if (skipIntegration) return;
@@ -225,13 +226,14 @@ describe('Tokens Studio REST API Integration', () => {
     it('creates a theme group for an imported variable collection', async () => {
       if (skipIntegration) return;
 
+      themeGroupName = `Mode-${Date.now()}`;
       const result = await createThemeGroupRest(authToken, API_BASE_URL, projectId, {
-        name: 'Mode',
+        name: themeGroupName,
         options: [],
       }, undefined, changeSetId);
       expect(result.data).toBeDefined();
       expect(result.data.id).toBeDefined();
-      expect(result.data.attributes.name).toBe('Mode');
+      expect(result.data.attributes.name).toBe(themeGroupName);
       themeGroupId = result.data.id;
     });
 

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/restApi.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/restApi.ts
@@ -105,6 +105,28 @@ export async function deleteTokenSetRest(
 }
 
 // Token Operations
+export async function batchCreateTokensRest(
+  authToken: string,
+  apiBaseUrl: string,
+  projectId: string,
+  tokens: Array<{
+    name: string;
+    value: any;
+    type: string;
+    token_set_id: string;
+    description?: string;
+  }>,
+  changeSetId: string,
+) {
+  return restRequest(authToken, apiBaseUrl, `/api/v1/projects/${projectId}/tokens/batch_create`, {
+    method: 'POST',
+    body: {
+      change_set_id: changeSetId,
+      tokens,
+    },
+  });
+}
+
 export async function createTokenRest(
   authToken: string,
   apiBaseUrl: string,


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

Closes #0000 <!-- link the related issue -->

When a user imports Figma variables or styles into a Tokens Studio OAuth project, the resulting tokens and themes were only stored locally in the plugin — nothing was written back to the Studio REST API. This meant the imported data was lost on the next pull.

### What does this pull request do?

**Variables import write-back (`setTokensFromVariables` effect)**
- After importing Figma variables, creates token sets and tokens on the Studio REST API for any new sets that don't already exist on the server.
- Token sets are created sequentially (no batch API available), then all tokens across all sets are sent in a **single `POST /tokens/batch_create` request** rather than one request per token.
- Pushes theme groups and theme options after all token sets are created, so `selected_token_sets` references are valid.
- Strips locally-generated name-based IDs from new themes before pushing (prevents `PATCH → 404` by forcing `CREATE_THEME`).
- Pushes themes sequentially to avoid duplicate theme groups when multiple modes share the same group name.
- Records newly-created set IDs in `tokenSetMetadata` with a `fromVariableImport` flag so the `createMultipleTokens` effect can skip them and avoid duplicates.

**Styles import write-back (`setTokensFromStyles` + `createMultipleTokens` effects)**
- Styles import intentionally defers the Studio write until the user confirms in the `ImportedTokensDialog` ("Import All"), preserving the review-first UX.
- The new `createMultipleTokens` effect fires on dialog confirmation, creates the token set if absent (or reuses the existing server ID), then sends all confirmed tokens in a **single `POST /tokens/batch_create` request**.
- Skips sets marked `fromVariableImport` to avoid double-writing variable tokens when a mixed import is confirmed.

**Race condition fix (`setThemesFromVariables`)**
- `setThemesFromVariables` returns early when new tokens are also being imported, delegating theme pushing to `setTokensFromVariables` which runs after all token sets exist.
- Added `await Promise.resolve()` in `setTokensFromVariables` before reading `importedThemes` to yield the event loop and allow the `setThemesFromVariables` reducer to populate state first.

**Integration tests**
- Added `Import Variables Flow` suite: creates two token sets, tokens, a theme group, and a theme option; cleans up in reverse order.
- Added `Import Styles Flow` suite: creates a token set for the active set, a color token, a typography token, and exercises the reuse path for an already-existing set.

### Testing this change

1. Open a Figma file with variable collections and multiple modes.
2. Connect the plugin to a Tokens Studio OAuth project (with a pulled branch so `changeSetId` is set).
3. **Import Variables**: Run "Import Variables" — the `ImportedTokensDialog` should appear. Verify that token sets, tokens, theme groups, and theme options are created in Studio immediately (before confirming in the dialog).
4. **Import Styles**: Run "Import Styles" — the `ImportedTokensDialog` should appear first. Confirm with "Import All" — token sets and tokens should be created in Studio only after confirmation.
5. Pull from Studio and verify the imported data round-trips correctly.

For a project with **no prior pull** (no `changeSetId`): variables and styles should still appear in the plugin dialog; Studio write-back is skipped gracefully since `changeSetId` is required by the REST API.

To run the integration tests locally:
```bash
# From packages/tokens-studio-for-figma/
TOKENS_STUDIO_TEST_EMAIL=... TOKENS_STUDIO_TEST_PASSWORD=... yarn jest src/utils/tokensStudio/__tests__/restApi.int.test.ts --testPathIgnorePatterns='[]'
```

### Additional Notes (if any)