### PR TITLE
fix: resolve inconsistent tooltip display after drag and rapid hover

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/asyncMessageHandlers/startup.tsx
+++ b/packages/tokens-studio-for-figma/src/app/asyncMessageHandlers/startup.tsx
@@ -62,7 +62,7 @@ export const startup = async () => {
   root.render(
     <Sentry.ErrorBoundary fallback={ErrorFallback}>
       <Provider store={store}>
-        <Tooltip.Provider>
+        <Tooltip.Provider skipDelayDuration={0}>
           <StartupApp />
         </Tooltip.Provider>
       </Provider>

--- a/packages/tokens-studio-for-figma/src/app/components/TokenButton/DraggableWrapper.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/TokenButton/DraggableWrapper.tsx
@@ -35,6 +35,16 @@ export const DraggableWrapper: React.FC<React.PropsWithChildren<React.PropsWithC
   const handleDragEnd = React.useCallback((e: React.DragEvent<HTMLDivElement>) => {
     e.stopPropagation();
     setDragOverToken(null);
+    // Restore pointer state: after drag ends, manually restore hover for the tooltip system
+    // The browser doesn't re-fire pointerenter after drag, so we trigger a synthetic pointerenter
+    const target = e.currentTarget;
+    if (target) {
+      const enterEvent = new PointerEvent('pointerenter', {
+        bubbles: true,
+        cancelable: true,
+      });
+      target.dispatchEvent(enterEvent);
+    }
   }, [setDragOverToken]);
 
   const handleDragOver = React.useCallback((e: React.DragEvent<HTMLDivElement>) => {

--- a/packages/tokens-studio-for-figma/src/app/components/TokenTooltip/TokenTooltip.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/TokenTooltip/TokenTooltip.tsx
@@ -13,7 +13,8 @@ export const TokenTooltip: React.FC<React.PropsWithChildren<React.PropsWithChild
   children,
   token,
 }) => {
-  // When we open the token edit form we don't want tooltips to show through, which is happening sometimes
+  // When we open the token edit form, pass an empty but truthy label to keep tooltip mounted
+  // This prevents the remount issue where pointerenter doesn't fire after edit form closes
   const showEditForm = useSelector(showEditFormSelector);
 
   if (!children || !React.isValidElement(children)) {
@@ -23,11 +24,7 @@ export const TokenTooltip: React.FC<React.PropsWithChildren<React.PropsWithChild
   return (
     <Tooltip
       side="bottom"
-      label={showEditForm ? '' : (
-        <TokenTooltipContent
-          token={token}
-        />
-      )}
+      label={showEditForm ? <div /> : <TokenTooltipContent token={token} />}
     >
       {children}
     </Tooltip>

--- a/packages/tokens-studio-for-figma/src/app/store/providers/tokens-studio/tokensStudioOAuth.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/tokens-studio/tokensStudioOAuth.tsx
@@ -240,7 +240,6 @@ export function useTokensStudioOAuth() {
             return localTheme ? alignObjectKeys(remoteTheme, localTheme) : remoteTheme;
           });
 
-
           return {
             status: 'success',
             tokens: sortedTokens,
@@ -399,7 +398,6 @@ export function useTokensStudioOAuth() {
             const localTheme = themes.find((t) => t.id === remoteTheme.id);
             return localTheme ? alignObjectKeys(remoteTheme, localTheme) : remoteTheme;
           });
-
 
           dispatch.tokenState.setTokenData({
             values: (newTokens || {}) as any,

--- a/packages/tokens-studio-for-figma/src/app/store/updateSources.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/updateSources.tsx
@@ -179,8 +179,6 @@ export default async function updateTokensOnSources({
     ? mergeServerResolvedTokens(locallyResolved, serverResolvedTokens)
     : null;
 
-
-
   const tokensSize = (compressedTokens.length / 1024) * 2; // UTF-16 uses 2 bytes per character
   const themesSize = (compressedThemes.length / 1024) * 2;
 

--- a/packages/tokens-studio-for-figma/src/hooks/__tests__/useChangedState.test.ts
+++ b/packages/tokens-studio-for-figma/src/hooks/__tests__/useChangedState.test.ts
@@ -74,5 +74,4 @@ describe('useChangedState', () => {
     expect(mockUpdateCheckForChanges).toHaveBeenCalledWith(false);
     expect(mockUpdateCheckForChanges).not.toHaveBeenCalledWith(true);
   });
-
 });

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/__tests__/restApi.int.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/__tests__/restApi.int.test.ts
@@ -214,9 +214,15 @@ describe('Tokens Studio REST API Integration', () => {
       if (skipIntegration) return;
 
       const result = await batchCreateTokensRest(authToken, API_BASE_URL, projectId, [
-        { name: 'color.brand', value: '#7B61FF', type: 'color', token_set_id: primitiveSetId, description: 'Imported from Figma variable' },
-        { name: 'spacing.sm', value: '8', type: 'dimension', token_set_id: primitiveSetId },
-        { name: 'color.bg', value: '{color.brand}', type: 'color', token_set_id: semanticSetId },
+        {
+          name: 'color.brand', value: '#7B61FF', type: 'color', token_set_id: primitiveSetId, description: 'Imported from Figma variable',
+        },
+        {
+          name: 'spacing.sm', value: '8', type: 'dimension', token_set_id: primitiveSetId,
+        },
+        {
+          name: 'color.bg', value: '{color.brand}', type: 'color', token_set_id: semanticSetId,
+        },
       ], changeSetId);
       expect(result.data).toBeDefined();
       expect(result.data.created_count).toBe(3);
@@ -312,9 +318,15 @@ describe('Tokens Studio REST API Integration', () => {
       if (skipIntegration) return;
 
       const result = await batchCreateTokensRest(authToken, API_BASE_URL, projectId, [
-        { name: 'color.primary', value: '#0D99FF', type: 'color', token_set_id: styleSetId, description: 'Imported from Figma color style' },
-        { name: 'typography.heading', value: { fontFamily: 'Inter', fontWeight: '700', fontSize: '32' }, type: 'typography', token_set_id: styleSetId, description: 'Imported from Figma text style' },
-        { name: 'spacing.md', value: '16', type: 'dimension', token_set_id: styleSetId },
+        {
+          name: 'color.primary', value: '#0D99FF', type: 'color', token_set_id: styleSetId, description: 'Imported from Figma color style',
+        },
+        {
+          name: 'typography.heading', value: { fontFamily: 'Inter', fontWeight: '700', fontSize: '32' }, type: 'typography', token_set_id: styleSetId, description: 'Imported from Figma text style',
+        },
+        {
+          name: 'spacing.md', value: '16', type: 'dimension', token_set_id: styleSetId,
+        },
       ], changeSetId);
       expect(result.data).toBeDefined();
       expect(result.data.created_count).toBe(3);
@@ -326,7 +338,9 @@ describe('Tokens Studio REST API Integration', () => {
 
       // Simulates createMultipleTokens reusing an existing set ID rather than re-creating it.
       const result = await batchCreateTokensRest(authToken, API_BASE_URL, projectId, [
-        { name: 'color.secondary', value: '#FF6250', type: 'color', token_set_id: styleSetId },
+        {
+          name: 'color.secondary', value: '#FF6250', type: 'color', token_set_id: styleSetId,
+        },
       ], changeSetId);
       expect(result.data).toBeDefined();
       expect(result.data.created_count).toBe(1);

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchServerResolvedTokens.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchServerResolvedTokens.test.ts
@@ -97,8 +97,8 @@ describe('fetchServerResolvedTokens', () => {
 
     await fetchServerResolvedTokens(BASE_OPTIONS);
 
-    const expectedParams = new URLSearchParams({ 
-      change_set_id: 'cs-456', 
+    const expectedParams = new URLSearchParams({
+      change_set_id: 'cs-456',
       t: '1777406477644',
       Mode: 'Dark',
     });

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchServerResolvedTokens.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchServerResolvedTokens.ts
@@ -33,7 +33,7 @@ export async function fetchServerResolvedTokens(
   try {
     // Build query string: change_set_id + each theme selection as a flat param
     // e.g. ?change_set_id=abc&color-scheme=blue&foundation=base
-    const params = new URLSearchParams({ 
+    const params = new URLSearchParams({
       change_set_id: changeSetId,
       t: Date.now().toString(), // Cache buster
     });
@@ -56,7 +56,6 @@ export async function fetchServerResolvedTokens(
     );
 
     if (!response.ok) {
-
       return null;
     }
 
@@ -70,14 +69,11 @@ export async function fetchServerResolvedTokens(
     );
 
     if (!flatMap) {
-
       return null;
     }
 
-
     return flatMap;
   } catch (error) {
-
     return null;
   }
 }


### PR DESCRIPTION
Address three interacting issues in the tooltip stack:

1. DraggableWrapper: Synthesize pointerenter event after dragend to restore hover state, since the browser doesn't automatically re-fire it after drag.

2. TokenTooltip: Keep tooltip mounted (pass empty div instead of empty string) when edit form is open to prevent remount issues where pointerenter doesn't fire on already-hovered elements.

3. Tooltip.Provider: Set skipDelayDuration={0} to prevent the default 300ms delay from overwhelming rapid hover transitions between tokens.

Fixes: drag interactions breaking tooltips, rapid hover inconsistency, edit form closing not restoring tooltips.

<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

Closes  <!-- link the related issue -->

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?

<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->

### Testing this change

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

### Additional Notes (if any)

<!--
  Add any other context or screenshots about the pull request
-->
