### PR TITLE
fix: bind backgroundBlur radius as Figma variable instead of raw value

### DIFF
--- a/.changeset/fix-background-blur-variable-binding.md
+++ b/.changeset/fix-background-blur-variable-binding.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Background blur tokens now bind the radius as a Figma variable instead of a static value, consistent with how box shadow effects handle variable binding.

--- a/packages/tokens-studio-for-figma/src/plugin/applyBackgroundBlurValuesOnNode.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/applyBackgroundBlurValuesOnNode.test.ts
@@ -1,0 +1,74 @@
+import { applyBackgroundBlurValuesOnNode } from './applyBackgroundBlurValuesOnNode';
+import setBackgroundBlurOnTarget from './setBackgroundBlurOnTarget';
+
+jest.mock('./setBackgroundBlurOnTarget');
+const mockSetBackgroundBlurOnTarget = setBackgroundBlurOnTarget as jest.MockedFunction<typeof setBackgroundBlurOnTarget>;
+
+describe('applyBackgroundBlurValuesOnNode', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSetBackgroundBlurOnTarget.mockResolvedValue(undefined);
+  });
+
+  const baseFontSize = '16px';
+
+  it('calls setBackgroundBlurOnTarget with value and token name', async () => {
+    const node = { type: 'RECTANGLE', effects: [] } as unknown as RectangleNode;
+    const data = { backgroundBlur: 'blur.background' };
+    const values = { backgroundBlur: '12' };
+
+    await applyBackgroundBlurValuesOnNode(node, data, values, baseFontSize);
+
+    expect(mockSetBackgroundBlurOnTarget).toHaveBeenCalledWith(
+      node,
+      { value: '12' },
+      baseFontSize,
+      'blur.background',
+    );
+  });
+
+  it('does nothing when values.backgroundBlur is undefined', async () => {
+    const node = { type: 'RECTANGLE', effects: [] } as unknown as RectangleNode;
+    const data = { backgroundBlur: 'blur.background' };
+    const values = {};
+
+    await applyBackgroundBlurValuesOnNode(node, data, values, baseFontSize);
+
+    expect(mockSetBackgroundBlurOnTarget).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when node has no effects property', async () => {
+    const node = { type: 'TEXT' } as unknown as BaseNode;
+    const data = { backgroundBlur: 'blur.background' };
+    const values = { backgroundBlur: '12' };
+
+    await applyBackgroundBlurValuesOnNode(node, data, values, baseFontSize);
+
+    expect(mockSetBackgroundBlurOnTarget).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when backgroundBlur value is not primitive (object)', async () => {
+    const node = { type: 'RECTANGLE', effects: [] } as unknown as RectangleNode;
+    const data = { backgroundBlur: 'blur.background' };
+    const values = { backgroundBlur: { nested: 'value' } as any };
+
+    await applyBackgroundBlurValuesOnNode(node, data, values, baseFontSize);
+
+    expect(mockSetBackgroundBlurOnTarget).not.toHaveBeenCalled();
+  });
+
+  it('passes token name from data to setBackgroundBlurOnTarget', async () => {
+    const node = { type: 'FRAME', effects: [] } as unknown as FrameNode;
+    const data = { backgroundBlur: 'dimension.blur.lg' };
+    const values = { backgroundBlur: '24' };
+
+    await applyBackgroundBlurValuesOnNode(node, data, values, baseFontSize);
+
+    expect(mockSetBackgroundBlurOnTarget).toHaveBeenCalledWith(
+      node,
+      { value: '24' },
+      baseFontSize,
+      'dimension.blur.lg',
+    );
+  });
+});

--- a/packages/tokens-studio-for-figma/src/plugin/applyBackgroundBlurValuesOnNode.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/applyBackgroundBlurValuesOnNode.ts
@@ -10,6 +10,6 @@ export async function applyBackgroundBlurValuesOnNode(
   baseFontSize: string,
 ) {
   if ('effects' in node && typeof values.backgroundBlur !== 'undefined' && isPrimitiveValue(values.backgroundBlur)) {
-    setBackgroundBlurOnTarget(node, { value: String(values.backgroundBlur) }, baseFontSize);
+    await setBackgroundBlurOnTarget(node, { value: String(values.backgroundBlur) }, baseFontSize, data.backgroundBlur);
   }
 }

