### PR TITLE
fix: skip local-changes dialog for Studio OAuth on plugin reopen

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/components/AppContainer/startupProcessSteps/__tests__/pullTokensFactory.test.ts
+++ b/packages/tokens-studio-for-figma/src/app/components/AppContainer/startupProcessSteps/__tests__/pullTokensFactory.test.ts
@@ -385,6 +385,66 @@ describe('pullTokensFactory', () => {
     expect(state.uiState.activeTab).toEqual(Tabs.START);
   });
 
+  it('should pull from Studio OAuth without showing local-changes dialog even when checkForChanges is true', async () => {
+    const mockOAuthStorageType: StorageType = {
+      id: 'my-project',
+      internalId: 'my-project',
+      name: 'Tokens Studio OAuth',
+      provider: StorageProviderType.TOKENS_STUDIO_OAUTH,
+    } as StorageType;
+
+    const mockStore = createMockStore({
+      uiState: {
+        storageType: mockOAuthStorageType,
+      },
+    });
+
+    const mockParams = {
+      localTokenData: {
+        checkForChanges: true,
+        values: {
+          global: [
+            {
+              type: TokenTypes.COLOR,
+              name: 'colors.red',
+              value: '#ff0000',
+              $extensions: {
+                'studio.tokens': {
+                  id: 'mock-uuid',
+                },
+              },
+            },
+          ],
+        },
+      },
+      localApiProviders: [
+        { ...mockOAuthStorageType, secret: 'secret' },
+      ],
+    } as unknown as StartupMessage;
+
+    const fn = pullTokensFactory(
+      mockStore,
+      mockStore.dispatch,
+      mockParams,
+      mockUseConfirm,
+      mockUseRemoteTokens,
+    );
+
+    mockFetchBranches.mockResolvedValueOnce(['main']);
+    mockPullTokens.mockResolvedValueOnce({
+      tokens: { global: [] },
+      themes: [],
+      metadata: {},
+    });
+
+    await fn();
+
+    // Dialog should never appear for Studio OAuth — changes are always in sync via REST
+    expect(mockConfirm).not.toBeCalled();
+    // Should pull from remote, not recover local state
+    expect(mockUseRemoteTokens.pullTokens).toBeCalledTimes(1);
+  });
+
   it('should categorize JSON parsing errors correctly', () => {
     const jsonError = new SyntaxError('Unexpected token } in JSON at position 10');
 

--- a/packages/tokens-studio-for-figma/src/app/components/AppContainer/startupProcessSteps/pullTokensFactory.ts
+++ b/packages/tokens-studio-for-figma/src/app/components/AppContainer/startupProcessSteps/pullTokensFactory.ts
@@ -191,8 +191,12 @@ export function pullTokensFactory(
     } else if (params.localTokenData) {
       const checkForChanges = params.localTokenData.checkForChanges ?? false;
 
+      // Studio providers sync every change immediately via REST — never treat stale local storage as "unsaved changes"
+      const isStudioProvider = storageType.provider === StorageProviderType.TOKENS_STUDIO_OAUTH;
+
       if (
         !checkForChanges
+        || isStudioProvider
         || (
           isRemoteStorage
           && checkForChanges && (!await askUserIfRecoverLocalChanges())

--- a/packages/tokens-studio-for-figma/src/app/components/AppContainer/startupProcessSteps/pullTokensFactory.ts
+++ b/packages/tokens-studio-for-figma/src/app/components/AppContainer/startupProcessSteps/pullTokensFactory.ts
@@ -191,12 +191,12 @@ export function pullTokensFactory(
     } else if (params.localTokenData) {
       const checkForChanges = params.localTokenData.checkForChanges ?? false;
 
-      // Studio providers sync every change immediately via REST — never treat stale local storage as "unsaved changes"
-      const isStudioProvider = storageType.provider === StorageProviderType.TOKENS_STUDIO_OAUTH;
+      // Studio OAuth syncs every change immediately via REST — never treat stale local storage as "unsaved changes"
+      const isStudioOAuthProvider = storageType.provider === StorageProviderType.TOKENS_STUDIO_OAUTH;
 
       if (
         !checkForChanges
-        || isStudioProvider
+        || isStudioOAuthProvider
         || (
           isRemoteStorage
           && checkForChanges && (!await askUserIfRecoverLocalChanges())

--- a/packages/tokens-studio-for-figma/src/app/store/models/tokenState.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/models/tokenState.tsx
@@ -1131,7 +1131,7 @@ export const tokenState = createModel<RootModel>()({
         }
 
         // Check if there are unsaved changes before updating
-        // Studio OAuth pushes every change immediately via REST — skip local-change tracking
+        // Tokens Studio (including OAuth) pushes every change immediately via REST — skip local-change tracking
         if (rootState.uiState.storageType.provider !== StorageProviderType.TOKENS_STUDIO
           && rootState.uiState.storageType.provider !== StorageProviderType.TOKENS_STUDIO_OAUTH) {
           const { lastSyncedState } = rootState.tokenState;

--- a/packages/tokens-studio-for-figma/src/app/store/models/tokenState.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/models/tokenState.tsx
@@ -1131,7 +1131,9 @@ export const tokenState = createModel<RootModel>()({
         }
 
         // Check if there are unsaved changes before updating
-        if (rootState.uiState.storageType.provider !== StorageProviderType.TOKENS_STUDIO) {
+        // Studio OAuth pushes every change immediately via REST — skip local-change tracking
+        if (rootState.uiState.storageType.provider !== StorageProviderType.TOKENS_STUDIO
+          && rootState.uiState.storageType.provider !== StorageProviderType.TOKENS_STUDIO_OAUTH) {
           const { lastSyncedState } = rootState.tokenState;
           const hasChanges = !compareLastSyncedState(
             rootState.tokenState.tokens,

--- a/packages/tokens-studio-for-figma/src/hooks/__tests__/useChangedState.test.ts
+++ b/packages/tokens-studio-for-figma/src/hooks/__tests__/useChangedState.test.ts
@@ -1,0 +1,79 @@
+import { renderHook } from '@testing-library/react';
+import { StorageProviderType } from '@/constants/StorageProviderType';
+
+import { useChangedState } from '../useChangedState';
+
+const mockUpdateCheckForChanges = jest.fn();
+const mockDispatch = {
+  tokenState: {
+    updateCheckForChanges: mockUpdateCheckForChanges,
+  },
+};
+
+const mockTokens = {};
+const mockThemes = [];
+let mockStorageType = { provider: StorageProviderType.LOCAL };
+const mockLastSyncedState = null;
+const mockTokenFormat = 'dtcg';
+
+jest.mock('react-redux', () => ({
+  useDispatch: () => mockDispatch,
+  useSelector: (selector: any) => selector({
+    tokenState: {
+      tokens: mockTokens,
+      themes: mockThemes,
+      lastSyncedState: mockLastSyncedState,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      tokenFormat: mockTokenFormat,
+      tokenSetMetadata: {},
+    },
+    uiState: {
+      storageType: mockStorageType,
+    },
+  }),
+}));
+
+jest.mock('@/selectors', () => ({
+  lastSyncedStateSelector: (state: any) => state.tokenState.lastSyncedState,
+  remoteDataSelector: (_state: any) => ({ tokens: {}, themes: [], metadata: {} }),
+  storageTypeSelector: (state: any) => state.uiState.storageType,
+  themesListSelector: (state: any) => state.tokenState.themes,
+  tokensSelector: (state: any) => state.tokenState.tokens,
+}));
+
+jest.mock('@/selectors/tokenSetMetadataSelector', () => ({
+  tokenSetMetadataSelector: (state: any) => state.tokenState.tokenSetMetadata,
+}));
+
+jest.mock('@/selectors/tokenFormatSelector', () => ({
+  tokenFormatSelector: (state: any) => state.tokenState.tokenFormat,
+}));
+
+jest.mock('@/utils/compareLastSyncedState', () => ({
+  compareLastSyncedState: jest.fn(() => false), // always "has changes" by default
+}));
+
+jest.mock('@/utils/findDifferentState', () => ({
+  findDifferentState: jest.fn(() => []),
+}));
+
+describe('useChangedState', () => {
+  beforeEach(() => {
+    mockUpdateCheckForChanges.mockClear();
+    mockStorageType = { provider: StorageProviderType.LOCAL };
+  });
+
+  it('dispatches hasChanges=true for LOCAL provider when state differs from lastSyncedState', () => {
+    mockStorageType = { provider: StorageProviderType.LOCAL };
+    renderHook(() => useChangedState());
+    expect(mockUpdateCheckForChanges).toHaveBeenCalledWith(true);
+  });
+
+  it('always dispatches checkForChanges=false for TOKENS_STUDIO_OAUTH regardless of token diff', () => {
+    mockStorageType = { provider: StorageProviderType.TOKENS_STUDIO_OAUTH };
+    renderHook(() => useChangedState());
+    expect(mockUpdateCheckForChanges).toHaveBeenCalledWith(false);
+    expect(mockUpdateCheckForChanges).not.toHaveBeenCalledWith(true);
+  });
+
+});

--- a/packages/tokens-studio-for-figma/src/hooks/__tests__/useChangedState.test.ts
+++ b/packages/tokens-studio-for-figma/src/hooks/__tests__/useChangedState.test.ts
@@ -23,7 +23,6 @@ jest.mock('react-redux', () => ({
       tokens: mockTokens,
       themes: mockThemes,
       lastSyncedState: mockLastSyncedState,
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       tokenFormat: mockTokenFormat,
       tokenSetMetadata: {},
     },

--- a/packages/tokens-studio-for-figma/src/hooks/useChangedState.ts
+++ b/packages/tokens-studio-for-figma/src/hooks/useChangedState.ts
@@ -52,8 +52,13 @@ export function useChangedState() {
 
   // Move the dispatch call to useEffect to avoid setState during render
   useEffect(() => {
+    // Studio OAuth pushes every change immediately via REST — no local-only changes exist
+    if (storageType.provider === StorageProviderType.TOKENS_STUDIO_OAUTH) {
+      dispatch.tokenState.updateCheckForChanges(false);
+      return;
+    }
     dispatch.tokenState.updateCheckForChanges(hasChanges);
-  }, [hasChanges, dispatch.tokenState]);
+  }, [hasChanges, dispatch.tokenState, storageType.provider]);
 
   return { changedPushState, changedPullState, hasChanges };
 }


### PR DESCRIPTION
### Why does this PR exist?

Closes #0000

When using Studio OAuth, reopening the plugin always showed the "Recover local changes?" dialog — even when all changes had already been written back to Studio. This happened because `lastSyncedState` was never updated after individual REST push operations (editToken, deleteToken, etc.), causing `checkForChanges` to be persisted as `true` to Figma plugin storage on every session.

### What does this pull request do?

- **`useChangedState.ts`** — For `TOKENS_STUDIO_OAUTH`, always dispatch `checkForChanges=false`. Every edit is immediately synced via individual REST actions, so the concept of unsaved local changes doesn't apply.
- **`tokenState.tsx`** — Extend the existing `updateDocument` guard (which already excluded `TOKENS_STUDIO`) to also exclude `TOKENS_STUDIO_OAUTH` for the same reason.
- **`pullTokensFactory.ts`** — Defense-in-depth: skip the local-changes dialog for `TOKENS_STUDIO_OAUTH` at startup, even if a stale `checkForChanges=true` is already stored in Figma plugin data from a session before this fix.

### Testing this change

1. Open the plugin with a Studio OAuth connection configured
2. Edit one or more tokens
3. Close and reopen the plugin
4. Confirm the "Recover local changes?" dialog no longer appears

### Additional Notes (if any)