### PR TITLE
fix: auto-close stranded tooltips via watchdog

### DIFF
--- a/.changeset/quick-plants-leave.md
+++ b/.changeset/quick-plants-leave.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fixed tooltips sometimes getting stuck on screen after moving the cursor away.

--- a/packages/tokens-studio-for-figma/src/app/asyncMessageHandlers/startup.tsx
+++ b/packages/tokens-studio-for-figma/src/app/asyncMessageHandlers/startup.tsx
@@ -12,6 +12,7 @@ import { RootState, store } from '../store';
 import { AppContainer } from '../components/AppContainer';
 import PreviewApp from '../preview/preview';
 import FigmaLoading from '../components/FigmaLoading';
+import TooltipWatchdog from '../components/TooltipWatchdog';
 
 // eslint-disable-next-line
 const PREVIEW_ENV = process.env.PREVIEW_ENV;
@@ -63,6 +64,7 @@ export const startup = async () => {
     <Sentry.ErrorBoundary fallback={ErrorFallback}>
       <Provider store={store}>
         <Tooltip.Provider>
+          <TooltipWatchdog />
           <StartupApp />
         </Tooltip.Provider>
       </Provider>

--- a/packages/tokens-studio-for-figma/src/app/components/TooltipWatchdog.test.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/TooltipWatchdog.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import * as Tooltip from '@radix-ui/react-tooltip';
+import { fireEvent, waitFor } from '@testing-library/react';
+import { render } from '../../../tests/config/setupTest';
+import TooltipWatchdog from './TooltipWatchdog';
+
+// These tests lock in the Radix internals that TooltipWatchdog depends on. If a Radix
+// upgrade renames the `tooltip.open` event, changes the tooltip `role`, or changes the
+// open-trigger `data-state` values, the watchdog would silently stop working — and one
+// of these assertions will fail instead.
+function renderOpenTooltip() {
+  return render(
+    <Tooltip.Provider>
+      <TooltipWatchdog />
+      <Tooltip.Root defaultOpen delayDuration={0}>
+        <Tooltip.Trigger data-testid="trigger">hover me</Tooltip.Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Content>tooltip label</Tooltip.Content>
+        </Tooltip.Portal>
+      </Tooltip.Root>
+    </Tooltip.Provider>,
+  );
+}
+
+describe('TooltipWatchdog', () => {
+  it('an open Radix tooltip exposes the contract the watchdog relies on', async () => {
+    const { getByTestId, findByRole } = renderOpenTooltip();
+
+    // 1. Open tooltip content is discoverable via role="tooltip".
+    await findByRole('tooltip');
+    // 2. The open trigger carries a data-state the watchdog whitelists.
+    expect(['instant-open', 'delayed-open']).toContain(getByTestId('trigger').getAttribute('data-state'));
+  });
+
+  it('closes a tooltip when the pointer moves away from its trigger', async () => {
+    const { queryByRole, findByRole } = renderOpenTooltip();
+    await findByRole('tooltip');
+
+    fireEvent.pointerMove(document.body);
+
+    await waitFor(() => expect(queryByRole('tooltip')).not.toBeInTheDocument());
+  });
+
+  it('keeps the tooltip while the pointer is still over its trigger', async () => {
+    const { getByTestId, findByRole, queryByRole } = renderOpenTooltip();
+    await findByRole('tooltip');
+
+    fireEvent.pointerMove(getByTestId('trigger'));
+
+    // Give any (unwanted) close a chance to flush, then assert it stayed open.
+    await new Promise((resolve) => { setTimeout(resolve, 50); });
+    expect(queryByRole('tooltip')).toBeInTheDocument();
+  });
+});

--- a/packages/tokens-studio-for-figma/src/app/components/TooltipWatchdog.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/TooltipWatchdog.tsx
@@ -1,0 +1,56 @@
+import { useEffect } from 'react';
+
+// Radix Tooltip dispatches this event on `document` whenever any tooltip opens; every
+// mounted tooltip listens for it and closes itself so only one can ever be visible. We
+// reuse it as a force-close for tooltips that have become stranded — e.g. the trigger
+// unmounted while hovered (no pointerleave fires), focus was restored to a hidden
+// trigger after a modal closed, or a long main-thread task blocked the pointer handlers.
+// In all of those cases the tooltip stays painted with no path back to closed; this
+// watchdog gives it one, tied to the next pointer move or scroll.
+const TOOLTIP_OPEN_EVENT = 'tooltip.open';
+const OPEN_TRIGGER_SELECTOR = '[data-state="instant-open"], [data-state="delayed-open"]';
+const POINTER_THROTTLE_MS = 150;
+
+function hasOpenTooltip() {
+  return document.querySelector('[role="tooltip"]') as HTMLElement | null;
+}
+
+function closeOpenTooltips() {
+  if (hasOpenTooltip()) {
+    document.dispatchEvent(new CustomEvent(TOOLTIP_OPEN_EVENT));
+  }
+}
+
+export default function TooltipWatchdog() {
+  useEffect(() => {
+    let lastPointerCheck = 0;
+
+    const handlePointerMove = (event: PointerEvent) => {
+      const now = Date.now();
+      if (now - lastPointerCheck < POINTER_THROTTLE_MS) return;
+      lastPointerCheck = now;
+
+      const openTooltip = hasOpenTooltip();
+      if (!openTooltip) return;
+
+      // Keep the tooltip while the pointer is genuinely over its trigger or the tooltip
+      // content itself; close it once the pointer has moved away and nothing reopened it.
+      const target = event.target as Element | null;
+      const overTrigger = target?.closest(OPEN_TRIGGER_SELECTOR);
+      const overTooltip = target ? openTooltip.contains(target) : false;
+      if (!overTrigger && !overTooltip) {
+        closeOpenTooltips();
+      }
+    };
+
+    window.addEventListener('scroll', closeOpenTooltips, { capture: true, passive: true });
+    window.addEventListener('pointermove', handlePointerMove, { passive: true });
+
+    return () => {
+      window.removeEventListener('scroll', closeOpenTooltips, { capture: true } as EventListenerOptions);
+      window.removeEventListener('pointermove', handlePointerMove);
+    };
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
Force-close tooltips that lose their pointer without a close event — trigger unmount, focus restore after modal close, or a main-thread stall.

### Why does this PR exist?

Closes #3891  <!-- link the related issue -->

Users hit an intermittent bug where a tooltip stays on screen detached from
its trigger, or a tooltip won't appear on hover. It's hard to reproduce because
it depends on what re-renders while a tooltip happens to be open.

Root cause: the design-system tooltip (`@tokens-studio/ui` 0.9.0 → Radix
`react-tooltip` 1.0.7, opened with `delayDuration={0}`) only closes on a fixed
set of events — pointerleave, click, Esc, or a scroll of a container that still
contains the trigger. Several common situations fire none of those and strand
the tooltip open:

- The trigger unmounts or shifts under a still pointer (list filter, remote sync,
  Alt+click expand/collapse) — no pointerleave, and the scroll-close listener is
  torn down with the trigger.
- Focus is restored to a hidden trigger after the token-edit modal closes,
  re-opening its tooltip with the cursor elsewhere.
- A long main-thread task blocks the event loop, so Radix's pointer handlers
  can't run; the open tooltip stays painted until the stall ends.

### What does this pull request do?

Adds a small, dependency-free `TooltipWatchdog` mounted once inside
`Tooltip.Provider`. On a throttled `pointermove` and capture-phase `scroll`, if a
tooltip is open but the pointer is no longer over its trigger
(`data-state="instant-open"|"delayed-open"`) or the tooltip itself, it dispatches
Radix's own `tooltip.open` event on `document` — the same signal Radix uses to
keep a single tooltip visible — which force-closes any stranded tooltip.

This heals every failure mode above on the next pointer move or scroll, including
the tooltip fallout from a main-thread stall (no library can prevent the stall
itself, but the ghost clears the moment the loop frees up). No dependency or
Radix version changes.

A guard test renders a real Radix tooltip and asserts the internals the watchdog
relies on (the `tooltip.open` event, `role="tooltip"`, the open `data-state`
values), so a future Radix upgrade that renames any of them fails CI instead of
silently disabling the fix.

### Testing this change

Automated: `yarn test src/app/components/TooltipWatchdog.test.tsx` (3 tests —
contract + close-on-leave + keep-on-trigger).

Manual (in Figma or the browser preview env):

1. **Focus-restore ghost** — hover a token group's `+`, click it to open the
   new-token modal, move the mouse away, close the modal with its X. Before: a
   tooltip appears at the now-hidden `+`. After: it clears on the next mouse move.
2. **Stranded via unmount** — in the plugin console, run
   `setTimeout(() => document.querySelector('[data-testid="button-add-new-token-in-group"]')?.remove(), 3000)`,
   then within 3s hover a group `+` and freeze the mouse. Before: tooltip stays
   forever. After: clears on next move/scroll.
3. **Main-thread stall** — run
   `setTimeout(() => { const t = performance.now(); while (performance.now() - t < 5000); }, 1500)`,
   hover swatches during the block. Before: stale tooltip pinned ~5s. After: it
   clears immediately once the pointer moves after the stall.

### Additional Notes (if any)