### PR TITLE
fix: loading bar no longer gets stuck after operations complete

### DIFF
--- a/.changeset/lazy-apes-speak.md
+++ b/.changeset/lazy-apes-speak.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fixed the loading bar getting stuck on "Hold on, updating…" after operations finished, especially when exporting variables on files with font-family tokens.

--- a/packages/tokens-studio-for-figma/src/app/components/LoadingBar.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/LoadingBar.tsx
@@ -43,12 +43,12 @@ export default function LoadingBar() {
   const expectedWaitTimeInSeconds = React.useMemo(() => (
     Math.round(expectedWaitTime / 1000)
   ), [expectedWaitTime]);
-  // Compute shouldShow directly from jobs. We previously used useDelayedFlag to
-  // add a 200ms show-delay (to avoid flashing on sub-100ms operations), but that
-  // wrapper had a race where a throttled setTimeout could flip the flag to true
-  // AFTER the queue emptied — leaving the bar visible forever with no jobs, and
-  // therefore no title, showing the "Hold on, updating..." fallback text. The
-  // sub-100ms flash is already avoided by the `expectedWaitTime >= 100` guard.
+  // Compute shouldShow directly from jobs. The previous useDelayedFlag wrapper
+  // added a 200ms show-delay to suppress brief flashes, but its internal timer
+  // could fire after the queue had already cleared (browser timer throttling),
+  // leaving the bar rendering with no jobs — which then showed the empty-title
+  // "Hold on, updating..." fallback text. Tradeoff: short-lived infinite jobs
+  // (<200ms) may now briefly flash the bar; imperceptible in practice.
   const shouldShow = backgroundJobs.length > 0 && (hasInfiniteJobs || expectedWaitTime >= 100);
   const completedTasks = React.useMemo(() => backgroundJobs.reduce((total, job) => (
     total + (job.completedTasks ?? 0)

--- a/packages/tokens-studio-for-figma/src/app/components/LoadingBar.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/LoadingBar.tsx
@@ -4,7 +4,6 @@ import { useSelector } from 'react-redux';
 import {
   Box, Button, Spinner, Stack, Text,
 } from '@tokens-studio/ui';
-import { useDelayedFlag } from '@/hooks';
 import { BackgroundJobs } from '@/constants/BackgroundJobs';
 import { backgroundJobsSelector, windowSizeSelector } from '@/selectors';
 import { AsyncMessageTypes } from '@/types/AsyncMessages';
@@ -44,16 +43,13 @@ export default function LoadingBar() {
   const expectedWaitTimeInSeconds = React.useMemo(() => (
     Math.round(expectedWaitTime / 1000)
   ), [expectedWaitTime]);
-    // Only delay showing the loading bar, hide immediately when jobs are cleared
-  const shouldShow = useDelayedFlag(
-    !(
-      (!backgroundJobs.length || expectedWaitTime < 100)
-        && !hasInfiniteJobs
-    ),
-    200,
-    true,
-    false,
-  );
+  // Compute shouldShow directly from jobs. We previously used useDelayedFlag to
+  // add a 200ms show-delay (to avoid flashing on sub-100ms operations), but that
+  // wrapper had a race where a throttled setTimeout could flip the flag to true
+  // AFTER the queue emptied — leaving the bar visible forever with no jobs, and
+  // therefore no title, showing the "Hold on, updating..." fallback text. The
+  // sub-100ms flash is already avoided by the `expectedWaitTime >= 100` guard.
+  const shouldShow = backgroundJobs.length > 0 && (hasInfiniteJobs || expectedWaitTime >= 100);
   const completedTasks = React.useMemo(() => backgroundJobs.reduce((total, job) => (
     total + (job.completedTasks ?? 0)
   ), 0), [backgroundJobs]);


### PR DESCRIPTION
useDelayedFlag's 200ms show-timer could be throttled by the browser and fire after the queue had already emptied, leaving the bar rendering with no jobs — hence the "Hold on, updating..." fallback text. Compute shouldShow directly from backgroundJobs instead.

<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

Closes #0000 <!-- also likely the same mechanism reported in other "Export to figma variables is stuck" reports -->

Users hit a bug where the loading bar would stay stuck on **"Hold on, updating…"** indefinitely after an operation had actually completed. It reproduced most reliably when exporting variables on a file containing font-family tokens, but the mechanism is generic — it can strand the bar after any background operation whose background job triggers Figma's local font agent enough to throttle the plugin iframe's timers.

Root cause is **not** a stranded background job (queue is verified empty at hang time) — it's a race in [`useDelayedFlag`](packages/tokens-studio-for-figma/src/hooks/useDelayedFlag.ts) that `LoadingBar` was using. The hook adds a 200 ms delay before flipping to visible (to suppress flashes on very short operations). When the plugin iframe is under heavy work — e.g. Figma's font-preview daemon at `127.0.0.1:44950` chews cycles resolving unknown fonts — the browser can throttle that 200 ms `setTimeout` up to several seconds. Sequence:

1. Job appears → `useEffect` schedules `setTimeout(setFlag(true), 200)`.
2. Job completes normally within, say, 2 s.
3. `useEffect` re-runs, cleanup calls `clearTimeout`.
4. But the throttled timer had *already fired* between JS ticks — `setFlag(true)` ran anyway.
5. `flag === true` with `backgroundJobs === []`. LoadingBar renders. No job → no title → the `|| 'Hold on, updating...'` fallback text is what the user sees.

Runtime evidence (temporary console log during diagnosis):
