### PR TITLE
Add Pro terms and subprocessors notice

### DIFF
--- a/.changeset/terms-subprocessors-notice.md
+++ b/.changeset/terms-subprocessors-notice.md
@@ -2,4 +2,4 @@
 "@tokens-studio/figma-plugin": patch
 ---
 
-Add a Pro-only start screen notice for the updated terms and subprocessors.
+We have updated our Terms and Conditions, which will come into effect in 30 days. The changes include adding a new Subprocess (Render.com) and improvements around our license portal.

--- a/.changeset/terms-subprocessors-notice.md
+++ b/.changeset/terms-subprocessors-notice.md
@@ -2,4 +2,4 @@
 "@tokens-studio/figma-plugin": patch
 ---
 
-We have updated our Terms and Conditions, which will come into effect in 30 days. The changes include adding a new Subprocess (Render.com) and improvements around our license portal.
+We have updated our Terms and Conditions, which will come into effect in 30 days, on August 14th, 2026. The changes include adding a new Subprocess (Render.com) and improvements around our license portal. This notice is dated July 15th, 2026.

--- a/.changeset/terms-subprocessors-notice.md
+++ b/.changeset/terms-subprocessors-notice.md
@@ -2,4 +2,4 @@
 "@tokens-studio/figma-plugin": patch
 ---
 
-We have updated our Terms and Conditions, which will come into effect in 30 days, on August 14th, 2026. The changes include adding a new Subprocess (Render.com) and improvements around our license portal. This notice is dated July 15th, 2026.
+We have updated our Terms and Conditions, which will come into effect on August 14th, 2026. The changes include adding a new Subprocessor (Render.com) and improvements around our license portal. This notice is dated July 15th, 2026.

--- a/.changeset/terms-subprocessors-notice.md
+++ b/.changeset/terms-subprocessors-notice.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Add a Pro-only start screen notice for the updated terms and subprocessors.

--- a/packages/tokens-studio-for-figma/src/app/components/Initiator.test.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/Initiator.test.tsx
@@ -667,6 +667,7 @@ describe('Initiator', () => {
       autoApplyThemeOnDrop: false,
       seenGenericVersionedHeaderMigrationDialog: false,
       seenTermsUpdate2026: false,
+      seenTermsUpdate2026Subprocessors: false,
     });
   });
 

--- a/packages/tokens-studio-for-figma/src/app/components/TermsUpdateModal.test.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/TermsUpdateModal.test.tsx
@@ -66,7 +66,7 @@ describe('TermsUpdateModal', () => {
     expect(screen.getByText('Terms & Conditions Update')).toBeInTheDocument();
     expect(
       screen.getByText(
-        'We have updated our Terms and Conditions, which will come into effect in 30 days, on August 14th, 2026. The changes include adding a new Subprocess (Render.com) and improvements around our license portal. This notice is dated July 15th, 2026.',
+        'We have updated our Terms and Conditions, which will come into effect on August 14th, 2026. The changes include adding a new Subprocessor (Render.com) and improvements around our license portal. This notice is dated July 15th, 2026.',
       ),
     ).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'View the terms' })).toHaveAttribute('href', 'https://tokens.studio/terms');

--- a/packages/tokens-studio-for-figma/src/app/components/TermsUpdateModal.test.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/TermsUpdateModal.test.tsx
@@ -19,7 +19,7 @@ describe('TermsUpdateModal', () => {
     jest.useFakeTimers();
     useIsProUserMock.mockReturnValue(true);
     act(() => {
-      useAuthStore.setState({ isAuthenticated: false });
+      useAuthStore.setState({ isAuthenticated: false, isPro: false });
     });
   });
 
@@ -27,7 +27,7 @@ describe('TermsUpdateModal', () => {
     jest.useRealTimers();
     useIsProUserMock.mockReset();
     act(() => {
-      useAuthStore.setState({ isAuthenticated: false });
+      useAuthStore.setState({ isAuthenticated: false, isPro: false });
     });
   });
 