--- a/packages/tokens-studio-for-figma/src/plugin/setBackgroundBlurOnTarget.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/setBackgroundBlurOnTarget.test.ts
@@ -1,4 +1,6 @@
+import { ApplyVariablesStylesOrRawValues } from '@/constants/ApplyVariablesStyleOrder';
 import { TokenTypes } from '@/constants/TokenTypes';
+import { defaultTokenValueRetriever } from './TokenValueRetriever';
 import setBackgroundBlurOnTarget from './setBackgroundBlurOnTarget';
 
 const shadowEffect = {
@@ -113,6 +115,82 @@ describe('setBackgroundBlurOnTarget', () => {
           radius: 3,
         },
       ],
+    });
+  });
+
+  describe('variable binding', () => {
+    const mockVariable = { id: 'var:123', name: 'blur/background' };
+    const boundEffect = {
+      type: 'BACKGROUND_BLUR',
+      visible: true,
+      radius: 3,
+      boundVariables: { radius: { type: 'VARIABLE_ALIAS', id: 'var:123' } },
+    };
+
+    beforeEach(() => {
+      defaultTokenValueRetriever.applyVariablesStylesOrRawValue = ApplyVariablesStylesOrRawValues.VARIABLES_STYLES;
+      defaultTokenValueRetriever.getVariableReference = jest.fn().mockResolvedValue(mockVariable);
+      (figma.variables.setBoundVariableForEffect as jest.Mock) = jest.fn().mockReturnValue(boundEffect);
+    });
+
+    afterEach(() => {
+      defaultTokenValueRetriever.applyVariablesStylesOrRawValue = ApplyVariablesStylesOrRawValues.RAW_VALUES;
+    });
+
+    it('binds variable to radius when tokenName is provided and variables mode is active', async () => {
+      await setBackgroundBlurOnTarget(rectangleNodeMock, dimensionToken, '16px', 'blur.background');
+
+      expect(defaultTokenValueRetriever.getVariableReference).toHaveBeenCalledWith('blur.background');
+      expect(figma.variables.setBoundVariableForEffect).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'BACKGROUND_BLUR', radius: 3 }),
+        'radius',
+        mockVariable,
+      );
+      expect(rectangleNodeMock.effects[0]).toEqual(expect.objectContaining({
+        boundVariables: { radius: { type: 'VARIABLE_ALIAS', id: 'var:123' } },
+      }));
+    });
+
+    it('does not bind variable when tokenName is not provided', async () => {
+      await setBackgroundBlurOnTarget(rectangleNodeMock, dimensionToken, '16px');
+
+      expect(defaultTokenValueRetriever.getVariableReference).not.toHaveBeenCalled();
+      expect(figma.variables.setBoundVariableForEffect).not.toHaveBeenCalled();
+    });
+
+    it('does not bind variable when applyVariablesStylesOrRawValue is not VARIABLES_STYLES', async () => {
+      defaultTokenValueRetriever.applyVariablesStylesOrRawValue = ApplyVariablesStylesOrRawValues.RAW_VALUES;
+
+      await setBackgroundBlurOnTarget(rectangleNodeMock, dimensionToken, '16px', 'blur.background');
+
+      expect(defaultTokenValueRetriever.getVariableReference).not.toHaveBeenCalled();
+    });
+
+    it('falls back to raw value when variable reference is not found', async () => {
+      defaultTokenValueRetriever.getVariableReference = jest.fn().mockResolvedValue(undefined);
+
+      await setBackgroundBlurOnTarget(rectangleNodeMock, dimensionToken, '16px', 'blur.background');
+
+      expect(figma.variables.setBoundVariableForEffect).not.toHaveBeenCalled();
+      expect(rectangleNodeMock.effects[0]).toEqual({
+        type: 'BACKGROUND_BLUR',
+        visible: true,
+        radius: 3,
+      });
+    });
+
+    it('falls back gracefully when setBoundVariableForEffect throws', async () => {
+      (figma.variables.setBoundVariableForEffect as jest.Mock).mockImplementation(() => {
+        throw new Error('Figma API error');
+      });
+
+      await setBackgroundBlurOnTarget(rectangleNodeMock, dimensionToken, '16px', 'blur.background');
+
+      expect(rectangleNodeMock.effects[0]).toEqual({
+        type: 'BACKGROUND_BLUR',
+        visible: true,
+        radius: 3,
+      });
     });
   });
 });

