### PR TITLE
feat: add figma-bridge CDP debugging tool under tools/

### DIFF
--- a/tools/figma-bridge/.gitignore
+++ b/tools/figma-bridge/.gitignore
@@ -1,0 +1,9 @@
+# figma-bridge runtime state lives in ~/.figma-bridge/, never in the repo.
+# This is a safety net in case anyone runs the tool with a local state dir.
+FigmaDebug.app/
+*.asar
+*.asar.bak
+figma.log
+state.json
+shot.png
+*.png

--- a/tools/figma-bridge/AGENTS.md
+++ b/tools/figma-bridge/AGENTS.md
@@ -1,0 +1,93 @@
+# figma-bridge — agent instructions
+
+Instructions for an AI agent (or a human) operating this tool. This file is
+**self-contained**: it travels with the `figma-bridge/` folder, so everything an
+agent needs to use the bridge lives here and in the sibling docs — not in any
+repo-level instructions file.
+
+## What this is / when to reach for it
+
+A zero-dependency tool that lets you drive the **local Figma Desktop** over the
+Chrome DevTools Protocol (CDP) and evaluate **Plugin-API** JS (`figma.*`) directly
+in the renderer — **no plugin, no UI clicks, no per-session setup**. Use it to close
+a **build → run → verify** loop against real Figma autonomously: read the document,
+mutate nodes, manage variables/styles, export a node to a PNG, screenshot the canvas.
+
+- **Platform:** macOS only, for now. **Runtime:** Node 22+ (built-in `WebSocket`/`fetch` globals). **Zero npm deps.**
+- Steady state: always launch via `node cli.mjs start` (it clones/patches/signs once, then reuses).
+
+## Start here
+
+1. **[README.md](./README.md)** — what it is, why it works, full command reference, setup.
+2. **[docs/BEST-PRACTICES.md](./docs/BEST-PRACTICES.md)** — how to operate it well. Read
+   **the verification hierarchy** first; it's the single most important habit.
+3. **[docs/AGENT-GUIDE.md](./docs/AGENT-GUIDE.md)** — copy-paste recipes for read / create / verify.
+
+## Commands
+
+From `tools/figma-bridge/`:
+
+```bash
+node cli.mjs <status | start | stop | eval "<js>" | export <nodeId> [file] [scale] | shot [file] | prepare | clean>
+```
+
+JSON on stdout; `{"error": ...}` + exit 1 on failure.
+
+## The one rule that matters most: the verification hierarchy
+
+Pick the cheapest check that actually answers your question; reach for a screenshot
+last. (Full version in [BEST-PRACTICES.md](./docs/BEST-PRACTICES.md#the-verification-hierarchy).)
+
+1. **Read the value with `eval`** (the Figma **Plugin API**, in-process over the bridge —
+   _not_ the REST API). For any _"what is this?"_ — color, name, size, bound variable,
+   font, node tree — read it, never eyeball it. Structured data is assertable.
+2. **`export <nodeId>` → PNG** to validate _a frame you drew_. `node.exportAsync` gives
+   just that node's pixels, tight-cropped, full fidelity, zoom/panel-independent.
+3. **`shot` (whole-window screenshot)** _only_ for Figma's own UI (plugin iframes,
+   panels) or values the API genuinely can't expose. A full-window shot to check a
+   frame's content is almost always the wrong call.
+
+## Key facts & gotchas (learned building it)
+
+- **How it works**: clone `/Applications/Figma.app` → `~/.figma-bridge/FigmaDebug.app`
+  (`ditto`, APFS clone), byte-flip the copy's `app.asar`
+  (`removeSwitch("remote-debugging-port")` → `...debugXing...`, same length so the asar
+  stays valid), ad-hoc `codesign --sign -`, launch the binary with
+  `--remote-debugging-port=9222`. Patching a **copy** needs no macOS "App Management"
+  permission; patching the installed app does.
+- **`figma` is reachable over CDP with NO plugin** (v126) — but only in a specific
+  renderer execution context, and only when a **design file** (URL
+  `figma.com/(design|file)/`) is open (not the recents/home page). Scan all matching
+  targets for the context where `typeof figma !== "undefined"`; suspended restored tabs
+  won't have it.
+- **`export` impl**: `node.exportAsync({ format: "PNG", constraint: { type: "SCALE", value: N } })`
+  → `figma.base64Encode(bytes)` (a string — transports cleanly over CDP; avoids
+  Uint8Array→JSON bloat and `btoa` stack limits) → `Buffer.from(b64, "base64")` in Node.
+  Guard `typeof node.exportAsync === "function"` (FrameNode/PageNode are exportable).
+- **Auto-layout hug/wrap gotcha** (hit + fixed for real): a VERTICAL frame that should
+  grow with children needs `primaryAxisSizingMode="AUTO"` or it stays at its initial
+  height and clips (the "content squished to 10px" symptom). A HORIZONTAL **wrap** row
+  needs `layoutWrap="WRAP"` + `primaryAxisSizingMode="FIXED"` (fixed width forces
+  wrapping) + `counterAxisSizingMode="AUTO"` (height hugs rows); `itemSpacing` = column
+  gap, `counterAxisSpacing` = row gap. When a layout looks collapsed, read the sizing
+  modes with `eval` rather than guessing from a screenshot.
+- **Mutations are real & cloud-synced** — `eval` edits the user's actual logged-in
+  Figma; there's no sandbox. Work on a scratch file/page, prefer additive changes, write
+  idempotent scripts (find-by-name before create), and never delete user content unasked.
+- **Target a specific file** among many tabs by filtering on its **file key**:
+  `connect({ targetUrl: "<key>" })` in an inline `node -e` script (the CLI itself doesn't
+  expose targetUrl; it picks the first live design context). See
+  [AGENT-GUIDE.md](./docs/AGENT-GUIDE.md#targeting-a-specific-file).
+- **Cold-start timing**: the CDP port opens several seconds _before_ the renderer injects
+  `figma`. Don't trust port-ready alone — poll until `figma` actually evaluates. `start`
+  already does this.
+- **One instance at a time**: installed app + debug copy share the login profile /
+  single-instance lock, so `start` gracefully quits any running Figma first
+  (`osascript ... quit`; Figma cloud-syncs, no dialog).
+- **CDP can't eval bare top-level `return`** — wrap snippets with `return`/`await` in
+  `(async () => { ... })()` (cli.mjs does this for you). Return JSON-serializable values
+  (node objects carry methods that won't serialize).
+- **Out of the workspace graph**: this tool lives under `tools/`, outside the `apps/*`
+  and `packages/*` workspaces, so it's not in the turbo build/lint/test graph. Keep it
+  zero-dep and standalone. Runtime state + the ~300 MB app copy live in
+  `~/.figma-bridge/`, never committed.

--- a/tools/figma-bridge/README.md
+++ b/tools/figma-bridge/README.md
@@ -1,0 +1,149 @@
+# figma-bridge
+
+Programmatic control of your local **Figma Desktop** from bash — no plugin, no UI
+clicks, no per-session setup. It drives Figma over the Chrome DevTools Protocol (CDP)
+and evaluates **Plugin-API** JavaScript (`figma.*`) directly in the renderer, so an
+agent (or you) can read the document, mutate nodes, manage variables, export any node
+to a PNG, and screenshot the canvas entirely from the command line.
+
+> **Platform:** macOS only, for now. **Runtime:** Node 22+ (uses the built-in global
+> `WebSocket`/`fetch`; `WebSocket` is a stable global from Node 22). **Zero npm dependencies.**
+
+## Why this exists
+
+Figma deliberately strips the `--remote-debugging-port` flag at launch, and its plugin
+sandbox can't be imported/run without a human clicking through the UI. This tool works
+around the first restriction with a one-byte patch to a **copy** of Figma.app and skips
+the plugin sandbox entirely — the agent talks to the real `figma` global over CDP.
+
+## How it works
+
+1. **Clone** `/Applications/Figma.app` → `~/.figma-bridge/FigmaDebug.app` (fast APFS
+   clone via `ditto`, ~300 MB, done once).
+2. **Patch** the copy's `app.asar`: Figma calls `removeSwitch("remote-debugging-port")`
+   to drop the debug flag; we flip one byte → `removeSwitch("remote-debugXing-port")`,
+   turning that call into a no-op. Same length, so the asar stays valid. We patch the
+   **copy**, so no macOS "App Management" permission is needed.
+3. **Ad-hoc re-sign** the copy (`codesign --sign -`) so macOS will launch the modified
+   bundle, then launch its binary directly with `--remote-debugging-port=9222`.
+4. **Connect** over CDP: find the target whose URL matches `figma.com/(design|file)/`,
+   locate the execution context exposing the `figma` global, and `Runtime.evaluate`
+   Plugin-API JS there. Screenshots use `Page.captureScreenshot`.
+
+All generated state (the app copy, logs, target cache) lives in `~/.figma-bridge/` —
+**nothing large is committed to the repo.** Only the code lives here.
+
+## Usage
+
+From `tools/figma-bridge/`:
+
+```bash
+node cli.mjs start                 # clone/patch/sign (once) + launch debug Figma, wait until ready
+node cli.mjs status                # is a debug Figma up? which file/page is open?
+node cli.mjs eval "return figma.currentPage.name"
+node cli.mjs eval "return (await figma.variables.getLocalVariableCollectionsAsync()).map(c => c.name)"
+node cli.mjs export "12:34" frame.png    # export ONE node's pixels (tight crop) — verify a frame
+node cli.mjs shot canvas.png       # screenshot the WHOLE Figma window (UI chrome)
+node cli.mjs stop                  # quit the debug Figma
+node cli.mjs prepare               # clone/patch/sign WITHOUT launching
+node cli.mjs clean                 # delete the cloned debug app (installed Figma untouched)
+```
+
+Every command prints JSON to stdout. On failure it prints `{"error": "..."}` to stderr
+and exits non-zero, so it's easy to script and check.
+
+### `export` vs `shot` — validating your work
+
+Two very different screenshots, and picking the right one matters:
+
+- **`export <nodeId> [file] [scale]`** calls `node.exportAsync()` and returns **just that
+  node's pixels** — tightly cropped, full fidelity, independent of zoom/viewport/panels.
+  This is the right way to **validate a frame you built**. Default scale is `2` (@2x).
+- **`shot [file]`** captures the **entire Figma window** (toolbar, panels, canvas chrome)
+  at the current zoom. Reserve it for when the thing you need to see *is Figma's own UI* —
+  a plugin's iframe, the inspector/variables panels, etc.
+
+And when the question is *"what is this value?"* (a color, a name, a bound variable), don't
+screenshot at all — **read it with `eval`**. See
+[docs/BEST-PRACTICES.md](./docs/BEST-PRACTICES.md#the-verification-hierarchy) for the full
+verification hierarchy.
+
+### Writing `eval` snippets
+
+- A **bare expression** is evaluated as-is: `figma.currentPage.name`.
+- A snippet containing `return` or `await` is auto-wrapped in an async IIFE, so you can
+  write multiple statements and await Plugin-API promises:
+  ```bash
+  node cli.mjs eval "const r = figma.createRectangle(); r.name='x'; return r.id"
+  ```
+- **Return JSON-serializable values.** Figma node objects have methods and won't
+  serialize — return primitives/plain objects (ids, names, counts, arrays).
+
+### Environment
+
+- `FIGMA_BRIDGE_PORT` — override the debug port (default `9222`).
+
+## Important caveats
+
+- **`start` quits any running Figma first.** The installed app and the debug copy share
+  one logged-in profile and Figma's single-instance lock, so only one can run at a time.
+  The quit is graceful (`osascript ... quit`) — Figma cloud-syncs and normally closes
+  without a dialog. In steady state, just always launch Figma via `node cli.mjs start`.
+- **A design *file* must be open** (not the recents/home page) for the Plugin API to be
+  reachable — that's where the `figma` global lives. `start` waits until a document's
+  `figma` is actually evaluable before returning; restored/suspended background tabs are
+  scanned and skipped automatically.
+- The debug copy is **ad-hoc signed**. That's fine for launching locally; it is not
+  distributable.
+
+## Fallback: patch the installed app (variant B)
+
+If the copied-app route ever fails on your machine (e.g. Gatekeeper refuses the ad-hoc
+copy), you can patch the installed app in place instead:
+
+1. **System Settings → Privacy & Security → App Management** → enable it for your
+   terminal app. (Required to modify `/Applications/Figma.app`.)
+2. Back up and patch the installed asar (same one-byte flip):
+   ```bash
+   cp /Applications/Figma.app/Contents/Resources/app.asar ~/figma-app.asar.bak
+   # flip removeSwitch("remote-debugging-port") -> removeSwitch("remote-debugXing-port")
+   ```
+   You can reuse this tool's patch logic by pointing it at the installed asar, or apply
+   the byte edit manually.
+3. Re-sign and relaunch with `--remote-debugging-port=9222`. The CDP path afterward is
+   identical.
+
+To undo: restore `~/figma-app.asar.bak` (or re-run Figma's updater, which replaces the
+asar).
+
+## Cleanup
+
+```bash
+node cli.mjs stop      # quit the debug Figma
+node cli.mjs clean     # remove ~/.figma-bridge/FigmaDebug.app
+```
+
+`clean` never touches your installed `/Applications/Figma.app`.
+
+## Files
+
+- `cdp.mjs` — zero-dep CDP client: target + `figma`-context discovery (with retry for
+  cold loads), `eval`, `exportNode` (per-node PNG), `screenshot` (whole window).
+- `launch.mjs` — lifecycle: clone, patch/unpatch (byte-flip), ad-hoc sign, start (quit
+  running Figma → launch → wait for Plugin-API readiness), stop, clean.
+- `cli.mjs` — the bash-callable command surface.
+
+This tool lives under `tools/` and is intentionally **outside** the npm workspaces
+(`apps/*`, `packages/*`), so it's not part of the turbo build/lint/test graph.
+
+## Docs
+
+- **[AGENTS.md](./AGENTS.md)** — start here if you're an AI agent (or automating this):
+  what it is, when to reach for it, the verification hierarchy in brief, and the key
+  gotchas. Self-contained so it travels with the folder.
+- **[docs/BEST-PRACTICES.md](./docs/BEST-PRACTICES.md)** — how to operate the bridge well.
+  Start with the verification hierarchy (read with `eval` → `export` a node → `shot` the
+  window), plus notes on idempotency, real/cloud-synced mutations, and file targeting.
+- **[docs/AGENT-GUIDE.md](./docs/AGENT-GUIDE.md)** — copy-paste recipes for the
+  build → run → verify loop: reading variables/styles, creating frames and text, the
+  auto-layout hug/wrap gotcha, exporting to verify, and targeting a specific file.

--- a/tools/figma-bridge/cdp.mjs
+++ b/tools/figma-bridge/cdp.mjs
@@ -1,0 +1,325 @@
+// Minimal Chrome DevTools Protocol (CDP) client for talking to a debug-enabled
+// Figma Desktop. Zero external deps: uses Node's built-in `WebSocket` and `fetch`
+// globals (Node 22+, where `WebSocket` is a stable global). No plugin required — we evaluate Plugin-API JS
+// directly in the renderer execution context where the `figma` global lives.
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export const DEFAULT_PORT = 9222;
+
+// Figma design/file documents. The trailing (design|file)/ avoids matching the
+// "recents-and-sharing" / team feed pages, which do not expose `figma`.
+const FIGMA_DOC_RE = /figma\.com\/(design|file)\//;
+
+const STATE_DIR = join(homedir(), ".figma-bridge");
+const STATE_FILE = join(STATE_DIR, "state.json");
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// `WebSocket` became a stable global in Node 22. Read it off `globalThis` (rather
+// than referencing a bare identifier) so older runtimes fail with a clear,
+// actionable message instead of a bare `ReferenceError` deep inside connection setup.
+function requireWebSocket() {
+  const WS = globalThis.WebSocket;
+  if (typeof WS !== "function") {
+    throw new Error(
+      `figma-bridge needs a global WebSocket, which is available in Node 22+. ` +
+        `Current runtime: ${process.version}. Please re-run with Node 22 or newer.`,
+    );
+  }
+  return WS;
+}
+
+function readState() {
+  try {
+    return JSON.parse(readFileSync(STATE_FILE, "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+function writeState(patch) {
+  try {
+    mkdirSync(STATE_DIR, { recursive: true });
+    writeFileSync(STATE_FILE, JSON.stringify({ ...readState(), ...patch }, null, 2));
+  } catch {
+    // best-effort cache; ignore failures
+  }
+}
+
+/** List all CDP targets (pages) exposed by the debug port. */
+export async function listTargets(port = DEFAULT_PORT) {
+  const res = await fetch(`http://localhost:${port}/json`);
+  if (!res.ok) throw new Error(`CDP /json returned ${res.status}`);
+  return res.json();
+}
+
+/** True if the debug port is up and responding. */
+export async function isPortReady(port = DEFAULT_PORT) {
+  try {
+    const res = await fetch(`http://localhost:${port}/json/version`, {
+      signal: AbortSignal.timeout(1500),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Connect to a Figma document target and locate the execution context that owns
+ * the `figma` Plugin-API global.
+ *
+ * Robust against a cold launch: many tabs may be restored but suspended, and the
+ * active document's `figma` global appears a few seconds after the debug port opens.
+ * We therefore scan every design/file target for a live `figma` context and retry
+ * the whole scan until `timeoutMs` elapses.
+ *
+ * @param {object} [opts]
+ * @param {number} [opts.port]       CDP port (default 9222).
+ * @param {string} [opts.targetUrl]  Substring/regex to pick a specific target.
+ * @param {number} [opts.timeoutMs]  Total time to keep retrying (default 20000).
+ * @returns {Promise<Client>}
+ */
+export async function connect({ port = DEFAULT_PORT, targetUrl, timeoutMs = 20000 } = {}) {
+  const deadline = Date.now() + Math.max(0, timeoutMs);
+  const lastGood = readState().lastTargetUrl;
+  let lastErr = null;
+
+  for (;;) {
+    const targets = await listTargets(port);
+    const pages = targets.filter((t) => t.type === "page" && t.webSocketDebuggerUrl);
+
+    let candidates;
+    if (targetUrl) {
+      candidates = pages.filter((t) => t.url.includes(targetUrl) || safeMatch(targetUrl, t.url));
+      if (candidates.length === 0) lastErr = new Error(`No target matched "${targetUrl}"`);
+    } else {
+      candidates = pages.filter((t) => FIGMA_DOC_RE.test(t.url));
+      // Try the previously-good document first (fast path + picks the tab you use).
+      if (lastGood) {
+        candidates.sort((a, b) => (b.url === lastGood ? 1 : 0) - (a.url === lastGood ? 1 : 0));
+      }
+    }
+
+    for (const target of candidates) {
+      const client = new Client(target);
+      try {
+        await client._open();
+        if (await client._findFigmaContext()) {
+          writeState({ lastTargetUrl: target.url });
+          return client;
+        }
+      } catch (e) {
+        lastErr = e;
+      }
+      client.close();
+    }
+
+    if (Date.now() >= deadline) break;
+    await sleep(1000);
+  }
+
+  throw (
+    lastErr ??
+    new Error(
+      "No Figma design/file tab with the Plugin API was found. Open or focus a " +
+        "document in the debug Figma (the recents/home page does not expose it).",
+    )
+  );
+}
+
+class Client {
+  constructor(target) {
+    this.target = target;
+    this.contextId = null;
+    this._ws = null;
+    this._nextId = 1;
+    this._pending = new Map();
+    this._contexts = [];
+  }
+
+  _open() {
+    return new Promise((resolve, reject) => {
+      const WS = requireWebSocket();
+      const ws = new WS(this.target.webSocketDebuggerUrl);
+      this._ws = ws;
+      ws.addEventListener("message", (ev) => {
+        let msg;
+        try {
+          msg = JSON.parse(ev.data);
+        } catch {
+          return;
+        }
+        if (msg.id && this._pending.has(msg.id)) {
+          const { resolve: r } = this._pending.get(msg.id);
+          this._pending.delete(msg.id);
+          r(msg);
+          return;
+        }
+        if (msg.method === "Runtime.executionContextCreated") {
+          this._contexts.push(msg.params.context);
+        } else if (msg.method === "Runtime.executionContextsCleared") {
+          this._contexts = [];
+          this.contextId = null;
+        }
+      });
+      ws.addEventListener("open", () => resolve(), { once: true });
+      ws.addEventListener(
+        "error",
+        (e) => reject(new Error(`CDP socket error: ${e?.message ?? e}`)),
+        { once: true },
+      );
+    });
+  }
+
+  /** Send a CDP command and await its reply (rejects after `timeoutMs`). */
+  _send(method, params = {}, timeoutMs = 15000) {
+    const id = this._nextId++;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this._pending.delete(id);
+        reject(new Error(`CDP ${method} timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      this._pending.set(id, {
+        resolve: (v) => {
+          clearTimeout(timer);
+          resolve(v);
+        },
+      });
+      this._ws.send(JSON.stringify({ id, method, params }));
+    });
+  }
+
+  async _rawEval(expression, { contextId, awaitPromise = true, timeoutMs } = {}) {
+    const params = { expression, returnByValue: true, awaitPromise };
+    if (contextId != null) params.contextId = contextId;
+    const reply = await this._send("Runtime.evaluate", params, timeoutMs);
+    return reply.result;
+  }
+
+  /**
+   * Enable the Runtime domain and find the context exposing `figma`. Polls, because
+   * on a freshly loading tab the contexts (and the `figma` global) arrive with a delay.
+   * Returns true if found, false otherwise (so the caller can try the next target).
+   */
+  async _findFigmaContext({ pollMs = 3000 } = {}) {
+    await this._send("Runtime.enable");
+    const deadline = Date.now() + pollMs;
+    for (;;) {
+      for (const ctx of this._contexts) {
+        try {
+          const res = await this._rawEval("typeof figma", {
+            contextId: ctx.id,
+            awaitPromise: false,
+            timeoutMs: 4000,
+          });
+          if (res?.result?.value && res.result.value !== "undefined") {
+            this.contextId = ctx.id;
+            return true;
+          }
+        } catch {
+          // suspended/loading context — skip it
+        }
+      }
+      if (Date.now() >= deadline) return false;
+      await sleep(250);
+    }
+  }
+
+  /**
+   * Evaluate Plugin-API JavaScript in the Figma renderer.
+   *
+   * Snippets containing a top-level `return` (or `await`) are wrapped in an async
+   * IIFE so you can write multi-statement code and use `await`. A bare expression
+   * (e.g. `figma.currentPage.name`) is evaluated directly. Return JSON-serializable
+   * values — Figma node objects have methods and won't serialize.
+   */
+  async eval(code) {
+    const needsWrap = /\breturn\b/.test(code) || /\bawait\b/.test(code);
+    const expression = needsWrap ? `(async () => { ${code} })()` : code;
+    const result = await this._rawEval(expression, { contextId: this.contextId });
+    if (result?.exceptionDetails) {
+      const ex = result.exceptionDetails;
+      const val = ex.exception?.value;
+      const msg =
+        (val && (typeof val === "string" ? val : JSON.stringify(val))) ||
+        ex.exception?.description ||
+        ex.text ||
+        "eval threw";
+      throw new Error(`figma.eval error: ${msg}`);
+    }
+    return result?.result?.value;
+  }
+
+  /**
+   * Capture a PNG of the target's **whole rendered viewport** — the Figma window
+   * as pixels, including the toolbar, panels and canvas chrome at the current zoom.
+   *
+   * Use this only when you need to see Figma's own UI (a plugin's iframe, the
+   * variables/inspector panels, a state you can't read through the Plugin API).
+   * To validate the *content* you drew, prefer {@link Client#exportNode}, which
+   * returns just that node's pixels, tightly cropped and zoom-independent.
+   */
+  async screenshot({ format = "png" } = {}) {
+    await this._send("Page.enable");
+    const reply = await this._send("Page.captureScreenshot", { format });
+    if (!reply.result?.data) throw new Error("captureScreenshot returned no data");
+    return Buffer.from(reply.result.data, "base64");
+  }
+
+  /**
+   * Export a single node's pixels via the Plugin API (`node.exportAsync`) and
+   * return them as a Buffer. This is the right way to *visually validate a frame*:
+   * the output is exactly that node, tightly cropped at full fidelity, regardless
+   * of the current viewport, zoom, or open panels — none of Figma's UI is included.
+   *
+   * @param {string} nodeId  The node id (e.g. from a created node's `.id`, or a selection).
+   * @param {object} [opts]
+   * @param {"PNG"|"JPG"|"SVG"} [opts.format]  Export format (default "PNG").
+   * @param {number} [opts.scale]              Scale factor for raster formats (default 2).
+   * @returns {Promise<Buffer>}
+   */
+  async exportNode(nodeId, { format = "PNG", scale = 2 } = {}) {
+    const id = JSON.stringify(String(nodeId));
+    const fmt = JSON.stringify(String(format).toUpperCase());
+    const raster = String(format).toUpperCase() !== "SVG";
+    let settings = `{ format: ${fmt} }`;
+    if (raster) {
+      const s = Number(scale);
+      if (!Number.isFinite(s) || s <= 0) {
+        throw new Error(
+          `invalid export scale: ${JSON.stringify(scale)} — must be a positive number`,
+        );
+      }
+      settings = `{ format: ${fmt}, constraint: { type: "SCALE", value: ${s} } }`;
+    }
+    const b64 = await this.eval(`
+      const node = await figma.getNodeByIdAsync(${id});
+      if (!node) throw new Error("node not found: " + ${id});
+      if (typeof node.exportAsync !== "function") throw new Error("node type " + node.type + " is not exportable");
+      const bytes = await node.exportAsync(${settings});
+      return figma.base64Encode(bytes);
+    `);
+    if (typeof b64 !== "string" || !b64) throw new Error("exportNode returned no data");
+    return Buffer.from(b64, "base64");
+  }
+
+  close() {
+    try {
+      this._ws?.close();
+    } catch {
+      // ignore
+    }
+  }
+}
+
+function safeMatch(pattern, str) {
+  try {
+    return new RegExp(pattern).test(str);
+  } catch {
+    return false;
+  }
+}

--- a/tools/figma-bridge/cli.mjs
+++ b/tools/figma-bridge/cli.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+// Bash-callable wrapper around the Figma CDP bridge. All output is JSON on stdout;
+// errors print {"error": "..."} on stderr and exit 1.
+//
+//   node cli.mjs status              # is a debug Figma up? what doc is open?
+//   node cli.mjs start               # clone/patch/sign (once) + launch debug Figma
+//   node cli.mjs stop                # quit the debug Figma
+//   node cli.mjs eval "<js>"         # run Plugin-API JS, print the returned value
+//   node cli.mjs export <id> [f.png] # export ONE node's pixels (tight crop) — verify a frame
+//   node cli.mjs shot [file.png]     # screenshot the WHOLE Figma window (UI chrome)
+//   node cli.mjs prepare             # clone/patch/sign without launching
+//   node cli.mjs clean               # remove the cloned debug app
+
+import { writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { connect, isPortReady, listTargets, DEFAULT_PORT } from "./cdp.mjs";
+import {
+  BRIDGE_DIR,
+  DEBUG_APP,
+  DEBUG_ASAR,
+  asarState,
+  clean,
+  prepare,
+  start,
+  stop,
+} from "./launch.mjs";
+
+const PORT = Number(process.env.FIGMA_BRIDGE_PORT || DEFAULT_PORT);
+
+function out(obj) {
+  process.stdout.write(JSON.stringify(obj, null, 2) + "\n");
+}
+
+function fail(err) {
+  process.stderr.write(JSON.stringify({ error: err?.message ?? String(err) }, null, 2) + "\n");
+  process.exit(1);
+}
+
+async function withClient(fn, opts = {}) {
+  const client = await connect({ port: PORT, ...opts });
+  try {
+    return await fn(client);
+  } finally {
+    client.close();
+  }
+}
+
+async function cmdStatus() {
+  const appExists = existsSync(DEBUG_APP);
+  const patched = appExists && existsSync(DEBUG_ASAR) ? asarState() : "absent";
+  if (!(await isPortReady(PORT))) {
+    return out({ running: false, port: PORT, debugApp: appExists ? DEBUG_APP : null, patched });
+  }
+  const targets = (await listTargets(PORT)).filter((t) => t.type === "page");
+  const info = await withClient(
+    (c) =>
+      c.eval(
+        "return { page: figma.currentPage.name, file: figma.root.name, editorType: figma.editorType };",
+      ),
+    { timeoutMs: 8000 },
+  );
+  out({ running: true, port: PORT, patched, openTabs: targets.length, ...info });
+}
+
+async function cmdStart() {
+  const res = await start({ port: PORT });
+  const info = await withClient((c) =>
+    c.eval("return { page: figma.currentPage.name, file: figma.root.name };"),
+  );
+  out({ started: true, ...res, ...info });
+}
+
+async function cmdStop() {
+  const stopped = await stop();
+  out({ stopped });
+}
+
+async function cmdEval(code) {
+  if (!code) throw new Error('eval needs a JS string, e.g. eval "return figma.currentPage.name"');
+  const value = await withClient((c) => c.eval(code));
+  out({ value });
+}
+
+async function cmdShot(file) {
+  const target = file || join(BRIDGE_DIR, "shot.png");
+  const buf = await withClient((c) => c.screenshot());
+  writeFileSync(target, buf);
+  out({ file: target, bytes: buf.length });
+}
+
+async function cmdExport(nodeId, file, scale) {
+  if (!nodeId) {
+    throw new Error('export needs a node id, e.g. export "12:34" frame.png [scale]');
+  }
+  const target = file || join(BRIDGE_DIR, "export.png");
+  const buf = await withClient((c) =>
+    c.exportNode(nodeId, { scale: scale ? Number(scale) : 2 }),
+  );
+  writeFileSync(target, buf);
+  out({ file: target, bytes: buf.length, nodeId });
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const cmd = args[0];
+  switch (cmd) {
+    case "status":
+      return cmdStatus();
+    case "start":
+      return cmdStart();
+    case "stop":
+      return cmdStop();
+    case "eval":
+      return cmdEval(args[1]);
+    case "export":
+      return cmdExport(args[1], args[2], args[3]);
+    case "shot":
+      return cmdShot(args[1]);
+    case "prepare":
+      return out(prepare());
+    case "clean":
+      clean();
+      return out({ cleaned: true });
+    default:
+      process.stderr.write(
+        'usage: cli.mjs <status|start|stop|eval "<js>"|export <id> [file] [scale]|shot [file]|prepare|clean>\n',
+      );
+      process.exit(2);
+  }
+}
+
+main().catch(fail);

--- a/tools/figma-bridge/docs/AGENT-GUIDE.md
+++ b/tools/figma-bridge/docs/AGENT-GUIDE.md
@@ -1,0 +1,215 @@
+# Figma bridge — agent guide
+
+Copy-paste recipes for driving Figma from bash over the CDP bridge. This is the
+practical companion to the [best practices](./BEST-PRACTICES.md); for how the
+bridge works internally see the [README](../README.md).
+
+All commands run from `tools/figma-bridge/`:
+
+```bash
+cd tools/figma-bridge
+```
+
+---
+
+## The loop: build → run → verify
+
+The whole point of this bridge is that an agent can close this loop **by itself**,
+with no human clicks:
+
+1. **Build** — write Plugin-API JS (inline, or a `.mjs` script for anything big).
+2. **Run** — execute it in the live renderer with `eval`.
+3. **Verify** — read the result back (`eval`) and, if it's visual, `export` the
+   node and view the PNG. Fix and re-run until it's right.
+
+```bash
+node cli.mjs status                              # 1. is a debug Figma up?
+node cli.mjs start                               #    (if not) launch one — quits any running Figma
+node cli.mjs eval 'return figma.currentPage.name'  # 2. run something
+node cli.mjs export "286:3" /tmp/frame.png       # 3. verify what you drew
+```
+
+> `eval` auto-wraps snippets that use top-level `return`/`await` in an async IIFE,
+> so you can `return` and `await` directly. Always return **JSON-serializable**
+> values.
+
+---
+
+## Reading (do this before you look at pixels)
+
+### List variable collections and variables
+
+```bash
+node cli.mjs eval '
+  const cols = await figma.variables.getLocalVariableCollectionsAsync();
+  const vars = await figma.variables.getLocalVariablesAsync();
+  return {
+    collections: cols.map(c => ({ name: c.name, modes: c.modes.map(m => m.name) })),
+    variables: vars.map(v => ({ name: v.name, type: v.resolvedType, collection: v.variableCollectionId })),
+  };
+'
+```
+
+### Resolve a variable's value in a mode
+
+```bash
+node cli.mjs eval '
+  const vars = await figma.variables.getLocalVariablesAsync();
+  const v = vars.find(x => x.name === "primary");
+  return { name: v.name, valuesByMode: v.valuesByMode };
+'
+```
+
+### Inspect the selection (name, type, size, fills, bindings)
+
+```bash
+node cli.mjs eval '
+  return figma.currentPage.selection.map(n => ({
+    id: n.id, name: n.name, type: n.type, w: n.width, h: n.height,
+    fills: "fills" in n ? n.fills : null,
+    bound: "boundVariables" in n ? n.boundVariables : null,
+  }));
+'
+```
+
+### List local styles
+
+```bash
+node cli.mjs eval '
+  const paints = await figma.getLocalPaintStylesAsync();
+  const texts = await figma.getLocalTextStylesAsync();
+  return { paints: paints.map(s => s.name), texts: texts.map(s => s.name) };
+'
+```
+
+---
+
+## Creating
+
+### Load a font before any text work
+
+Text ops throw if the font isn't loaded. Always load first:
+
+```bash
+node cli.mjs eval '
+  await figma.loadFontAsync({ family: "Inter", style: "Regular" });
+  const t = figma.createText();
+  t.characters = "Hello from the terminal";
+  figma.currentPage.appendChild(t);
+  return { id: t.id, chars: t.characters };
+'
+```
+
+### Create a frame and get its id back (then verify)
+
+```bash
+# create → capture the id from the JSON output
+node cli.mjs eval '
+  const f = figma.createFrame();
+  f.name = "Scratch";
+  f.resize(400, 200);
+  f.fills = [{ type: "SOLID", color: { r: 0.96, g: 0.96, b: 0.97 } }];
+  figma.currentPage.appendChild(f);
+  return { id: f.id };
+'
+# then export that id and look at it
+node cli.mjs export "<id-from-above>" /tmp/scratch.png
+```
+
+### Bind a variable to a paint (swatch pattern)
+
+```bash
+node cli.mjs eval '
+  const vars = await figma.variables.getLocalVariablesAsync();
+  const v = vars.find(x => x.name === "primary");
+  const rect = figma.createRectangle();
+  rect.resize(120, 80);
+  let paint = { type: "SOLID", color: { r: 0, g: 0, b: 0 } };
+  paint = figma.variables.setBoundVariableForPaint(paint, "color", v);
+  rect.fills = [paint];
+  figma.currentPage.appendChild(rect);
+  return { id: rect.id, boundTo: v.name };
+'
+```
+
+---
+
+## Auto-layout: the collapse/​wrap gotcha
+
+This bit us for real while building the demo page. Auto-layout frames don't size
+the way you'd guess:
+
+- A **VERTICAL** stack that should grow with its children needs
+  `primaryAxisSizingMode = "AUTO"` (hug contents). Leave it `FIXED` and the frame
+  keeps its initial height and **clips everything** — the classic "my content is
+  invisible / squished to 10px" symptom.
+- A **HORIZONTAL wrap** row (a grid of cards) needs all three:
+  - `layoutWrap = "WRAP"`
+  - `primaryAxisSizingMode = "FIXED"` — a fixed width is what forces wrapping
+  - `counterAxisSizingMode = "AUTO"` — height hugs however many rows result
+  - `itemSpacing` = gap between columns, `counterAxisSpacing` = gap between rows
+
+```bash
+node cli.mjs eval '
+  const wrap = figma.createFrame();
+  wrap.layoutMode = "HORIZONTAL";
+  wrap.layoutWrap = "WRAP";
+  wrap.primaryAxisSizingMode = "FIXED";     // fixed width → wrapping kicks in
+  wrap.counterAxisSizingMode = "AUTO";      // height hugs the rows
+  wrap.itemSpacing = 16;                    // column gap
+  wrap.counterAxisSpacing = 16;             // row gap
+  wrap.resize(768, 10);                     // width matters; height will hug
+  figma.currentPage.appendChild(wrap);
+  return { id: wrap.id };
+'
+```
+
+When a built layout looks collapsed, **read the sizing modes with `eval`**
+(don't just stare at a screenshot) and flip the offending mode to `AUTO`.
+
+---
+
+## Verifying
+
+```bash
+# preferred: export just the node you care about (tight crop, full fidelity)
+node cli.mjs export "<nodeId>" /tmp/out.png 2     # 2 = @2x scale (default)
+
+# only for Figma's own UI (plugin iframes, panels): whole-window shot
+node cli.mjs shot /tmp/figma-window.png
+```
+
+Then view the PNG. See the [verification hierarchy](./BEST-PRACTICES.md#the-verification-hierarchy)
+for when to use which — the short version is: **read values with `eval`, validate
+frames with `export`, and only `shot` the whole window for Figma's chrome.**
+
+---
+
+## Targeting a specific file
+
+The CLI connects to whichever live design context it finds first. When several
+files are open and you need a specific one, filter by its **file key** (the
+`…/design/<KEY>/…` segment of the URL) via `connect({ targetUrl })`:
+
+```bash
+node -e '
+  import("./cdp.mjs").then(async ({ connect }) => {
+    const c = await connect({ targetUrl: "xKlAp4LLn5JAUAS0NFyg0M", timeoutMs: 8000 });
+    const name = await c.eval("return figma.root.name");
+    console.log(name);
+    c.close();
+  });
+'
+```
+
+The same `connect({ targetUrl })` handle exposes `eval()`, `screenshot()` and
+`exportNode(id, { scale })` if you need to script a full targeted flow.
+
+---
+
+## Big jobs: use a script, not a giant inline string
+
+For anything past a few lines, write a `.mjs` file that imports `connect` from
+`cdp.mjs`, do all the work in one `eval` (so it's one round-trip and one
+transaction of intent), return a small JSON summary, and `export` the result to
+verify. Delete the temp script and PNGs when done.

--- a/tools/figma-bridge/docs/BEST-PRACTICES.md
+++ b/tools/figma-bridge/docs/BEST-PRACTICES.md
@@ -1,0 +1,134 @@
+# Figma bridge — best practices
+
+Hard-won rules for driving Figma over the CDP bridge well. If you only read one
+thing, read **[The verification hierarchy](#the-verification-hierarchy)** — it is
+the single most important habit and the reason this tool has an `export` command.
+
+> These are guidelines for an **agent** operating the bridge from bash, but they
+> apply equally to a human at the keyboard. The bridge itself is documented in the
+> [README](../README.md); the copy-paste recipes live in the
+> [Agent guide](./AGENT-GUIDE.md).
+
+---
+
+## The verification hierarchy
+
+You have three ways to "check" something in Figma. They are **not**
+interchangeable — pick the cheapest one that actually answers your question,
+and reach for a screenshot last.
+
+### 1. Read the value with the Plugin API — _always try this first_
+
+If the question is _"what is this?"_ — a color, a name, a size, a bound variable,
+a font, the node tree — **read it**, don't look at it. `eval` runs real Plugin-API
+JS in the live renderer and returns structured data you can assert on.
+
+```bash
+node cli.mjs eval 'return figma.currentPage.selection.map(n => ({ name: n.name, type: n.type, w: n.width, h: n.height }))'
+```
+
+Values you should read, never eyeball:
+
+- fills / strokes and whether they are `(bound)` to a variable
+- variable values, collections, modes, aliases
+- text content, font family/style, font size
+- layout props (`layoutMode`, sizing modes, padding, spacing)
+- the node hierarchy and node ids
+
+This is what the user means by _"the API-based way"_ — the **Figma Plugin API**,
+in-process over the bridge. (Not the Figma REST API — that's a different, external
+HTTP service and not what this tool uses.)
+
+### 2. `export` a node — _to validate something you drew_
+
+When the question is visual — _"does the frame I just built actually look right?"_
+— export **just that node** to a PNG and view it:
+
+```bash
+node cli.mjs export "286:3" /tmp/frame.png   # nodeId, output path, optional scale (default 2)
+```
+
+`export` calls `node.exportAsync()`, so you get **exactly that node's pixels,
+tightly cropped, at full fidelity, independent of the current zoom, viewport, or
+which panels are open**. No toolbar, no sidebars, no canvas chrome. This is the
+right tool for _"validate what's on a frame"_ and it should be your default for
+visual checks.
+
+### 3. `shot` the whole window — _only for Figma's own UI_
+
+`shot` captures the **entire Figma window as pixels** — toolbar, panels, canvas
+chrome, at the current zoom. Reserve it for the few cases where the thing you need
+to see _is_ Figma itself:
+
+- a plugin's own iframe/UI while you're building or debugging a plugin
+- the state of the variables / inspector / layers panels
+- something the Plugin API genuinely can't expose
+
+```bash
+node cli.mjs shot /tmp/figma-window.png
+```
+
+**Rule of thumb:** validating _content_ → `export` the node. Inspecting _Figma_ →
+`shot`. Answering _"what is the value"_ → don't screenshot at all, `eval` and read
+it. A full-window screenshot to check a frame's colors is almost always the wrong
+call — it's zoom-dependent, cluttered, and lower fidelity than an `export`.
+
+---
+
+## Other practices
+
+### Prefer Plugin-API reads over pixels, everywhere
+
+Beyond validation: whenever you're gathering information to make a decision
+(what variables exist, what a token resolves to, whether text fits), read it with
+`eval`. Structured data is assertable, diffable, and doesn't lie about anti-aliased
+edges. Screenshots are for humans and for genuinely visual questions.
+
+### Mutations are real and sync to the cloud
+
+`eval` runs against the user's actual, logged-in Figma. Anything you create,
+rename, restyle, or **delete is a real edit** on a real document and will sync.
+There is no sandbox. So:
+
+- Work on a scratch page/file when experimenting (the demo used a dedicated
+  "Test CDP" file).
+- Prefer additive changes; think twice before `.remove()`.
+- Never delete or restructure the user's content without being asked.
+
+### Write idempotent scripts
+
+Assume your script may run more than once (you'll re-run to fix a bug). Before
+creating a page/frame/style, look for an existing one by name and reuse or clear
+it, so re-runs don't pile up duplicates.
+
+```js
+let page = figma.root.children.find((p) => p.name === "My scratch page");
+if (!page) {
+  page = figma.createPage();
+  page.name = "My scratch page";
+}
+```
+
+### Target a specific file by key when many tabs are open
+
+The CLI connects to whichever live design context it finds first, which may be the
+wrong tab. To pin a specific document, filter targets by its **file key** (unique),
+using the `connect({ targetUrl })` option from `cdp.mjs` in a small inline script —
+see the [Agent guide](./AGENT-GUIDE.md#targeting-a-specific-file).
+
+### Load fonts before touching text
+
+`createText`, setting `.characters`, or changing font size throws if the font isn't
+loaded. `await figma.loadFontAsync(...)` first. See the recipe in the Agent guide.
+
+### Clean up temp artifacts
+
+Screenshots and exports are throwaway. Write them to `/tmp` (or the bridge dir) and
+delete them when you're done validating; don't leave PNGs in the repo.
+
+### Keep the tool zero-dep and out of the workspace graph
+
+`tools/figma-bridge/` is intentionally outside the npm/turbo workspaces and has no
+dependencies (Node built-ins only). Keep it that way — it must run standalone. The
+cloned 300 MB debug app and all runtime state live in `~/.figma-bridge/` and are
+never committed.

--- a/tools/figma-bridge/launch.mjs
+++ b/tools/figma-bridge/launch.mjs
@@ -1,0 +1,179 @@
+// Lifecycle for a debug-enabled copy of Figma Desktop (macOS).
+//
+// Strategy (zero-touch): copy /Applications/Figma.app into ~/.figma-bridge, flip
+// one byte in the copy's app.asar so Figma stops stripping --remote-debugging-port,
+// ad-hoc re-sign the copy, then launch it with the debug port. The copy shares the
+// logged-in profile, so it reopens your recent files. No system permission needed.
+//
+// If the copied-app route ever fails (e.g. Gatekeeper), the same patch can be applied
+// to the installed app after granting Terminal "App Management" in System Settings —
+// see README.md.
+
+import { execFile, execFileSync, spawn } from "node:child_process";
+import { existsSync, mkdirSync, openSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { DEFAULT_PORT, connect, isPortReady } from "./cdp.mjs";
+
+const execFileAsync = promisify(execFile);
+
+export const SRC_APP = "/Applications/Figma.app";
+export const BRIDGE_DIR = join(homedir(), ".figma-bridge");
+export const DEBUG_APP = join(BRIDGE_DIR, "FigmaDebug.app");
+export const DEBUG_BIN = join(DEBUG_APP, "Contents/MacOS/Figma");
+export const DEBUG_ASAR = join(DEBUG_APP, "Contents/Resources/app.asar");
+export const LOG_FILE = join(BRIDGE_DIR, "figma.log");
+
+// One-byte flip: Figma calls removeSwitch("remote-debugging-port") to drop the
+// flag; corrupting the switch name to "remote-debugXing-port" makes that call a
+// no-op, so our --remote-debugging-port survives. Same length => asar stays valid.
+const BLOCK = 'removeSwitch("remote-debugging-port")';
+const PATCH = 'removeSwitch("remote-debugXing-port")';
+
+function assertMacSourceApp() {
+  if (process.platform !== "darwin") throw new Error("figma-bridge currently supports macOS only.");
+  if (!existsSync(SRC_APP)) throw new Error(`Figma not found at ${SRC_APP}. Install Figma Desktop first.`);
+}
+
+/** Clone /Applications/Figma.app into the bridge dir (fast APFS clone via ditto). */
+export function ensureDebugApp({ force = false } = {}) {
+  assertMacSourceApp();
+  mkdirSync(BRIDGE_DIR, { recursive: true });
+  if (force && existsSync(DEBUG_APP)) rmSync(DEBUG_APP, { recursive: true, force: true });
+  if (!existsSync(DEBUG_APP)) {
+    execFileSync("ditto", [SRC_APP, DEBUG_APP]);
+  }
+}
+
+export function asarState() {
+  const buf = readFileSync(DEBUG_ASAR);
+  if (buf.includes(PATCH)) return "patched";
+  if (buf.includes(BLOCK)) return "unpatched";
+  return "unknown";
+}
+
+/** Apply the byte-flip to the copy's asar (idempotent). */
+export function patch() {
+  const buf = readFileSync(DEBUG_ASAR);
+  if (buf.includes(PATCH)) return false; // already patched
+  const i = buf.indexOf(BLOCK);
+  if (i === -1) throw new Error("Patch anchor not found in app.asar (Figma internals may have changed).");
+  Buffer.from(PATCH).copy(buf, i);
+  writeFileSync(DEBUG_ASAR, buf);
+  return true;
+}
+
+/** Revert the byte-flip (used before re-cloning / cleanup). */
+export function unpatch() {
+  const buf = readFileSync(DEBUG_ASAR);
+  const i = buf.indexOf(PATCH);
+  if (i === -1) return false;
+  Buffer.from(BLOCK).copy(buf, i);
+  writeFileSync(DEBUG_ASAR, buf);
+  return true;
+}
+
+/** Ad-hoc re-sign the copy so macOS will launch the modified bundle. */
+export function sign() {
+  execFileSync("codesign", ["--force", "--deep", "--sign", "-", DEBUG_APP]);
+}
+
+/** Clone + patch + sign, only doing the work that isn't already done. */
+export function prepare({ force = false } = {}) {
+  ensureDebugApp({ force });
+  const didPatch = patch();
+  if (didPatch || force) sign();
+  return { app: DEBUG_APP, patched: asarState() === "patched" };
+}
+
+/** PIDs of any running process named exactly "Figma" (installed OR our copy). */
+export function runningPids() {
+  try {
+    const out = execFileSync("pgrep", ["-x", "Figma"], { encoding: "utf8" });
+    return out.split("\n").map((s) => s.trim()).filter(Boolean);
+  } catch {
+    return []; // pgrep exits non-zero when nothing matches
+  }
+}
+
+/** Gracefully quit any running Figma (lets it sync + prompt on unsaved work). */
+export async function quitFigma({ timeoutMs = 15000 } = {}) {
+  if (runningPids().length === 0) return true;
+  try {
+    await execFileAsync("osascript", ["-e", 'tell application "Figma" to quit']);
+  } catch {
+    // fall through to polling; app may already be closing
+  }
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (runningPids().length === 0) return true;
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  return runningPids().length === 0;
+}
+
+/**
+ * Launch the debug copy with the remote debugging port and wait until the Plugin
+ * API is actually usable (not just the port). Quits any running Figma first
+ * (installed and debug share one profile → one at a time).
+ */
+export async function start({ port = DEFAULT_PORT, waitMs = 45000 } = {}) {
+  prepare();
+
+  const quit = await quitFigma();
+  if (!quit) {
+    throw new Error("A Figma instance is still running (possibly blocked on an unsaved-changes dialog).");
+  }
+
+  mkdirSync(BRIDGE_DIR, { recursive: true });
+  const fd = openSync(LOG_FILE, "a");
+  const child = spawn(DEBUG_BIN, [`--remote-debugging-port=${port}`], {
+    detached: true,
+    stdio: ["ignore", fd, fd],
+  });
+  child.unref();
+
+  const deadline = Date.now() + waitMs;
+
+  // Phase 1: wait for the CDP port to accept connections.
+  let portUp = false;
+  while (Date.now() < deadline) {
+    if (await isPortReady(port)) {
+      portUp = true;
+      break;
+    }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  if (!portUp) {
+    throw new Error(`Debug port ${port} did not come up within ${waitMs}ms. See ${LOG_FILE}.`);
+  }
+
+  // Phase 2: wait until a document's `figma` global is evaluable. The port opens
+  // several seconds before the renderer injects the Plugin API, and restored tabs
+  // may be suspended — connect() scans + retries for us.
+  const remaining = Math.max(2000, deadline - Date.now());
+  let client;
+  try {
+    client = await connect({ port, timeoutMs: remaining });
+    const page = await client.eval("return figma.currentPage.name");
+    return { pid: child.pid, port, page };
+  } catch (e) {
+    throw new Error(
+      `Debug Figma launched on port ${port} but the Plugin API did not become ready: ${e.message}. ` +
+        "Make sure a design file (not the recents/home page) is open, then retry.",
+    );
+  } finally {
+    client?.close();
+  }
+}
+
+/** Quit the debug Figma. */
+export async function stop() {
+  return quitFigma();
+}
+
+/** Remove the cloned debug app (does not touch the installed Figma). */
+export function clean() {
+  if (existsSync(DEBUG_APP)) rmSync(DEBUG_APP, { recursive: true, force: true });
+}


### PR DESCRIPTION
## What

Ports the `figma-bridge` standalone debugging utility from `tokens-studio/consumer-plugins` into this repo at `tools/figma-bridge/`.

## What figma-bridge does

A **zero-dependency, macOS-only** tool that lets an agent (or you) drive **Figma Desktop** over the Chrome DevTools Protocol (CDP) and evaluate **Plugin-API JS** (`figma.*`) directly in the renderer — no plugin, no UI clicks, no per-session setup.

It clones `/Applications/Figma.app` → `~/.figma-bridge/FigmaDebug.app` (once, ~300 MB, fast APFS clone via `ditto`), byte-patches the copy's `app.asar` to keep `--remote-debugging-port` alive (Figma normally strips it), ad-hoc re-signs the copy, and launches it on port 9222. From there you can read the document, mutate nodes, manage variables/styles, export individual nodes to PNG, and screenshot the canvas — all from bash.

**Requires Node 22+** (uses the built-in `WebSocket`/`fetch` globals; zero npm deps).

## Commands

```bash
cd tools/figma-bridge

# First time setup (clone + patch + sign, ~300 MB, one-time):
node cli.mjs prepare

# Launch debug Figma (quits any running Figma first, then waits until Plugin API is ready):
node cli.mjs start

# Check status:
node cli.mjs status

# Evaluate Plugin-API JS:
node cli.mjs eval "return figma.currentPage.name"
node cli.mjs eval "return (await figma.variables.getLocalVariableCollectionsAsync()).map(c => c.name)"

# Export a node's pixels (tight crop — preferred for content validation):
node cli.mjs export "<nodeId>" /tmp/frame.png

# Screenshot the whole Figma window (for inspecting Figma's own UI):
node cli.mjs shot /tmp/window.png

# Quit debug Figma:
node cli.mjs stop

# Clean up cloned app:
node cli.mjs clean
```

All commands emit JSON on stdout; `{"error": "..."}` + exit 1 on failure.

## What's NOT included (intentional)

**No browser mode.** The Figma web app cannot import development (manifest-based) plugins, so browser mode can't support the real plugin dev loop. Desktop Mode only.

## Build graph isolation

`tools/` is outside the `apps/*` and `packages/*` workspace globs and not referenced by `turbo.json`, so this tool is **not** in the build/lint/test graph. No config changes were needed. Runtime state (the ~300 MB `FigmaDebug.app`, logs, state cache) lives in `~/.figma-bridge/` — never committed.

## Files

- `tools/figma-bridge/cdp.mjs` — zero-dep CDP client (target discovery, `eval`, `exportNode`, `screenshot`)
- `tools/figma-bridge/launch.mjs` — lifecycle: clone/patch/sign/start/stop/clean
- `tools/figma-bridge/cli.mjs` — bash-callable command surface
- `tools/figma-bridge/AGENTS.md` — self-contained agent instructions
- `tools/figma-bridge/README.md` — full docs, command reference, caveats
- `tools/figma-bridge/docs/AGENT-GUIDE.md` — copy-paste recipes
- `tools/figma-bridge/docs/BEST-PRACTICES.md` — verification hierarchy and operating rules
- `tools/figma-bridge/.gitignore` — keeps runtime state out of the repo