### PR TITLE
fix: stop granting Pro from offline legacy Studio PAT

### DIFF
--- a/packages/tokens-studio-for-figma/src/app/hooks/useIsProUser.ts
+++ b/packages/tokens-studio-for-figma/src/app/hooks/useIsProUser.ts
@@ -11,10 +11,9 @@ export function useIsProUser() {
 
   return useMemo(() => {
     const hasLicenseKey = Boolean(existingKey && !licenseKeyError);
-    // Pro is granted by a validated license key or an active Tokens Studio OAuth
-    // subscription (`isPro`). The legacy PAT-based Tokens Studio path is deliberately
-    // excluded: that server is decommissioned, so a locally-stored PAT can no longer be
-    // validated and must not confer Pro on its own.
+    // Pro is granted by a license key with no recorded validation error, or an active Tokens Studio OAuth
+    // subscription (`isPro`). The legacy PAT-based Tokens Studio path is deliberately excluded: that server is
+    // decommissioned, so a locally-stored PAT can no longer be validated and must not confer Pro on its own.
     return hasLicenseKey || isPro;
   }, [existingKey, licenseKeyError, isPro]);
 }

--- a/packages/tokens-studio-for-figma/src/app/hooks/useIsProUser.ts
+++ b/packages/tokens-studio-for-figma/src/app/hooks/useIsProUser.ts
@@ -2,21 +2,19 @@ import { useSelector } from 'react-redux';
 import { useMemo } from 'react';
 import { licenseKeySelector } from '@/selectors/licenseKeySelector';
 import { licenseKeyErrorSelector } from '@/selectors/licenseKeyErrorSelector';
-import { tokensStudioPATSelector } from '@/selectors/tokensStudioPATSelector';
-import { storageTypeSelector } from '@/selectors/storageTypeSelector';
-import { StorageProviderType } from '@/constants/StorageProviderType';
 import { useAuthStore } from '@/app/store/useAuthStore';
 
 export function useIsProUser() {
   const existingKey = useSelector(licenseKeySelector);
   const licenseKeyError = useSelector(licenseKeyErrorSelector);
-  const validPAT = useSelector(tokensStudioPATSelector);
-  const storageType = useSelector(storageTypeSelector);
   const { isPro } = useAuthStore();
 
   return useMemo(() => {
     const hasLicenseKey = Boolean(existingKey && !licenseKeyError);
-    const hasTokensStudioPAT = Boolean(validPAT && (storageType?.provider === StorageProviderType.TOKENS_STUDIO));
-    return hasLicenseKey || hasTokensStudioPAT || isPro;
-  }, [existingKey, licenseKeyError, validPAT, storageType, isPro]);
+    // Pro is granted by a validated license key or an active Tokens Studio OAuth
+    // subscription (`isPro`). The legacy PAT-based Tokens Studio path is deliberately
+    // excluded: that server is decommissioned, so a locally-stored PAT can no longer be
+    // validated and must not confer Pro on its own.
+    return hasLicenseKey || isPro;
+  }, [existingKey, licenseKeyError, isPro]);
 }


### PR DESCRIPTION
The legacy Tokens Studio server is decommissioned, so a locally-stored PAT can no longer be validated. useIsProUser treated a stored PAT plus the tokensstudio provider as Pro without any server check, letting old users keep Pro for free. Grant Pro only via a validated license key or active Studio OAuth subscription.

<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

Closes #0000 <!-- link the related issue -->

<!--
  Describe the problem you're addressing and the rationale behind this PR.
-->

### What does this pull request do?

<!--
  Detailed summary of the changes, including any visual or interactive updates.
  For UI changes, add before/after screenshots. For interactive elements, consider including a video or an animated gif.
  Explain some of the choices you've made in the PR, if they're not obvious.
-->

### Testing this change

<!--
  Describe how this change can be tested. Are there steps required to get there? Explain what's required so a reviewer can test these changes locally.

  If you have a review link available, add it here.
-->

### Additional Notes (if any)

<!--
  Add any other context or screenshots about the pull request
-->
