### PR TITLE
delete connected variables to tokens

### DIFF
--- a/.changeset/little-ghosts-press.md
+++ b/.changeset/little-ghosts-press.md
@@ -2,4 +2,4 @@
 "@tokens-studio/figma-plugin": patch
 ---
 
-Implement ability to delete connected variables/styles in Figma when a token is deleted in the plugin
+When you delete a token, we now ask you if you want to delete the associated variable/style in Figma

--- a/.changeset/little-ghosts-press.md
+++ b/.changeset/little-ghosts-press.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Implement ability to delete connected variables/styles in Figma when a token is deleted in the plugin

--- a/.changeset/little-ghosts-press.md
+++ b/.changeset/little-ghosts-press.md
@@ -2,4 +2,4 @@
 "@tokens-studio/figma-plugin": patch
 ---
 
-When you delete a token, we now ask you if you want to delete the associated variable/style in Figma
+When you delete a token, we now ask you if you want to delete the associated variable in Figma

--- a/packages/tokens-studio-for-figma/src/app/store/useManageTokens.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/useManageTokens.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/types/payloads';
 import useTokens from './useTokens';
 import { StyleOptions } from '@/constants/StyleOptions';
+import { tokenTypesToCreateVariable } from '@/constants/VariableTypes';
 import { ColorModifier } from '@/types/Modifier';
 import { wrapTransaction } from '@/profiling/transaction';
 