@@ -61,7 +61,7 @@ describe('TermsUpdateModal', () => {
 
     expect(screen.getByText('Terms & Conditions Update')).toBeInTheDocument();
     expect(screen.getByText('We have updated our Terms and Conditions, which will come into effect in 30 days. The changes include adding a new Subprocess (Render.com) and improvements around our license portal.')).toBeInTheDocument();
-    expect(screen.getByText('July 15th, 2026')).toBeInTheDocument();
+    expect(screen.getByText('Notice date: July 15th, 2026')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'View the terms' })).toHaveAttribute('href', 'https://tokens.studio/terms');
   });
 
@@ -78,7 +78,7 @@ describe('TermsUpdateModal', () => {
 
   it('does not show the announcement to Tokens Studio subscription users', () => {
     act(() => {
-      useAuthStore.setState({ isAuthenticated: true });
+      useAuthStore.setState({ isAuthenticated: true, isPro: true });
     });
     renderModal();
 
@@ -87,6 +87,19 @@ describe('TermsUpdateModal', () => {
     });
 
     expect(screen.queryByText('Terms & Conditions Update')).not.toBeInTheDocument();
+  });
+
+  it('shows the announcement for an authenticated user with a standalone license', () => {
+    act(() => {
+      useAuthStore.setState({ isAuthenticated: true, isPro: false });
+    });
+    renderModal();
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByText('Terms & Conditions Update')).toBeInTheDocument();
   });
 
   it('shows the announcement for Pro users with an existing file', () => {

--- a/packages/tokens-studio-for-figma/src/app/components/TermsUpdateModal.test.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/TermsUpdateModal.test.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import {
-  act, createMockStore, fireEvent, render, screen,
+  act,
+  createMockStore,
+  fireEvent,
+  render,
+  screen,
 } from '../../../tests/config/setupTest';
 import { Tabs } from '@/constants/Tabs';
 import { useIsProUser } from '@/app/hooks/useIsProUser';
@@ -60,8 +64,11 @@ describe('TermsUpdateModal', () => {
     });
 
     expect(screen.getByText('Terms & Conditions Update')).toBeInTheDocument();
-    expect(screen.getByText('We have updated our Terms and Conditions, which will come into effect in 30 days. The changes include adding a new Subprocess (Render.com) and improvements around our license portal.')).toBeInTheDocument();
-    expect(screen.getByText('Notice date: July 15th, 2026')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'We have updated our Terms and Conditions, which will come into effect in 30 days, on August 14th, 2026. The changes include adding a new Subprocess (Render.com) and improvements around our license portal. This notice is dated July 15th, 2026.',
+      ),
+    ).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'View the terms' })).toHaveAttribute('href', 'https://tokens.studio/terms');
   });
 

--- a/packages/tokens-studio-for-figma/src/app/components/TermsUpdateModal.test.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/TermsUpdateModal.test.tsx
@@ -5,6 +5,7 @@ import {
 } from '../../../tests/config/setupTest';
 import { Tabs } from '@/constants/Tabs';
 import { useIsProUser } from '@/app/hooks/useIsProUser';