--- a/packages/tokens-studio-for-figma/src/plugin/setBackgroundBlurOnTarget.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/setBackgroundBlurOnTarget.ts
@@ -1,21 +1,39 @@
+import { ApplyVariablesStylesOrRawValues } from '@/constants/ApplyVariablesStyleOrder';
 import { SingleDimensionToken } from '@/types/tokens';
+import { defaultTokenValueRetriever } from './TokenValueRetriever';
 import { transformValue } from './helpers';
 
-export default function setBackgroundBlurOnTarget(
+export default async function setBackgroundBlurOnTarget(
   target: BaseNode | EffectStyle,
   token: Pick<SingleDimensionToken, 'value'>,
-  baseFontSize: string,
+  baseFontSize?: string,
+  tokenName?: string,
 ) {
   try {
     if ('effects' in target) {
       const existingEffectIndex = target.effects.findIndex((effect) => effect.type === 'BACKGROUND_BLUR');
       let newEffects = [...target.effects];
       // @ts-ignore TODO: Update typings
-      const blurEffect: BlurEffect = {
+      let blurEffect: BlurEffect = {
         type: 'BACKGROUND_BLUR',
         visible: true,
-        radius: transformValue(String(token.value), 'backgroundBlur', baseFontSize),
+        radius: transformValue(String(token.value), 'backgroundBlur', baseFontSize ?? ''),
       };
+
+      if (tokenName && defaultTokenValueRetriever.applyVariablesStylesOrRawValue === ApplyVariablesStylesOrRawValues.VARIABLES_STYLES) {
+        try {
+          const variable = await defaultTokenValueRetriever.getVariableReference(tokenName);
+          if (variable) {
+            const updatedEffect = figma.variables.setBoundVariableForEffect(blurEffect, 'radius' as VariableBindableEffectField, variable);
+            blurEffect = {
+              ...blurEffect,
+              boundVariables: updatedEffect.boundVariables,
+            };
+          }
+        } catch (e) {
+          console.error('Error binding variable to background blur', e);
+        }
+      }
 
       if (existingEffectIndex > -1) {
         newEffects = Object.assign([], target.effects, { [existingEffectIndex]: blurEffect });


### PR DESCRIPTION
### Why does this PR exist?

Closes #3886 

Background blur tokens applied the radius as a raw number instead of binding it as a Figma variable. Box shadow already handled this correctly via `setBoundVariableForEffect` — background blur was missing the same logic.

### What does this pull request do?

- Calls `figma.variables.setBoundVariableForEffect` on the blur radius when a variable reference exists, matching box shadow behaviour in `setEffectValuesOnTarget`
- Passes the token name through `applyBackgroundBlurValuesOnNode` → `setBackgroundBlurOnTarget` to enable the variable lookup
- Falls back to raw value if no variable is found or the API throws
- Adds tests for `applyBackgroundBlurValuesOnNode` and extends `setBackgroundBlurOnTarget` tests to cover variable binding and fallback cases

### Testing this change

1. Create a Dimension token (e.g. `blur.background = 12`)
2. Export variables so a Figma variable is created for it
3. Select a frame → right-click token → apply as Background Blur
4. Check the blur in Figma's design panel — radius should show a bound variable

### Additional Notes (if any)