@@ -56,7 +57,7 @@ export default function useManageTokens() {
   const store = useStore<RootState>();
   const dispatch = useDispatch<Dispatch>();
   const { confirm } = useConfirm();
-  const { removeStylesFromTokens } = useTokens();
+  const { removeStylesFromTokens, removeVariablesFromToken } = useTokens();
   const {
     editToken, createToken, deleteToken, duplicateToken, deleteTokenGroup, renameTokenGroup, duplicateTokenGroup, renameTokenAcrossSets, deleteDuplicateTokens,
   } = dispatch.tokenState;
@@ -132,9 +133,15 @@ export default function useManageTokens() {
 
   const deleteSingleToken = useCallback(async (data: DeleteTokenPayload) => {
     const choices: Choice[] = [];
-    if (store.getState().tokenState.themes.length > 0 && data.type && [TokenTypes.COLOR, TokenTypes.TYPOGRAPHY, TokenTypes.BOX_SHADOW].includes(data?.type)) {
+    const themes = store.getState().tokenState.themes;
+    if (themes.length > 0 && data.type && [TokenTypes.COLOR, TokenTypes.TYPOGRAPHY, TokenTypes.BOX_SHADOW].includes(data?.type)) {
       choices.push({
         key: StyleOptions.REMOVE, label: 'Delete associated style',
+      });
+    }
+    if (themes.length > 0 && data.type && tokenTypesToCreateVariable.includes(data.type as TokenTypes)) {
+      choices.push({
+        key: StyleOptions.REMOVE_VARIABLE, label: 'Delete connected variable',
       });
     }
 
@@ -162,11 +169,14 @@ export default function useManageTokens() {
       if (Array.isArray(userConfirmation.data) && userConfirmation.data.includes(StyleOptions.REMOVE)) {
         removeStylesFromTokens(data);
       }
+      if (Array.isArray(userConfirmation.data) && userConfirmation.data.includes(StyleOptions.REMOVE_VARIABLE)) {
+        removeVariablesFromToken(data.path);
+      }
       dispatch.uiState.completeJob(BackgroundJobs.UI_DELETETOKEN);
       dispatch.tokenState.removeStyleNamesFromThemes(data.path, data.parent); // TODO: This triggers an updateDocument call
       dispatch.tokenState.removeVariableNamesFromThemes(data.path, data.parent); // TODO: This triggers an updateDocument call - its own!
     }
-  }, [confirm, deleteToken, dispatch.uiState]);
+  }, [confirm, deleteToken, dispatch.uiState, removeVariablesFromToken, removeStylesFromTokens]);
 
   const deleteGroup = useCallback(async (path: string, type: string) => {
     const userConfirmation = await confirm({

--- a/packages/tokens-studio-for-figma/src/app/store/useManageTokens.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/useManageTokens.tsx
@@ -134,12 +134,14 @@ export default function useManageTokens() {
   const deleteSingleToken = useCallback(async (data: DeleteTokenPayload) => {
     const choices: Choice[] = [];
     const themes = store.getState().tokenState.themes;
-    if (themes.length > 0 && data.type && [TokenTypes.COLOR, TokenTypes.TYPOGRAPHY, TokenTypes.BOX_SHADOW].includes(data?.type)) {
+    const hasConnectedStyle = themes.some((theme) => !!theme.$figmaStyleReferences?.[data.path]);
+    if (hasConnectedStyle && data.type && [TokenTypes.COLOR, TokenTypes.TYPOGRAPHY, TokenTypes.BOX_SHADOW].includes(data?.type)) {
       choices.push({
         key: StyleOptions.REMOVE, label: 'Delete associated style',
       });
     }
-    if (themes.length > 0 && data.type && tokenTypesToCreateVariable.includes(data.type as TokenTypes)) {
+    const hasConnectedVariable = themes.some((theme) => !!theme.$figmaVariableReferences?.[data.path]);
+    if (hasConnectedVariable && data.type && tokenTypesToCreateVariable.includes(data.type as TokenTypes)) {
       choices.push({
         key: StyleOptions.REMOVE_VARIABLE, label: 'Delete connected variable',
       });

--- a/packages/tokens-studio-for-figma/src/app/store/useTokens.test.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/useTokens.test.tsx
@@ -7,7 +7,7 @@ import useTokens from './useTokens';
 import { AnyTokenList, SingleToken } from '@/types/tokens';
 import { AsyncMessageChannel } from '@/AsyncMessageChannel';
 import { AsyncMessageTypes, GetThemeInfoMessageResult } from '@/types/AsyncMessages';
-import { createStyles, renameStyles, removeStyles } from '@/plugin/asyncMessageHandlers';
+import { createStyles, renameStyles, removeStyles, removeVariables } from '@/plugin/asyncMessageHandlers';
 import { AllTheProviders, createMockStore, resetStore } from '../../../tests/config/setupTest';
 import { store } from '../store';
 import { TokenSetStatus } from '@/constants/TokenSetStatus';
@@ -472,6 +472,7 @@ describe('useToken test', () => {
     AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.CREATE_STYLES, createStyles);
     AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.RENAME_STYLES, renameStyles);
     AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.REMOVE_STYLES, removeStyles);
+    AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.REMOVE_VARIABLES, removeVariables);
 
     it('creates all styles', async () => {
       const tokens = [
@@ -741,6 +742,66 @@ describe('useToken test', () => {
         token: tokenToDelete,
         settings: store.getState().settings,
       });
+    });
+
+    it('removeVariablesFromToken sends REMOVE_VARIABLES with deduped keys from themes', async () => {
+      const storeWithRefs = createMockStore({
+        tokenState: {
+          themes: [
+            {
+              id: 'light',
+              name: 'Light',
+              selectedTokenSets: { global: TokenSetStatus.ENABLED },
+              $figmaVariableReferences: { 'color.red': 'key-abc' },
+            },
+            {
+              id: 'dark',
+              name: 'Dark',
+              selectedTokenSets: { global: TokenSetStatus.ENABLED },
+              $figmaVariableReferences: { 'color.red': 'key-abc' },
+            },
+          ],
+        },
+      });
+      const { result: hookResult } = renderHook(() => useTokens(), {
+        wrapper: ({ children }: { children?: React.ReactNode }) => (
+          <Provider store={storeWithRefs}>{children}</Provider>
+        ),
+      });
+      await act(async () => {
+        await hookResult.current.removeVariablesFromToken('color.red');
+      });
+      expect(messageSpy).toBeCalledWith({
+        type: AsyncMessageTypes.REMOVE_VARIABLES,
+        variableKeys: ['key-abc'],
+      });
+    });
+
+    it('removeVariablesFromToken does not send message when no variable keys found', async () => {
+      messageSpy.mockClear();
+      const storeWithNoRefs = createMockStore({
+        tokenState: {
+          themes: [
+            {
+              id: 'light',
+              name: 'Light',
+              selectedTokenSets: { global: TokenSetStatus.ENABLED },
+              $figmaVariableReferences: {},
+            },
+          ],
+        },
+      });
+      const { result: hookResult } = renderHook(() => useTokens(), {
+        wrapper: ({ children }: { children?: React.ReactNode }) => (
+          <Provider store={storeWithNoRefs}>{children}</Provider>
+        ),
+      });
+      await act(async () => {
+        await hookResult.current.removeVariablesFromToken('color.red');
+      });
+      expect(messageSpy).not.toBeCalledWith(
+        expect.objectContaining({ type: AsyncMessageTypes.REMOVE_VARIABLES }),
+      );
     });
   });
 

--- a/packages/tokens-studio-for-figma/src/app/store/useTokens.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/useTokens.tsx
@@ -772,8 +772,8 @@ export default function useTokens() {
     async (tokenName: string) => {
       track('removeVariables', { tokenName });
 
-      const { themes } = store.getState().tokenState;
-      const variableKeys = themes.reduce<string[]>((acc, theme) => {
+      const { themes: tokenStateThemes } = store.getState().tokenState;
+      const variableKeys = tokenStateThemes.reduce<string[]>((acc, theme) => {
         const key = theme.$figmaVariableReferences?.[tokenName];
         if (key && !acc.includes(key)) {
           acc.push(key);

--- a/packages/tokens-studio-for-figma/src/app/store/useTokens.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/useTokens.tsx
@@ -768,6 +768,29 @@ export default function useTokens() {
     [dispatch.tokenState],
   );
 
+  const removeVariablesFromToken = useCallback(
+    async (tokenName: string) => {
+      track('removeVariables', { tokenName });
+
+      const { themes } = store.getState().tokenState;
+      const variableKeys = themes.reduce<string[]>((acc, theme) => {
+        const key = theme.$figmaVariableReferences?.[tokenName];
+        if (key && !acc.includes(key)) {
+          acc.push(key);
+        }
+        return acc;
+      }, []);
+
+      if (variableKeys.length === 0) return;
+
+      await wrapTransaction({ name: 'removeVariables' }, async () => AsyncMessageChannel.ReactInstance.message({
+        type: AsyncMessageTypes.REMOVE_VARIABLES,
+        variableKeys,
+      }));
+    },
+    [store],
+  );
+
   const updateVariablesFromToken = useCallback(async (payload: UpdateTokenVariablePayload) => {
     track('updateVariables', payload);
 
@@ -799,6 +822,7 @@ export default function useTokens() {
       createVariables,
       createVariablesFromSets,
       renameVariablesFromToken,
+      removeVariablesFromToken,
       createVariablesFromThemes,
       updateVariablesFromToken,
       filterMultiValueTokens,
@@ -825,6 +849,7 @@ export default function useTokens() {
       createVariablesFromSets,
       createVariablesFromThemes,
       renameVariablesFromToken,
+      removeVariablesFromToken,
       updateVariablesFromToken,
       filterMultiValueTokens,
     ],

--- a/packages/tokens-studio-for-figma/src/constants/StyleOptions.ts
+++ b/packages/tokens-studio-for-figma/src/constants/StyleOptions.ts
@@ -1,4 +1,5 @@
 export enum StyleOptions {
   REMOVE = 'style-remove',
   RENAME = 'style-rename',
+  REMOVE_VARIABLE = 'variable-remove',
 }

--- a/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/__tests__/removeVariables.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/__tests__/removeVariables.test.ts
@@ -1,0 +1,43 @@
+import {
+  mockGetLocalVariableCollectionsAsync,
+  mockGetLocalVariablesAsync,
+} from '../../../../tests/__mocks__/figmaMock';
+import { removeVariables } from '../removeVariables';
+import { AsyncMessageTypes } from '@/types/AsyncMessages';
+
+describe('removeVariables', () => {
+  const mockVariable = {
+    id: 'VariableID:1234',
+    key: 'abc123',
+    name: 'color/primary',
+    variableCollectionId: 'VariableCollectionId:1:1',
+    remove: jest.fn(),
+  };
+
+  beforeEach(() => {
+    mockVariable.remove.mockClear();
+    mockGetLocalVariablesAsync.mockResolvedValue([mockVariable]);
+    mockGetLocalVariableCollectionsAsync.mockResolvedValue([
+      {
+        id: 'VariableCollectionId:1:1',
+        name: 'Collection',
+        remote: false,
+        modes: [{ name: 'Default', modeId: '1' }],
+      },
+    ]);
+  });
+
+  it('removes variables matching provided keys and returns their keys', async () => {
+    const msg = { type: AsyncMessageTypes.REMOVE_VARIABLES, variableKeys: ['abc123'] };
+    const result = await removeVariables(msg as any);
+    expect(mockVariable.remove).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ variableKeys: ['abc123'] });
+  });
+
+  it('returns empty array and does not throw when no keys match', async () => {
+    const msg = { type: AsyncMessageTypes.REMOVE_VARIABLES, variableKeys: ['nonexistent'] };
+    const result = await removeVariables(msg as any);
+    expect(mockVariable.remove).not.toHaveBeenCalled();
+    expect(result).toEqual({ variableKeys: [] });
+  });
+});

--- a/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/index.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/index.ts
@@ -38,6 +38,7 @@ export * from './createLocalVariablesWithoutModes';
 export * from './resolveVariableInfo';
 export * from './attachLocalVariablesToTheme';
 export * from './renameVariables';
+export * from './removeVariables';
 export * from './updateVariables';
 export * from './setInitialLoad';
 export * from './preview';

--- a/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/removeStyles.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/removeStyles.ts
@@ -5,7 +5,7 @@ import removeStylesFromPlugin from '../removeStylesFromPlugin';
 export const removeStyles: AsyncMessageChannelHandlers[AsyncMessageTypes.REMOVE_STYLES] = async (msg) => {
   try {
     return {
-      styleIds: await removeStylesFromPlugin(msg.token),
+      styleIds: await removeStylesFromPlugin(msg.token, msg.settings),
     };
   } catch (e) {
     console.error(e);

--- a/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/removeVariables.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/removeVariables.ts
@@ -5,13 +5,13 @@ import removeVariablesFromPlugin from '../removeVariablesFromPlugin';
 export const removeVariables: AsyncMessageChannelHandlers[AsyncMessageTypes.REMOVE_VARIABLES] = async (msg) => {
   try {
     return {
-      variableIds: await removeVariablesFromPlugin(msg.variableKeys),
+      variableKeys: await removeVariablesFromPlugin(msg.variableKeys),
     };
   } catch (e) {
     console.error(e);
   }
 
   return {
-    variableIds: [],
+    variableKeys: [],
   };
 };

--- a/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/removeVariables.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/removeVariables.ts
@@ -1,0 +1,17 @@
+import { AsyncMessageChannelHandlers } from '@/AsyncMessageChannel';
+import { AsyncMessageTypes } from '@/types/AsyncMessages';
+import removeVariablesFromPlugin from '../removeVariablesFromPlugin';
+
+export const removeVariables: AsyncMessageChannelHandlers[AsyncMessageTypes.REMOVE_VARIABLES] = async (msg) => {
+  try {
+    return {
+      variableIds: await removeVariablesFromPlugin(msg.variableKeys),
+    };
+  } catch (e) {
+    console.error(e);
+  }
+
+  return {
+    variableIds: [],
+  };
+};

--- a/packages/tokens-studio-for-figma/src/plugin/controller.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/controller.ts
@@ -72,6 +72,7 @@ AsyncMessageChannel.PluginInstance.handle(
   asyncHandlers.attachLocalVariablesToTheme,
 );
 AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.RENAME_VARIABLES, asyncHandlers.renameVariables);
+AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.REMOVE_VARIABLES, asyncHandlers.removeVariables);
 AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.UPDATE_VARIABLES, asyncHandlers.updateVariables);
 AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.SET_USED_EMAIL, asyncHandlers.setUsedEmail);
 AsyncMessageChannel.PluginInstance.handle(AsyncMessageTypes.PREVIEW_REQUEST_STARTUP, asyncHandlers.previewRequestStartup);

--- a/packages/tokens-studio-for-figma/src/plugin/removeStylesFromPlugin.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/removeStylesFromPlugin.test.ts
@@ -59,6 +59,6 @@ describe('removeStylesFromPlugin', () => {
   runAfter.push(AsyncMessageChannel.PluginInstance.connect());
 
   it('should remove styles from plugin', async () => {
-    expect(await removeStylesFromPlugin(tokenToDelete)).toEqual(['456']);
+    expect(await removeStylesFromPlugin(tokenToDelete, { prefixStylesWithThemeName: true })).toEqual(['456']);
   });
 });

--- a/packages/tokens-studio-for-figma/src/plugin/removeStylesFromPlugin.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/removeStylesFromPlugin.ts
@@ -1,7 +1,7 @@
 import { AsyncMessageChannel } from '@/AsyncMessageChannel';
 import { TokenSetStatus } from '@/constants/TokenSetStatus';
 import { AsyncMessageTypes } from '@/types/AsyncMessages';
-import { SettingsState } from '@/app/store/models/settings';
+import type { SettingsState } from '@/app/store/models/settings';
 import { DeleteTokenPayload } from '@/types/payloads';
 import { convertTokenNameToPath } from '@/utils/convertTokenNameToPath';
 import { isMatchingStyle } from '@/utils/is/isMatchingStyle';

--- a/packages/tokens-studio-for-figma/src/plugin/removeStylesFromPlugin.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/removeStylesFromPlugin.ts
@@ -1,11 +1,12 @@
 import { AsyncMessageChannel } from '@/AsyncMessageChannel';
 import { TokenSetStatus } from '@/constants/TokenSetStatus';
 import { AsyncMessageTypes } from '@/types/AsyncMessages';
+import { SettingsState } from '@/app/store/models/settings';
 import { DeleteTokenPayload } from '@/types/payloads';
 import { convertTokenNameToPath } from '@/utils/convertTokenNameToPath';
 import { isMatchingStyle } from '@/utils/is/isMatchingStyle';
 
-export default async function removeStylesFromPlugin(token: DeleteTokenPayload) {
+export default async function removeStylesFromPlugin(token: DeleteTokenPayload, settings: Partial<SettingsState> = {}) {
   const effectStyles = figma.getLocalEffectStyles();
   const paintStyles = figma.getLocalPaintStyles();
   const textStyles = figma.getLocalTextStyles();
@@ -14,12 +15,15 @@ export default async function removeStylesFromPlugin(token: DeleteTokenPayload) 
   const themeInfo = await AsyncMessageChannel.PluginInstance.message({
     type: AsyncMessageTypes.GET_THEME_INFO,
   });
+  const slice = settings.ignoreFirstPartForStyles && token.path.split('.').length > 1 ? 1 : 0;
   const themesToContainToken = themeInfo.themes
     .filter((theme) => Object.entries(theme.selectedTokenSets).some(
       ([tokenSet, value]) => tokenSet === token.parent && value === TokenSetStatus.ENABLED,
-    ))
-    .map((filteredTheme) => filteredTheme.name);
-  const pathNames = themesToContainToken.map((theme) => convertTokenNameToPath(token.path, theme));
+    ));
+  const pathNames = themesToContainToken.map((theme) => {
+    const prefix = settings.prefixStylesWithThemeName ? theme.name : null;
+    return convertTokenNameToPath(token.path, prefix, slice);
+  });
 
   const allStyleIds = allStyles
     .filter((style) => pathNames.some((pathName) => isMatchingStyle(pathName, style)))

--- a/packages/tokens-studio-for-figma/src/plugin/removeVariablesFromPlugin.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/removeVariablesFromPlugin.ts
@@ -1,0 +1,16 @@
+import { getVariablesMap } from '@/utils/getVariablesMap';
+
+export default async function removeVariablesFromPlugin(variableKeys: string[]) {
+  const variableMap = await getVariablesMap();
+  const removedVariableIds: string[] = [];
+
+  variableKeys.forEach((key) => {
+    const variable = variableMap[key];
+    if (variable) {
+      removedVariableIds.push(variable.key);
+      variable.remove();
+    }
+  });
+
+  return removedVariableIds;
+}

--- a/packages/tokens-studio-for-figma/src/types/AsyncMessages.ts
+++ b/packages/tokens-studio-for-figma/src/types/AsyncMessages.ts
@@ -77,6 +77,7 @@ export enum AsyncMessageTypes {
   RESOLVE_VARIABLE_INFO = 'async/resolve-variable-info',
   ATTACH_LOCAL_VARIABLES_TO_THEME = 'async/attach-local-variables-to-theme',
   RENAME_VARIABLES = 'async/rename-variables',
+  REMOVE_VARIABLES = 'async/remove-variables',
   UPDATE_VARIABLES = 'async/update-variables',
   SET_INITIAL_LOAD = 'async/set-initial-load',
   PREVIEW_REQUEST_STARTUP = 'async/preview-request-startup',
@@ -379,6 +380,13 @@ export type RenameVariablesAsyncMessageResult = AsyncMessage<AsyncMessageTypes.R
   renameVariableToken: RenameVariableToken[];
 }>;
 
+export type RemoveVariablesAsyncMessage = AsyncMessage<AsyncMessageTypes.REMOVE_VARIABLES, {
+  variableKeys: string[];
+}>;
+export type RemoveVariablesAsyncMessageResult = AsyncMessage<AsyncMessageTypes.REMOVE_VARIABLES, {
+  variableIds: string[];
+}>;
+
 export type UpdateVariablesAsyncMessage = AsyncMessage<AsyncMessageTypes.UPDATE_VARIABLES, {
   payload: UpdateTokenVariablePayload
 }>;
@@ -450,6 +458,7 @@ export type AsyncMessages =
   | ResolveVariableInfo
   | AttachLocalVariablesToTheme
   | RenameVariablesAsyncMessage
+  | RemoveVariablesAsyncMessage
   | UpdateVariablesAsyncMessage
   | PreviewRequestStartupAsyncMessage
   | RemoveRelaunchDataMessage
@@ -504,6 +513,7 @@ export type AsyncMessageResults =
   | ResolveVariableInfoResult
   | AttachLocalVariablesToThemeResult
   | RenameVariablesAsyncMessageResult
+  | RemoveVariablesAsyncMessageResult
   | UpdateVariablesAsyncMessageResult
   | PreviewRequestStartupAsyncMessageResult
   | RemoveRelaunchDataMessageResult

--- a/packages/tokens-studio-for-figma/src/types/AsyncMessages.ts
+++ b/packages/tokens-studio-for-figma/src/types/AsyncMessages.ts
@@ -384,7 +384,7 @@ export type RemoveVariablesAsyncMessage = AsyncMessage<AsyncMessageTypes.REMOVE_
   variableKeys: string[];
 }>;
 export type RemoveVariablesAsyncMessageResult = AsyncMessage<AsyncMessageTypes.REMOVE_VARIABLES, {
-  variableIds: string[];
+  variableKeys: string[];
 }>;
 
 export type UpdateVariablesAsyncMessage = AsyncMessage<AsyncMessageTypes.UPDATE_VARIABLES, {


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

Closes #0000

When a token is deleted, its connected Figma variable is left behind. The only workaround — "Remove styles and variables without connection to a token" — is destructive: it clears all unconnected variables, can drop token-to-variable links, and has known bugs in the companion plugin. This PR adds an explicit opt-in to delete only the variable (and/or style) tied to the token being removed.

<img width="551" height="730" alt="Screenshot 2026-06-23 at 1 04 10 PM" src="https://github.com/user-attachments/assets/eac63c44-e7f8-481c-b55e-740f9b3f26fb" />


### What does this pull request do?

Mirrors the existing "Rename connected variable" UX from the rename flow: when you delete a token, a confirmation dialog now offers optional checkboxes to also **Delete connected variable** and/or **Delete associated style** — both off by default.

**Variable deletion**
- Adds `REMOVE_VARIABLES` async message type and handler
- Variable keys are resolved from Redux theme state on the UI side before the message is sent, avoiding a race condition where `removeVariableNamesFromThemes` could dispatch and clear the references before the plugin's `GET_THEME_INFO` round-trip completed
- Deduplicates keys across themes (same variable referenced by multiple themes only gets deleted once)

**Style deletion fix**
- `removeStylesFromPlugin` previously always prefixed the style path with the theme name regardless of the `prefixStylesWithThemeName` setting, so style matching always failed for users without that setting enabled
- Now correctly reads `prefixStylesWithThemeName` and `ignoreFirstPartForStyles` from the settings passed in the message, matching the logic in `updateStyles.ts`

### Testing this change

1. In a Figma file with at least one theme and variables pushed from Tokens Studio, delete a token
2. Confirm the dialog now shows "Delete connected variable" (and "Delete associated style" for color/typography/shadow tokens)
3. Check the box and confirm — the corresponding Figma variable should be removed from the Variables panel
4. Repeat with the style checkbox — the Figma style should be removed
5. Verify that leaving both unchecked behaves identically to the previous behavior (token deleted, variable/style untouched)

### Additional Notes (if any)

The `prefixStylesWithThemeName` bug in `removeStylesFromPlugin` predates this PR but was discovered while investigating style deletion. The fix is included here since it affects the same dialog flow.