+import { useAuthStore } from '@/app/store/useAuthStore';
 import TermsUpdateModal from './TermsUpdateModal';
 
 jest.mock('@/app/hooks/useIsProUser', () => ({
@@ -17,11 +18,17 @@ describe('TermsUpdateModal', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     useIsProUserMock.mockReturnValue(true);
+    act(() => {
+      useAuthStore.setState({ isAuthenticated: false });
+    });
   });
 
   afterEach(() => {
     jest.useRealTimers();
     useIsProUserMock.mockReset();
+    act(() => {
+      useAuthStore.setState({ isAuthenticated: false });
+    });
   });
 
   const renderModal = (activeTab = Tabs.START) => {
@@ -60,6 +67,19 @@ describe('TermsUpdateModal', () => {
 
   it('does not show the announcement to non-Pro users', () => {
     useIsProUserMock.mockReturnValue(false);
+    renderModal();
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(screen.queryByText('Terms & Conditions Update')).not.toBeInTheDocument();
+  });
+
+  it('does not show the announcement to Tokens Studio subscription users', () => {
+    act(() => {
+      useAuthStore.setState({ isAuthenticated: true });
+    });
     renderModal();
 
     act(() => {

--- a/packages/tokens-studio-for-figma/src/app/components/TermsUpdateModal.test.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/TermsUpdateModal.test.tsx
@@ -55,6 +55,7 @@ describe('TermsUpdateModal', () => {
     expect(screen.getByText('Terms & Conditions Update')).toBeInTheDocument();
     expect(screen.getByText(/30 days/)).toBeInTheDocument();
     expect(screen.getByText(/Render\.com/)).toBeInTheDocument();
+    expect(screen.getByText('July 15th, 2026')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'View the terms' })).toHaveAttribute('href', 'https://tokens.studio/terms');
   });
 
@@ -69,8 +70,18 @@ describe('TermsUpdateModal', () => {
     expect(screen.queryByText('Terms & Conditions Update')).not.toBeInTheDocument();
   });
 
-  it('does not show the announcement outside the start screen', () => {
+  it('shows the announcement for Pro users with an existing file', () => {
     renderModal(Tabs.TOKENS);
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByText('Terms & Conditions Update')).toBeInTheDocument();
+  });
+
+  it('does not show the announcement while the application is loading', () => {
+    renderModal(Tabs.LOADING);
 
     act(() => {
       jest.advanceTimersByTime(1000);

--- a/packages/tokens-studio-for-figma/src/app/components/TermsUpdateModal.test.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/TermsUpdateModal.test.tsx
@@ -53,8 +53,7 @@ describe('TermsUpdateModal', () => {
     });
 
     expect(screen.getByText('Terms & Conditions Update')).toBeInTheDocument();
-    expect(screen.getByText(/30 days/)).toBeInTheDocument();
-    expect(screen.getByText(/Render\.com/)).toBeInTheDocument();
+    expect(screen.getByText('We have updated our Terms and Conditions, which will come into effect in 30 days. The changes include adding a new Subprocess (Render.com) and improvements around our license portal.')).toBeInTheDocument();
     expect(screen.getByText('July 15th, 2026')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'View the terms' })).toHaveAttribute('href', 'https://tokens.studio/terms');
   });

--- a/packages/tokens-studio-for-figma/src/app/components/TermsUpdateModal.test.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/TermsUpdateModal.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import {
+  act, createMockStore, fireEvent, render, screen,
+} from '../../../tests/config/setupTest';
+import { Tabs } from '@/constants/Tabs';
+import { useIsProUser } from '@/app/hooks/useIsProUser';
+import TermsUpdateModal from './TermsUpdateModal';
+
+jest.mock('@/app/hooks/useIsProUser', () => ({
+  useIsProUser: jest.fn(),
+}));
+
+const useIsProUserMock = useIsProUser as jest.MockedFunction<typeof useIsProUser>;
+
+describe('TermsUpdateModal', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    useIsProUserMock.mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    useIsProUserMock.mockReset();
+  });
+
+  const renderModal = (activeTab = Tabs.START) => {
+    const store = createMockStore({
+      settings: {
+        seenTermsUpdate2026Subprocessors: false,
+      },
+      uiState: {
+        activeTab,
+      },
+    });
+
+    render(
+      <Provider store={store}>
+        <TermsUpdateModal />
+      </Provider>,
+    );
+
+    return store;
+  };
+
+  it('shows the announcement for Pro users on the start screen', () => {
+    renderModal();
+
+    expect(screen.queryByText('Terms & Conditions Update')).not.toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByText('Terms & Conditions Update')).toBeInTheDocument();
+    expect(screen.getByText(/30 days/)).toBeInTheDocument();
+    expect(screen.getByText(/Render\.com/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'View the terms' })).toHaveAttribute('href', 'https://tokens.studio/terms');
+  });
+
+  it('does not show the announcement to non-Pro users', () => {
+    useIsProUserMock.mockReturnValue(false);
+    renderModal();
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(screen.queryByText('Terms & Conditions Update')).not.toBeInTheDocument();
+  });
+
+  it('does not show the announcement outside the start screen', () => {
+    renderModal(Tabs.TOKENS);
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(screen.queryByText('Terms & Conditions Update')).not.toBeInTheDocument();
+  });
+
+  it('persists dismissal', () => {
+    const store = renderModal();
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+    expect(store.getState().settings.seenTermsUpdate2026Subprocessors).toBe(true);
+  });
+});

--- a/packages/tokens-studio-for-figma/src/app/components/TermsUpdateModal.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/TermsUpdateModal.tsx
@@ -6,6 +6,7 @@ import { Modal } from './Modal/Modal';
 import { useIsProUser } from '@/app/hooks/useIsProUser';
 import { activeTabSelector } from '@/selectors/activeTabSelector';
 import { Tabs } from '@/constants/Tabs';
+import { useAuthStore } from '@/app/store/useAuthStore';
 
 const ModalFooterRight = styled('div', {
   display: 'flex',
@@ -19,6 +20,7 @@ const TERMS_URL = 'https://tokens.studio/terms';
 export default function TermsUpdateModal() {
   const dispatch = useDispatch();
   const isProUser = useIsProUser();
+  const { isAuthenticated } = useAuthStore();
   const activeTab = useSelector(activeTabSelector);
   const seenFlag = useSelector((state: any) => state.settings?.[TERMS_UPDATE_MODAL_KEY]);
   const [open, setOpen] = useState(false);
@@ -26,7 +28,7 @@ export default function TermsUpdateModal() {
   useEffect(() => {
     // Skip showing modal in Cypress tests
     const isCypress = typeof window !== 'undefined' && (window as any).Cypress;
-    if (seenFlag !== false || !isProUser || activeTab === Tabs.LOADING || isCypress) {
+    if (seenFlag !== false || !isProUser || isAuthenticated || activeTab === Tabs.LOADING || isCypress) {
       setOpen(false);
       return undefined;
     }
@@ -34,7 +36,7 @@ export default function TermsUpdateModal() {
     // Let the application settle before showing the announcement.
     const timer = setTimeout(() => setOpen(true), 1000);
     return () => clearTimeout(timer);
-  }, [activeTab, isProUser, seenFlag]);
+  }, [activeTab, isAuthenticated, isProUser, seenFlag]);
 
   const handleClose = useCallback(() => {
     dispatch.settings.setSeenTermsUpdate2026Subprocessors(true);

--- a/packages/tokens-studio-for-figma/src/app/components/TermsUpdateModal.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/TermsUpdateModal.tsx
@@ -20,7 +20,7 @@ const TERMS_URL = 'https://tokens.studio/terms';
 export default function TermsUpdateModal() {
   const dispatch = useDispatch();
   const isProUser = useIsProUser();
-  const { isAuthenticated } = useAuthStore();
+  const { isPro: hasTokensStudioSubscription } = useAuthStore();
   const activeTab = useSelector(activeTabSelector);
   const seenFlag = useSelector((state: any) => state.settings?.[TERMS_UPDATE_MODAL_KEY]);
   const [open, setOpen] = useState(false);
@@ -28,7 +28,7 @@ export default function TermsUpdateModal() {
   useEffect(() => {
     // Skip showing modal in Cypress tests
     const isCypress = typeof window !== 'undefined' && (window as any).Cypress;
-    if (seenFlag !== false || !isProUser || isAuthenticated || activeTab === Tabs.LOADING || isCypress) {
+    if (seenFlag !== false || !isProUser || hasTokensStudioSubscription || activeTab === Tabs.LOADING || isCypress) {
       setOpen(false);
       return undefined;
     }
@@ -36,7 +36,7 @@ export default function TermsUpdateModal() {
     // Let the application settle before showing the announcement.
     const timer = setTimeout(() => setOpen(true), 1000);
     return () => clearTimeout(timer);
-  }, [activeTab, isAuthenticated, isProUser, seenFlag]);
+  }, [activeTab, hasTokensStudioSubscription, isProUser, seenFlag]);
 
   const handleClose = useCallback(() => {
     dispatch.settings.setSeenTermsUpdate2026Subprocessors(true);
@@ -68,7 +68,7 @@ export default function TermsUpdateModal() {
           We have updated our Terms and Conditions, which will come into effect in 30 days. The changes include adding a new Subprocess (Render.com) and improvements around our license portal.
         </span>
         <span style={{ display: 'block', marginTop: '16px', fontSize: '12px' }}>
-          July 15th, 2026
+          Notice date: July 15th, 2026
         </span>
       </div>
     </Modal>

--- a/packages/tokens-studio-for-figma/src/app/components/TermsUpdateModal.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/TermsUpdateModal.tsx
@@ -63,7 +63,7 @@ export default function TermsUpdateModal() {
     >
       <div style={{ lineHeight: 1.6 }}>
         <span>
-          We have updated our Terms & Conditions. These changes will come into effect in 30 days. We have also updated our Subprocessors. This includes adding Render.com and improving our license portal.
+          We have updated our Terms and Conditions, which will come into effect in 30 days. The changes include adding a new Subprocess (Render.com) and improvements around our license portal.
         </span>
         <span style={{ display: 'block', marginTop: '16px', fontSize: '12px' }}>
           July 15th, 2026

--- a/packages/tokens-studio-for-figma/src/app/components/TermsUpdateModal.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/TermsUpdateModal.tsx
@@ -26,12 +26,12 @@ export default function TermsUpdateModal() {
   useEffect(() => {
     // Skip showing modal in Cypress tests
     const isCypress = typeof window !== 'undefined' && (window as any).Cypress;
-    if (seenFlag !== false || !isProUser || activeTab !== Tabs.START || isCypress) {
+    if (seenFlag !== false || !isProUser || activeTab === Tabs.LOADING || isCypress) {
       setOpen(false);
       return undefined;
     }
 
-    // Let the start screen settle before showing the announcement.
+    // Let the application settle before showing the announcement.
     const timer = setTimeout(() => setOpen(true), 1000);
     return () => clearTimeout(timer);
   }, [activeTab, isProUser, seenFlag]);
@@ -62,12 +62,12 @@ export default function TermsUpdateModal() {
       )}
     >
       <div style={{ lineHeight: 1.6 }}>
-        <p>
-          We have updated our Terms & Conditions. These changes will come into effect in 30 days.
-        </p>
-        <p>
-          We have also updated our Subprocessors. This includes adding Render.com and improving our license portal.
-        </p>
+        <span>
+          We have updated our Terms & Conditions. These changes will come into effect in 30 days. We have also updated our Subprocessors. This includes adding Render.com and improving our license portal.
+        </span>
+        <span style={{ display: 'block', marginTop: '16px', fontSize: '12px' }}>
+          July 15th, 2026
+        </span>
       </div>
     </Modal>
   );

--- a/packages/tokens-studio-for-figma/src/app/components/TermsUpdateModal.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/TermsUpdateModal.tsx
@@ -65,9 +65,9 @@ export default function TermsUpdateModal() {
     >
       <div style={{ lineHeight: 1.6 }}>
         <p>
-          We have updated our Terms and Conditions, which will come into effect in 30 days, on August 14th, 2026. The
-          changes include adding a new Subprocess (Render.com) and improvements around our license portal. This notice
-          is dated July 15th, 2026.
+          We have updated our Terms and Conditions, which will come into effect on August 14th, 2026. The changes
+          include adding a new Subprocessor (Render.com) and improvements around our license portal. This notice is
+          dated July 15th, 2026.
         </p>
       </div>
     </Modal>

--- a/packages/tokens-studio-for-figma/src/app/components/TermsUpdateModal.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/TermsUpdateModal.tsx
@@ -3,33 +3,41 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Button } from '@tokens-studio/ui';
 import { styled } from '@/stitches.config';
 import { Modal } from './Modal/Modal';
-import Link from './Link';
+import { useIsProUser } from '@/app/hooks/useIsProUser';
+import { activeTabSelector } from '@/selectors/activeTabSelector';
+import { Tabs } from '@/constants/Tabs';
 
 const ModalFooterRight = styled('div', {
   display: 'flex',
   justifyContent: 'flex-end',
+  gap: '$3',
 });
 
-export const TERMS_UPDATE_MODAL_KEY = 'seenTermsUpdate2026';
+export const TERMS_UPDATE_MODAL_KEY = 'seenTermsUpdate2026Subprocessors';
+const TERMS_URL = 'https://tokens.studio/terms';
 
 export default function TermsUpdateModal() {
   const dispatch = useDispatch();
-  const seenFlag = useSelector((state: any) => state.settings?.seenTermsUpdate2026);
+  const isProUser = useIsProUser();
+  const activeTab = useSelector(activeTabSelector);
+  const seenFlag = useSelector((state: any) => state.settings?.[TERMS_UPDATE_MODAL_KEY]);
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
     // Skip showing modal in Cypress tests
     const isCypress = typeof window !== 'undefined' && (window as any).Cypress;
-    // Only show modal if settings have been loaded (seenFlag is not undefined) and it's false
-    if (seenFlag === false && !isCypress) {
-      setOpen(true);
-    } else if (seenFlag === true) {
+    if (seenFlag !== false || !isProUser || activeTab !== Tabs.START || isCypress) {
       setOpen(false);
+      return undefined;
     }
-  }, [seenFlag]);
+
+    // Let the start screen settle before showing the announcement.
+    const timer = setTimeout(() => setOpen(true), 1000);
+    return () => clearTimeout(timer);
+  }, [activeTab, isProUser, seenFlag]);
 
   const handleClose = useCallback(() => {
-    dispatch.settings.setSeenTermsUpdate2026(true);
+    dispatch.settings.setSeenTermsUpdate2026Subprocessors(true);
     setOpen(false);
   }, [dispatch]);
 
@@ -43,25 +51,22 @@ export default function TermsUpdateModal() {
       showClose={false}
       footer={(
         <ModalFooterRight>
-          <Button variant="primary" onClick={handleClose}>Continue</Button>
+          {/* @ts-ignore Exception for Button to accept target */}
+          <Button as="a" href={TERMS_URL} target="_blank" rel="noreferrer" variant="secondary">
+            View the terms
+          </Button>
+          <Button variant="primary" onClick={handleClose}>
+            Continue
+          </Button>
         </ModalFooterRight>
       )}
     >
       <div style={{ lineHeight: 1.6 }}>
         <p>
-          We have made updates to our
-          {' '}
-          <Link href="https://tokens.studio/terms/plugin">Terms & Conditions</Link>
-          {' '}
-          and our
-          {' '}
-          <Link href="https://tokens.studio/privacy/plugin">Privacy Policy</Link>
-          {', Please review these documents which will come into effect on '}
-          <b>15 January 2026</b>
-          .
+          We have updated our Terms & Conditions. These changes will come into effect in 30 days.
         </p>
         <p>
-          These updates add details about our subprocessors and their compliance, and incorporate a Data Processing Addendum (DPA) into our Terms & Conditions.
+          We have also updated our Subprocessors. This includes adding Render.com and improving our license portal.
         </p>
       </div>
     </Modal>

--- a/packages/tokens-studio-for-figma/src/app/components/TermsUpdateModal.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/TermsUpdateModal.tsx
@@ -64,12 +64,11 @@ export default function TermsUpdateModal() {
       )}
     >
       <div style={{ lineHeight: 1.6 }}>
-        <span>
-          We have updated our Terms and Conditions, which will come into effect in 30 days. The changes include adding a new Subprocess (Render.com) and improvements around our license portal.
-        </span>
-        <span style={{ display: 'block', marginTop: '16px', fontSize: '12px' }}>
-          Notice date: July 15th, 2026
-        </span>
+        <p>
+          We have updated our Terms and Conditions, which will come into effect in 30 days, on August 14th, 2026. The
+          changes include adding a new Subprocess (Render.com) and improvements around our license portal. This notice
+          is dated July 15th, 2026.
+        </p>
       </div>
     </Modal>
   );

--- a/packages/tokens-studio-for-figma/src/app/store/models/settings.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/models/settings.tsx
@@ -58,6 +58,7 @@ export interface SettingsState {
   autoApplyThemeOnDrop?: boolean;
   seenGenericVersionedHeaderMigrationDialog?: boolean;
   seenTermsUpdate2026?: boolean;
+  seenTermsUpdate2026Subprocessors?: boolean;
 }
 
 const setUI = (state: SettingsState) => {
@@ -76,6 +77,7 @@ export const settings = createModel<RootModel>()({
     },
     seenGenericVersionedHeaderMigrationDialog: false,
     seenTermsUpdate2026: false,
+    seenTermsUpdate2026Subprocessors: false,
     language: 'en',
     sessionRecording: false,
     updateMode: UpdateMode.SELECTION,
@@ -247,6 +249,12 @@ export const settings = createModel<RootModel>()({
         seenTermsUpdate2026: payload,
       };
     },
+    setSeenTermsUpdate2026Subprocessors(state, payload: boolean) {
+      return {
+        ...state,
+        seenTermsUpdate2026Subprocessors: payload,
+      };
+    },
     setSeenGenericVersionedHeaderMigrationDialog(state, payload: boolean) {
       return {
         ...state,
@@ -319,6 +327,9 @@ export const settings = createModel<RootModel>()({
       setUI(rootState.settings);
     },
     setSeenTermsUpdate2026: (payload: boolean, rootState) => {
+      setUI(rootState.settings);
+    },
+    setSeenTermsUpdate2026Subprocessors: (payload: boolean, rootState) => {
       setUI(rootState.settings);
     },
     ...Object.fromEntries(

--- a/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/setUi.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/asyncMessageHandlers/setUi.ts
@@ -39,6 +39,7 @@ export const setUi: AsyncMessageChannelHandlers[AsyncMessageTypes.SET_UI] = asyn
     autoApplyThemeOnDrop: msg.autoApplyThemeOnDrop,
     seenGenericVersionedHeaderMigrationDialog: msg.seenGenericVersionedHeaderMigrationDialog,
     seenTermsUpdate2026: msg.seenTermsUpdate2026,
+    seenTermsUpdate2026Subprocessors: msg.seenTermsUpdate2026Subprocessors,
   });
   figma.ui.resize(width, height);
   if (store.inspectDeep !== msg.inspectDeep) {

--- a/packages/tokens-studio-for-figma/src/plugin/notifiers.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/notifiers.ts
@@ -94,6 +94,7 @@ export type SavedSettings = {
   autoApplyThemeOnDrop: boolean;
   seenGenericVersionedHeaderMigrationDialog?: boolean;
   seenTermsUpdate2026?: boolean;
+  seenTermsUpdate2026Subprocessors?: boolean;
 };
 
 export function notifyUISettings(
@@ -130,6 +131,7 @@ export function notifyUISettings(
     removeStylesAndVariablesWithoutConnection,
     seenGenericVersionedHeaderMigrationDialog,
     seenTermsUpdate2026,
+    seenTermsUpdate2026Subprocessors,
   }: SavedSettings,
 ) {
   postToUI({
@@ -169,6 +171,7 @@ export function notifyUISettings(
       removeStylesAndVariablesWithoutConnection,
       seenGenericVersionedHeaderMigrationDialog,
       seenTermsUpdate2026,
+      seenTermsUpdate2026Subprocessors,
     },
   });
   postToUI({

--- a/packages/tokens-studio-for-figma/src/types/messages.tsx
+++ b/packages/tokens-studio-for-figma/src/types/messages.tsx
@@ -73,6 +73,7 @@ export type UiSettingsFromPluginMessage = {
     tokenFormat: TokenFormatOptions;
     seenGenericVersionedHeaderMigrationDialog?: boolean;
     seenTermsUpdate2026?: boolean;
+    seenTermsUpdate2026Subprocessors?: boolean;
   };
 };
 

--- a/packages/tokens-studio-for-figma/src/utils/__tests__/uiSettings.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/__tests__/uiSettings.test.ts
@@ -63,6 +63,7 @@ describe('uiSettings', () => {
       aliasBaseFontSize: '16',
       seenGenericVersionedHeaderMigrationDialog: undefined,
       seenTermsUpdate2026: undefined,
+      seenTermsUpdate2026Subprocessors: undefined,
     }));
   });
 
@@ -105,6 +106,7 @@ describe('uiSettings', () => {
       autoApplyThemeOnDrop: false,
       seenGenericVersionedHeaderMigrationDialog: false,
       seenTermsUpdate2026: false,
+      seenTermsUpdate2026Subprocessors: false,
     });
   });
 
@@ -171,6 +173,7 @@ describe('uiSettings', () => {
       autoApplyThemeOnDrop: false,
       seenGenericVersionedHeaderMigrationDialog: false,
       seenTermsUpdate2026: false,
+      seenTermsUpdate2026Subprocessors: false,
     });
   });
 

--- a/packages/tokens-studio-for-figma/src/utils/uiSettings.ts
+++ b/packages/tokens-studio-for-figma/src/utils/uiSettings.ts
@@ -43,6 +43,8 @@ export async function updateUISettings(uiSettings: Partial<SavedSettings>) {
       autoApplyThemeOnDrop: uiSettings.autoApplyThemeOnDrop ?? data?.autoApplyThemeOnDrop,
       seenGenericVersionedHeaderMigrationDialog: uiSettings.seenGenericVersionedHeaderMigrationDialog ?? data?.seenGenericVersionedHeaderMigrationDialog,
       seenTermsUpdate2026: uiSettings.seenTermsUpdate2026 ?? data?.seenTermsUpdate2026,
+      seenTermsUpdate2026Subprocessors:
+        uiSettings.seenTermsUpdate2026Subprocessors ?? data?.seenTermsUpdate2026Subprocessors,
     });
   } catch (err) {
     notifyUI('There was an issue saving your credentials. Please try again.');
@@ -87,6 +89,7 @@ export async function getUISettings(notify = true): Promise<SavedSettings> {
     let autoApplyThemeOnDrop: boolean;
     let seenGenericVersionedHeaderMigrationDialog: boolean;
     let seenTermsUpdate2026: boolean;
+    let seenTermsUpdate2026Subprocessors: boolean;
 
     if (data) {
       width = data.width || 400;
@@ -122,6 +125,7 @@ export async function getUISettings(notify = true): Promise<SavedSettings> {
       autoApplyThemeOnDrop = typeof data.autoApplyThemeOnDrop === 'undefined' ? false : data.autoApplyThemeOnDrop;
       seenGenericVersionedHeaderMigrationDialog = typeof data.seenGenericVersionedHeaderMigrationDialog === 'undefined' ? false : data.seenGenericVersionedHeaderMigrationDialog;
       seenTermsUpdate2026 = typeof data.seenTermsUpdate2026 === 'undefined' ? false : data.seenTermsUpdate2026;
+      seenTermsUpdate2026Subprocessors = typeof data.seenTermsUpdate2026Subprocessors === 'undefined' ? false : data.seenTermsUpdate2026Subprocessors;
       settings = {
         language,
         width: Math.max(300, width),
@@ -156,6 +160,7 @@ export async function getUISettings(notify = true): Promise<SavedSettings> {
         autoApplyThemeOnDrop,
         seenGenericVersionedHeaderMigrationDialog,
         seenTermsUpdate2026,
+        seenTermsUpdate2026Subprocessors,
       };
 
       if (notify) {


### PR DESCRIPTION
### Why does this PR exist?

Pro users need to be notified about the updated Terms and Conditions before the August 14th, 2026 effective date. Related issue: N/A.

### What does this pull request do?

Adds a globally mounted Pro terms-update dialog that appears for legacy Pro license users on both the Start screen and existing-token files. The notice uses the final dated copy, links to `https://tokens.studio/terms`, persists dismissal, and excludes users whose Pro access comes from the Tokens Studio subscription. The persisted UI setting is wired through startup, plugin messages, and Figma client storage, with focused coverage for visibility, gating, existing files, loading, dismissal, and the terms link.

### Testing this change

- `yarn --cwd packages/tokens-studio-for-figma test src/app/components/TermsUpdateModal.test.tsx --runInBand`
- `cd packages/tokens-studio-for-figma && node_modules/.bin/eslint src/app/components/TermsUpdateModal.tsx src/app/components/TermsUpdateModal.test.tsx`
- For manual testing, create `packages/tokens-studio-for-figma/.env` from `.env.example`, run the development server, and use a legacy Pro license account. Subscription users are intentionally excluded.

### Additional Notes (if any)

The terms URL is temporary and can be replaced when the final link is available. No related issue or screenshots apply.