### PR TITLE
fix: resolve variable modes independently on export for Tokens Studio…

### DIFF
--- a/.changeset/olive-ads-travel.md
+++ b/.changeset/olive-ads-travel.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fix Figma variable export writing the same values to every mode of a multi-mode theme group (Tokens Studio OAuth). Server-resolved token deltas are now fetched per theme so each mode resolves independently. Also fixes the analogous by-sets export where active-theme values could leak into unrelated sets.

--- a/packages/tokens-studio-for-figma/src/app/store/useTokens.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/useTokens.tsx
@@ -12,6 +12,7 @@ import { track } from '@/utils/analytics';
 import { checkIfAlias, getAliasValue } from '@/utils/alias';
 import {
   activeTokenSetSelector,
+  activeThemeSelector,
   storeTokenIdInJsonEditorSelector,
   inspectStateSelector,
   settingsStateSelector,
@@ -21,6 +22,8 @@ import {
   themesListSelector,
   storageTypeSelector,
 } from '@/selectors';
+import { useAuthStore } from '@/app/store/useAuthStore';
+import { fetchServerResolvedTokensPerTheme } from '@/utils/tokensStudio/fetchServerResolvedTokensPerTheme';
 import { StorageProviderType } from '@/constants/StorageProviderType';
 import { TokenSetStatus } from '@/constants/TokenSetStatus';
 import { TokenTypes } from '@/constants/TokenTypes';
@@ -358,6 +361,8 @@ export default function useTokens() {
   );
 
   const serverResolvedTokens = useSelector((state: RootState) => state.tokenState.serverResolvedTokens);
+  const serverResolverContext = useSelector((state: RootState) => state.tokenState.serverResolverContext);
+  const activeTheme = useSelector(activeThemeSelector);
 
   // Asks user which styles to create, then calls Figma with all tokens to create styles
   const createStylesFromSelectedTokenSets = useCallback(
@@ -645,12 +650,14 @@ export default function useTokens() {
         type: AsyncMessageTypes.CREATE_LOCAL_VARIABLES,
         tokens: multiValueFilteredTokens,
         settings,
-        serverResolvedTokens: storageType.provider === StorageProviderType.TOKENS_STUDIO_OAUTH ? serverResolvedTokens : null,
+        // No selectedThemes here → the plugin no-ops, so a per-theme delta is
+        // unnecessary and we skip the server round-trip.
+        serverResolvedTokens: null,
       }),
     );
     dispatch.tokenState.assignVariableIdsToTheme(createVariableResult.variableIds);
     dispatch.uiState.completeJob(BackgroundJobs.UI_CREATEVARIABLES);
-  }, [dispatch.tokenState, dispatch.uiState, tokens, settings, serverResolvedTokens, storageType]);
+  }, [dispatch.tokenState, dispatch.uiState, tokens, settings]);
 
   const createVariablesFromSets = useCallback(
     async (selectedSets: ExportTokenSet[]) => {
@@ -713,6 +720,31 @@ export default function useTokens() {
         name: BackgroundJobs.UI_CREATEVARIABLES,
         isInfinite: true,
       });
+
+      // For Tokens Studio OAuth projects, fetch the server-resolved delta
+      // ONCE PER SELECTED THEME so each mode gets the correct values. The
+      // Redux `serverResolvedTokens` is a single flat map built for the
+      // currently active theme — using it for every mode clobbers each mode
+      // with the active theme's values.
+      let perThemeServerResolvedTokens: Record<string, Record<string, string>> | null = null;
+      if (storageType.provider === StorageProviderType.TOKENS_STUDIO_OAUTH && serverResolverContext) {
+        const { oauthTokens } = useAuthStore.getState();
+        if (oauthTokens?.accessToken) {
+          const selectedThemeObjects = themes.filter((t) => selectedThemes.includes(t.id));
+          perThemeServerResolvedTokens = await fetchServerResolvedTokensPerTheme(
+            selectedThemeObjects,
+            activeTheme,
+            themes,
+            {
+              apiBaseUrl: serverResolverContext.apiBaseUrl,
+              projectId: serverResolverContext.projectId,
+              changeSetId: serverResolverContext.changeSetId,
+              authToken: oauthTokens.accessToken,
+            },
+          );
+        }
+      }
+
       const createVariableResult = await wrapTransaction(
         {
           name: 'createVariables',
@@ -739,14 +771,14 @@ export default function useTokens() {
           tokens,
           settings,
           selectedThemes,
-          serverResolvedTokens: storageType.provider === StorageProviderType.TOKENS_STUDIO_OAUTH ? serverResolvedTokens : null,
+          serverResolvedTokens: perThemeServerResolvedTokens,
         }),
       );
       dispatch.tokenState.assignVariableIdsToTheme(createVariableResult.variableIds);
       dispatch.uiState.completeJob(BackgroundJobs.UI_CREATEVARIABLES);
       Promise.resolve();
     },
-    [dispatch.tokenState, dispatch.uiState, tokens, settings, serverResolvedTokens, storageType],
+    [dispatch.tokenState, dispatch.uiState, tokens, settings, storageType, serverResolverContext, themes, activeTheme],
   );
 
   const renameVariablesFromToken = useCallback(

--- a/packages/tokens-studio-for-figma/src/app/store/useTokens.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/useTokens.tsx
@@ -12,7 +12,6 @@ import { track } from '@/utils/analytics';
 import { checkIfAlias, getAliasValue } from '@/utils/alias';
 import {
   activeTokenSetSelector,
-  activeThemeSelector,
   storeTokenIdInJsonEditorSelector,
   inspectStateSelector,
   settingsStateSelector,
@@ -362,7 +361,6 @@ export default function useTokens() {
 
   const serverResolvedTokens = useSelector((state: RootState) => state.tokenState.serverResolvedTokens);
   const serverResolverContext = useSelector((state: RootState) => state.tokenState.serverResolverContext);
-  const activeTheme = useSelector(activeThemeSelector);
 
   // Asks user which styles to create, then calls Figma with all tokens to create styles
   const createStylesFromSelectedTokenSets = useCallback(
@@ -698,13 +696,18 @@ export default function useTokens() {
           tokens,
           settings,
           selectedSets,
-          serverResolvedTokens: storageType.provider === StorageProviderType.TOKENS_STUDIO_OAUTH ? serverResolvedTokens : null,
+          // No theme dimension here — each set becomes its own single-mode
+          // collection. The Redux server-resolved delta is scoped to the
+          // currently active theme, so applying it here would leak active-
+          // theme values into unrelated sets. Local resolution is the source
+          // of truth for per-set exports.
+          serverResolvedTokens: null,
         }),
       );
       dispatch.uiState.completeJob(BackgroundJobs.UI_CREATEVARIABLES);
       Promise.resolve();
     },
-    [dispatch.uiState, tokens, settings, serverResolvedTokens, storageType],
+    [dispatch.uiState, tokens, settings],
   );
 
   const createVariablesFromThemes = useCallback(
@@ -721,64 +724,75 @@ export default function useTokens() {
         isInfinite: true,
       });
 
-      // For Tokens Studio OAuth projects, fetch the server-resolved delta
-      // ONCE PER SELECTED THEME so each mode gets the correct values. The
-      // Redux `serverResolvedTokens` is a single flat map built for the
-      // currently active theme — using it for every mode clobbers each mode
-      // with the active theme's values.
-      let perThemeServerResolvedTokens: Record<string, Record<string, string>> | null = null;
-      if (storageType.provider === StorageProviderType.TOKENS_STUDIO_OAUTH && serverResolverContext) {
-        const { oauthTokens } = useAuthStore.getState();
-        if (oauthTokens?.accessToken) {
-          const selectedThemeObjects = themes.filter((t) => selectedThemes.includes(t.id));
-          perThemeServerResolvedTokens = await fetchServerResolvedTokensPerTheme(
-            selectedThemeObjects,
-            activeTheme,
-            themes,
-            {
-              apiBaseUrl: serverResolverContext.apiBaseUrl,
-              projectId: serverResolverContext.projectId,
-              changeSetId: serverResolverContext.changeSetId,
-              authToken: oauthTokens.accessToken,
-            },
-          );
-        }
-      }
-
-      const createVariableResult = await wrapTransaction(
-        {
-          name: 'createVariables',
-          statExtractor: async (result, transaction) => {
-            const data = await result;
-            if (data) {
-              track('createVariables', {
-                type: 'themes',
-                totalVariables: data.totalVariables,
-                themeCount: selectedThemes.length,
-                variablesColor: settings.variablesColor,
-                variablesNumber: settings.variablesNumber,
-                variablesString: settings.variablesString,
-                variablesBoolean: settings.variablesBoolean,
-                removeStylesAndVariablesWithoutConnection: settings.removeStylesAndVariablesWithoutConnection,
-                renameExistingStylesAndVariables: settings.renameExistingStylesAndVariables,
-              });
-              transaction.setMeasurement('variables', data.totalVariables, '');
+      try {
+        // For Tokens Studio OAuth projects, fetch the server-resolved delta
+        // ONCE PER SELECTED THEME so each mode gets the correct values. The
+        // Redux `serverResolvedTokens` is a single flat map built for the
+        // currently active theme — using it for every mode clobbers each mode
+        // with the active theme's values.
+        //
+        // Snapshot the resolver context up front so an in-flight project
+        // switch can't cause us to dispatch A's deltas against B's Redux.
+        const snapshotContext = serverResolverContext;
+        let perThemeServerResolvedTokens: Record<string, Record<string, string>> | null = null;
+        if (storageType.provider === StorageProviderType.TOKENS_STUDIO_OAUTH && snapshotContext) {
+          const { oauthTokens } = useAuthStore.getState();
+          if (oauthTokens?.accessToken) {
+            const selectedThemeObjects = themes.filter((t) => selectedThemes.includes(t.id));
+            perThemeServerResolvedTokens = await fetchServerResolvedTokensPerTheme(
+              selectedThemeObjects,
+              {
+                apiBaseUrl: snapshotContext.apiBaseUrl,
+                projectId: snapshotContext.projectId,
+                changeSetId: snapshotContext.changeSetId,
+                authToken: oauthTokens.accessToken,
+              },
+            );
+            // Bail out of the write if the user switched projects mid-fetch —
+            // our snapshot no longer describes current state.
+            if (serverResolverContext?.projectId !== snapshotContext.projectId) {
+              return;
             }
+          }
+        }
+
+        const createVariableResult = await wrapTransaction(
+          {
+            name: 'createVariables',
+            statExtractor: async (result, transaction) => {
+              const data = await result;
+              if (data) {
+                track('createVariables', {
+                  type: 'themes',
+                  totalVariables: data.totalVariables,
+                  themeCount: selectedThemes.length,
+                  variablesColor: settings.variablesColor,
+                  variablesNumber: settings.variablesNumber,
+                  variablesString: settings.variablesString,
+                  variablesBoolean: settings.variablesBoolean,
+                  removeStylesAndVariablesWithoutConnection: settings.removeStylesAndVariablesWithoutConnection,
+                  renameExistingStylesAndVariables: settings.renameExistingStylesAndVariables,
+                });
+                transaction.setMeasurement('variables', data.totalVariables, '');
+              }
+            },
           },
-        },
-        async () => await AsyncMessageChannel.ReactInstance.message({
-          type: AsyncMessageTypes.CREATE_LOCAL_VARIABLES,
-          tokens,
-          settings,
-          selectedThemes,
-          serverResolvedTokens: perThemeServerResolvedTokens,
-        }),
-      );
-      dispatch.tokenState.assignVariableIdsToTheme(createVariableResult.variableIds);
-      dispatch.uiState.completeJob(BackgroundJobs.UI_CREATEVARIABLES);
-      Promise.resolve();
+          async () => await AsyncMessageChannel.ReactInstance.message({
+            type: AsyncMessageTypes.CREATE_LOCAL_VARIABLES,
+            tokens,
+            settings,
+            selectedThemes,
+            serverResolvedTokens: perThemeServerResolvedTokens,
+          }),
+        );
+        dispatch.tokenState.assignVariableIdsToTheme(createVariableResult.variableIds);
+      } finally {
+        // Always tear down the spinner — otherwise a thrown fetch/dispatch
+        // leaves the infinite UI_CREATEVARIABLES job stuck forever.
+        dispatch.uiState.completeJob(BackgroundJobs.UI_CREATEVARIABLES);
+      }
     },
-    [dispatch.tokenState, dispatch.uiState, tokens, settings, storageType, serverResolverContext, themes, activeTheme],
+    [dispatch.tokenState, dispatch.uiState, tokens, settings, storageType, serverResolverContext, themes],
   );
 
   const renameVariablesFromToken = useCallback(

--- a/packages/tokens-studio-for-figma/src/app/store/useTokens.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/useTokens.tsx
@@ -748,9 +748,17 @@ export default function useTokens() {
                 authToken: oauthTokens.accessToken,
               },
             );
-            // Bail out of the write if the user switched projects mid-fetch —
-            // our snapshot no longer describes current state.
-            if (serverResolverContext?.projectId !== snapshotContext.projectId) {
+            // Bail out of the write if the user switched project/change-set
+            // mid-fetch — our snapshot no longer describes current state. Read
+            // the LIVE context from the store (not the closure-captured
+            // `serverResolverContext`, which is frozen to the snapshot value
+            // and can never detect an in-flight switch).
+            const liveContext = store.getState().tokenState.serverResolverContext;
+            if (
+              liveContext?.projectId !== snapshotContext.projectId
+              || liveContext?.changeSetId !== snapshotContext.changeSetId
+              || liveContext?.apiBaseUrl !== snapshotContext.apiBaseUrl
+            ) {
               return;
             }
           }
@@ -792,7 +800,7 @@ export default function useTokens() {
         dispatch.uiState.completeJob(BackgroundJobs.UI_CREATEVARIABLES);
       }
     },
-    [dispatch.tokenState, dispatch.uiState, tokens, settings, storageType, serverResolverContext, themes],
+    [dispatch.tokenState, dispatch.uiState, tokens, settings, storageType, serverResolverContext, themes, store],
   );
 
   const renameVariablesFromToken = useCallback(

--- a/packages/tokens-studio-for-figma/src/plugin/createLocalVariablesInPlugin.perThemeDelta.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/createLocalVariablesInPlugin.perThemeDelta.test.ts
@@ -1,0 +1,134 @@
+// Regression guard for the multi-mode variable export bug: when a per-theme
+// server-resolved delta is passed to createLocalVariablesInPlugin, each call
+// to generateTokensToCreate inside the export loop must receive ITS OWN
+// theme's slice, not a shared map. This test lives at the plugin-loop layer
+// because that is where the slicing (`deltaFor(...)`) is actually performed —
+// the earlier test in generateTokensToCreate.test.ts only proves the leaf
+// helper applies whatever delta the caller supplies, not that the caller
+// slices correctly.
+
+import { mockCreateVariableCollection, mockGetLocalVariableCollections, mockGetLocalVariableCollectionsAsync } from '../../tests/__mocks__/figmaMock';
+import { AsyncMessageTypes, GetThemeInfoMessageResult } from '@/types/AsyncMessages';
+import { TokenSetStatus } from '@/constants/TokenSetStatus';
+import { AsyncMessageChannel } from '@/AsyncMessageChannel';
+import { TokenTypes } from '@/constants/TokenTypes';
+import { SettingsState } from '@/app/store/models/settings';
+import { SingleToken } from '@/types/tokens';
+
+// Mock BEFORE importing the module under test so the mock replaces the real
+// generateTokensToCreate that createLocalVariablesInPlugin closes over.
+jest.mock('./generateTokensToCreate', () => ({
+  generateTokensToCreate: jest.fn(() => ({ tokensToCreate: [], resolvedTokens: [] })),
+}));
+
+// eslint-disable-next-line import/first
+import createLocalVariablesInPlugin from './createLocalVariablesInPlugin';
+// eslint-disable-next-line import/first
+import { generateTokensToCreate } from './generateTokensToCreate';
+
+const mockGenerate = generateTokensToCreate as jest.MockedFunction<typeof generateTokensToCreate>;
+
+describe('createLocalVariablesInPlugin — per-theme serverResolvedTokens slicing', () => {
+  const runAfter: (() => void)[] = [];
+
+  const themes = [
+    {
+      id: 'light',
+      name: 'light',
+      group: 'color',
+      selectedTokenSets: { global: TokenSetStatus.ENABLED },
+      $figmaStyleReferences: {},
+    },
+    {
+      id: 'dark',
+      name: 'dark',
+      group: 'color',
+      selectedTokenSets: { global: TokenSetStatus.ENABLED },
+      $figmaStyleReferences: {},
+    },
+  ];
+
+  const mockGetThemeInfoHandler = async (): Promise<GetThemeInfoMessageResult> => ({
+    type: AsyncMessageTypes.GET_THEME_INFO,
+    activeTheme: { color: 'light' },
+    themes,
+  });
+
+  beforeAll(() => {
+    runAfter.push(AsyncMessageChannel.ReactInstance.connect());
+    AsyncMessageChannel.ReactInstance.handle(AsyncMessageTypes.GET_THEME_INFO, mockGetThemeInfoHandler);
+    runAfter.push(AsyncMessageChannel.PluginInstance.connect());
+  });
+
+  afterAll(() => {
+    runAfter.forEach((fn) => fn());
+  });
+
+  beforeEach(() => {
+    mockGenerate.mockClear();
+    mockGetLocalVariableCollections.mockImplementation(() => []);
+    mockGetLocalVariableCollectionsAsync.mockImplementation(async () => []);
+    // Same collection reference reused across themes — findCollectionAndModeIdForTheme
+    // then finds it by group name for each theme and adds a second mode.
+    const collection = {
+      id: 'VariableCollectionId:1',
+      name: 'color',
+      modes: [{ name: 'light', modeId: 'light-mode' }],
+      addMode: jest.fn(() => {
+        (collection.modes as { name: string; modeId: string }[]).push({ name: 'dark', modeId: 'dark-mode' });
+        return 'dark-mode';
+      }),
+      renameMode: jest.fn(),
+    };
+    mockCreateVariableCollection.mockImplementation(() => collection);
+  });
+
+  const tokens = {
+    global: [{ name: 'color.bg', value: '#local', type: TokenTypes.COLOR } as SingleToken],
+  };
+  const settings = { baseFontSize: '16', variablesColor: true } as SettingsState;
+
+  it('passes ONLY that theme\'s slice of serverResolvedTokens to each per-theme call', async () => {
+    const perThemeDelta = {
+      light: { 'color.bg': '#ffffff' },
+      dark: { 'color.bg': '#000000' },
+    };
+
+    await createLocalVariablesInPlugin(tokens, settings, ['light', 'dark'], perThemeDelta);
+
+    // Collect the (themeId → serverResolvedTokens) pairs the plugin passed to
+    // generateTokensToCreate. Any call that got the WHOLE per-theme map (the
+    // pre-fix bug) or that got the WRONG theme's slice fails this assertion.
+    const passedByTheme = new Map<string, unknown>();
+    for (const call of mockGenerate.mock.calls) {
+      const arg = call[0];
+      passedByTheme.set(arg.theme.id, arg.serverResolvedTokens);
+    }
+
+    expect(passedByTheme.get('light')).toEqual({ 'color.bg': '#ffffff' });
+    expect(passedByTheme.get('dark')).toEqual({ 'color.bg': '#000000' });
+    // Not the whole map (that would be the pre-fix bug shape)
+    expect(passedByTheme.get('light')).not.toEqual(perThemeDelta);
+    expect(passedByTheme.get('dark')).not.toEqual(perThemeDelta);
+  });
+
+  it('passes null to generateTokensToCreate for a theme absent from the delta map', async () => {
+    // Simulate a case where the server resolved only some themes (or the
+    // caller passed a sparse map): the plugin must NOT fall back to another
+    // theme's delta — that's the exact clobber the fix prevents.
+    const partialDelta = { light: { 'color.bg': '#ffffff' } };
+
+    await createLocalVariablesInPlugin(tokens, settings, ['light', 'dark'], partialDelta);
+
+    const darkCall = mockGenerate.mock.calls.find(([arg]) => arg.theme.id === 'dark');
+    expect(darkCall?.[0].serverResolvedTokens).toBeNull();
+  });
+
+  it('passes null to every theme when serverResolvedTokens is null', async () => {
+    await createLocalVariablesInPlugin(tokens, settings, ['light', 'dark'], null);
+
+    for (const [arg] of mockGenerate.mock.calls) {
+      expect(arg.serverResolvedTokens).toBeNull();
+    }
+  });
+});

--- a/packages/tokens-studio-for-figma/src/plugin/createLocalVariablesInPlugin.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/createLocalVariablesInPlugin.ts
@@ -24,6 +24,16 @@ export type LocalVariableInfo = {
   variableIds: Record<string, string>
 };
 
+// Pick the server-resolved delta for a single theme from the per-theme map.
+// Centralised so the theme.id key convention has exactly one owner — a
+// future rename only has to update this helper.
+function deltaFor(
+  serverResolvedTokens: Record<string, Record<string, string>> | null | undefined,
+  themeId: string,
+): Record<string, string> | null {
+  return serverResolvedTokens?.[themeId] ?? null;
+}
+
 /**
 * This function is used to create and update variables based on themes
 * - It first creates the necessary variable collections and modes or returns existing ones
@@ -63,7 +73,7 @@ export default async function createLocalVariablesInPlugin(tokens: Record<string
     // Calculate total number of variables for progress tracking
     const totalVariableTokens = selectedThemeObjects.reduce((total, theme) => {
       const { tokensToCreate } = generateTokensToCreate({
-        theme, tokens, overallConfig, serverResolvedTokens: serverResolvedTokens?.[theme.id] ?? null,
+        theme, tokens, overallConfig, serverResolvedTokens: deltaFor(serverResolvedTokens, theme.id),
       });
       const variableTokenCount = tokensToCreate.filter((token) => checkIfTokenCanCreateVariable(token, settings)).length;
       return total + variableTokenCount;
@@ -112,7 +122,7 @@ export default async function createLocalVariablesInPlugin(tokens: Record<string
      */
     selectedThemeObjects.forEach((theme) => {
       const { tokensToCreate } = generateTokensToCreate({
-        theme, tokens, overallConfig, serverResolvedTokens: serverResolvedTokens?.[theme.id] ?? null,
+        theme, tokens, overallConfig, serverResolvedTokens: deltaFor(serverResolvedTokens, theme.id),
       });
       tokensToCreate.forEach((token) => {
         const figmaExtensions = token.$extensions?.['com.figma'] as FigmaExtensions;
@@ -145,7 +155,7 @@ export default async function createLocalVariablesInPlugin(tokens: Record<string
           progressTracker: globalProgressTracker,
           metadataUpdateTracker,
           providedPlatformsByVariable,
-          serverResolvedTokens: serverResolvedTokens?.[theme.id] ?? null,
+          serverResolvedTokens: deltaFor(serverResolvedTokens, theme.id),
         });
 
         figmaVariablesAfterCreate += allVariableObj.removedVariables.length;

--- a/packages/tokens-studio-for-figma/src/plugin/createLocalVariablesInPlugin.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/createLocalVariablesInPlugin.ts
@@ -31,7 +31,7 @@ export type LocalVariableInfo = {
 * - Then goes on to update variables for each theme
 * - There's another step that we perform where we check if any variables need to be using references to other variables. This is a second step, as we need to have all variables created first before we can reference them.
 * */
-export default async function createLocalVariablesInPlugin(tokens: Record<string, AnyTokenList>, settings: SettingsState, selectedThemes?: string[], serverResolvedTokens?: Record<string, string> | null) {
+export default async function createLocalVariablesInPlugin(tokens: Record<string, AnyTokenList>, settings: SettingsState, selectedThemes?: string[], serverResolvedTokens?: Record<string, Record<string, string>> | null) {
   // Big O (n * m * x): (n: amount of themes, m: amount of variableCollections, x: amount of modes)
   const themeInfo = await AsyncMessageChannel.PluginInstance.message({
     type: AsyncMessageTypes.GET_THEME_INFO,
@@ -63,7 +63,7 @@ export default async function createLocalVariablesInPlugin(tokens: Record<string
     // Calculate total number of variables for progress tracking
     const totalVariableTokens = selectedThemeObjects.reduce((total, theme) => {
       const { tokensToCreate } = generateTokensToCreate({
-        theme, tokens, overallConfig, serverResolvedTokens,
+        theme, tokens, overallConfig, serverResolvedTokens: serverResolvedTokens?.[theme.id] ?? null,
       });
       const variableTokenCount = tokensToCreate.filter((token) => checkIfTokenCanCreateVariable(token, settings)).length;
       return total + variableTokenCount;
@@ -112,7 +112,7 @@ export default async function createLocalVariablesInPlugin(tokens: Record<string
      */
     selectedThemeObjects.forEach((theme) => {
       const { tokensToCreate } = generateTokensToCreate({
-        theme, tokens, overallConfig, serverResolvedTokens,
+        theme, tokens, overallConfig, serverResolvedTokens: serverResolvedTokens?.[theme.id] ?? null,
       });
       tokensToCreate.forEach((token) => {
         const figmaExtensions = token.$extensions?.['com.figma'] as FigmaExtensions;
@@ -145,7 +145,7 @@ export default async function createLocalVariablesInPlugin(tokens: Record<string
           progressTracker: globalProgressTracker,
           metadataUpdateTracker,
           providedPlatformsByVariable,
-          serverResolvedTokens,
+          serverResolvedTokens: serverResolvedTokens?.[theme.id] ?? null,
         });
 
         figmaVariablesAfterCreate += allVariableObj.removedVariables.length;

--- a/packages/tokens-studio-for-figma/src/plugin/generateTokensToCreate.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/generateTokensToCreate.test.ts
@@ -44,40 +44,26 @@ describe('generateTokensToCreate', () => {
     ]);
   });
 
-  it('applies serverResolvedTokens delta on top of local resolution (per-mode invariant)', () => {
-    // Regression guard for the multi-mode variable export bug: each theme in a
-    // multi-mode export must receive its OWN server-resolved delta so modes get
-    // distinct values. A shared delta across themes would clobber every mode
-    // with the same value.
-    const lightTheme: ThemeObject = {
-      id: 'light',
-      name: 'Light',
-      group: 'Mode',
-      selectedTokenSets: { core: TokenSetStatus.ENABLED },
+  it('applies a flat serverResolvedTokens delta on top of local resolution', () => {
+    // Leaf-level check: given a delta, the resolved value wins over local.
+    // The per-theme *slicing* invariant is guarded at the caller layer, in
+    // createLocalVariablesInPlugin.perThemeDelta.test.ts — this test would
+    // still pass if the caller ever regressed to sharing one map across
+    // themes, so it is deliberately scoped narrow.
+    const singleTheme: ThemeObject = {
+      id: 'x', name: 'X', selectedTokenSets: { core: TokenSetStatus.ENABLED },
     };
-    const darkTheme: ThemeObject = {
-      id: 'dark',
-      name: 'Dark',
-      group: 'Mode',
-      selectedTokenSets: { core: TokenSetStatus.ENABLED },
-    };
-    const tokensForMultiMode: Record<string, AnyTokenList> = {
+    const singleToken: Record<string, AnyTokenList> = {
       core: [{ name: 'color.bg', value: '#local', type: TokenTypes.COLOR }],
     };
 
-    const light = generateTokensToCreate({
-      theme: lightTheme,
-      tokens: tokensForMultiMode,
+    const { tokensToCreate } = generateTokensToCreate({
+      theme: singleTheme,
+      tokens: singleToken,
       serverResolvedTokens: { 'color.bg': '#ffffff' },
     });
-    const dark = generateTokensToCreate({
-      theme: darkTheme,
-      tokens: tokensForMultiMode,
-      serverResolvedTokens: { 'color.bg': '#000000' },
-    });
 
-    expect(light.tokensToCreate[0].value).toBe('#ffffff');
-    expect(dark.tokensToCreate[0].value).toBe('#000000');
+    expect(tokensToCreate[0].value).toBe('#ffffff');
   });
 
   it('does not create tokens if their type is not in tokenTypesToCreateVariable', () => {

--- a/packages/tokens-studio-for-figma/src/plugin/generateTokensToCreate.test.ts
+++ b/packages/tokens-studio-for-figma/src/plugin/generateTokensToCreate.test.ts
@@ -44,6 +44,42 @@ describe('generateTokensToCreate', () => {
     ]);
   });
 
+  it('applies serverResolvedTokens delta on top of local resolution (per-mode invariant)', () => {
+    // Regression guard for the multi-mode variable export bug: each theme in a
+    // multi-mode export must receive its OWN server-resolved delta so modes get
+    // distinct values. A shared delta across themes would clobber every mode
+    // with the same value.
+    const lightTheme: ThemeObject = {
+      id: 'light',
+      name: 'Light',
+      group: 'Mode',
+      selectedTokenSets: { core: TokenSetStatus.ENABLED },
+    };
+    const darkTheme: ThemeObject = {
+      id: 'dark',
+      name: 'Dark',
+      group: 'Mode',
+      selectedTokenSets: { core: TokenSetStatus.ENABLED },
+    };
+    const tokensForMultiMode: Record<string, AnyTokenList> = {
+      core: [{ name: 'color.bg', value: '#local', type: TokenTypes.COLOR }],
+    };
+
+    const light = generateTokensToCreate({
+      theme: lightTheme,
+      tokens: tokensForMultiMode,
+      serverResolvedTokens: { 'color.bg': '#ffffff' },
+    });
+    const dark = generateTokensToCreate({
+      theme: darkTheme,
+      tokens: tokensForMultiMode,
+      serverResolvedTokens: { 'color.bg': '#000000' },
+    });
+
+    expect(light.tokensToCreate[0].value).toBe('#ffffff');
+    expect(dark.tokensToCreate[0].value).toBe('#000000');
+  });
+
   it('does not create tokens if their type is not in tokenTypesToCreateVariable', () => {
     const tokensWithInvalidType: Record<string, AnyTokenList> = {
       core: [

--- a/packages/tokens-studio-for-figma/src/types/AsyncMessages.ts
+++ b/packages/tokens-studio-for-figma/src/types/AsyncMessages.ts
@@ -337,7 +337,9 @@ export type CreateLocalVariablesAsyncMessage = AsyncMessage<AsyncMessageTypes.CR
   tokens: Record<string, AnyTokenList>;
   settings: SettingsState,
   selectedThemes?: string[]
-  serverResolvedTokens?: Record<string, string> | null;
+  // Keyed by theme.id — one flat delta per mode, so multi-mode export writes
+  // per-mode values instead of clobbering every mode with the active theme.
+  serverResolvedTokens?: Record<string, Record<string, string>> | null;
 }>;
 export type CreateLocalVariablesAsyncMessageResult = AsyncMessage<AsyncMessageTypes.CREATE_LOCAL_VARIABLES, {
   variableIds: Record<string, LocalVariableInfo>

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchServerResolvedTokensPerTheme.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchServerResolvedTokensPerTheme.test.ts
@@ -23,12 +23,6 @@ const themes: ThemeObject[] = [
     group: 'Mode',
     selectedTokenSets: { core: TokenSetStatus.ENABLED, dark: TokenSetStatus.ENABLED },
   },
-  {
-    id: 'base-id',
-    name: 'Base',
-    group: 'Foundation',
-    selectedTokenSets: { foundation: TokenSetStatus.ENABLED },
-  },
 ];
 
 describe('fetchServerResolvedTokensPerTheme', () => {
@@ -43,7 +37,7 @@ describe('fetchServerResolvedTokensPerTheme', () => {
   });
 
   it('returns null when no themes are selected', async () => {
-    const result = await fetchServerResolvedTokensPerTheme([], { 'Mode': 'light-id' }, themes, CONTEXT);
+    const result = await fetchServerResolvedTokensPerTheme([], CONTEXT);
     expect(result).toBeNull();
     expect(fetchSpy).not.toHaveBeenCalled();
   });
@@ -55,12 +49,7 @@ describe('fetchServerResolvedTokensPerTheme', () => {
         : { 'color.bg': '#000000' }
     ));
 
-    const result = await fetchServerResolvedTokensPerTheme(
-      [themes[0], themes[1]],
-      { Mode: 'light-id' },
-      themes,
-      CONTEXT,
-    );
+    const result = await fetchServerResolvedTokensPerTheme([themes[0], themes[1]], CONTEXT);
 
     expect(fetchSpy).toHaveBeenCalledTimes(2);
     expect(result).toEqual({
@@ -69,75 +58,51 @@ describe('fetchServerResolvedTokensPerTheme', () => {
     });
   });
 
-  it('forces the target theme option for that theme, even when activeTheme picks another option in the same group', async () => {
+  it('sends ONLY the target theme\'s own group in themeSelections — no active-theme baseline', async () => {
     fetchSpy.mockResolvedValue({});
 
-    await fetchServerResolvedTokensPerTheme(
-      [themes[0], themes[1]],
-      { Mode: 'light-id' }, // active theme picks Light for Mode
-      themes,
-      CONTEXT,
-    );
+    await fetchServerResolvedTokensPerTheme([themes[0], themes[1]], CONTEXT);
 
-    const selections = fetchSpy.mock.calls.map((c) => c[0].themeSelections);
-    expect(selections[0]).toEqual({ Mode: 'Light' });
-    expect(selections[1]).toEqual({ Mode: 'Dark' });
+    expect(fetchSpy.mock.calls[0][0].themeSelections).toEqual({ Mode: 'Light' });
+    expect(fetchSpy.mock.calls[1][0].themeSelections).toEqual({ Mode: 'Dark' });
   });
 
-  it('layers active-theme selections for OTHER groups so the server has full context', async () => {
+  it('falls back to theme.name as group key when theme.group is absent (no internal-id leak)', async () => {
     fetchSpy.mockResolvedValue({});
+    const ungrouped: ThemeObject = {
+      id: 'ungrouped-id',
+      name: 'Solo',
+      selectedTokenSets: { core: TokenSetStatus.ENABLED },
+    };
 
-    await fetchServerResolvedTokensPerTheme(
-      [themes[1]], // export only Dark from group "Mode"
-      { Mode: 'light-id', Foundation: 'base-id' },
-      themes,
-      CONTEXT,
-    );
+    await fetchServerResolvedTokensPerTheme([ungrouped], CONTEXT);
 
-    expect(fetchSpy.mock.calls[0][0].themeSelections).toEqual({
-      Mode: 'Dark', // target theme's group overridden
-      Foundation: 'Base', // other group carried over from activeTheme
-    });
+    expect(fetchSpy.mock.calls[0][0].themeSelections).toEqual({ Solo: 'Solo' });
   });
 
   it('passes only ENABLED sets from each theme (excludes DISABLED)', async () => {
     fetchSpy.mockResolvedValue({});
 
-    await fetchServerResolvedTokensPerTheme(
-      [themes[0], themes[1]],
-      {},
-      themes,
-      CONTEXT,
-    );
+    await fetchServerResolvedTokensPerTheme([themes[0], themes[1]], CONTEXT);
 
     expect(fetchSpy.mock.calls[0][0].activeSets).toEqual(['core']);
     expect(fetchSpy.mock.calls[1][0].activeSets).toEqual(['core', 'dark']);
   });
 
-  it('skips null results from failed fetches and keeps the rest', async () => {
+  it('returns null (all-or-nothing) when any theme fetch fails, to avoid mixing server-resolved and local resolution across modes', async () => {
     fetchSpy
       .mockResolvedValueOnce({ 'color.bg': '#ffffff' })
       .mockResolvedValueOnce(null);
 
-    const result = await fetchServerResolvedTokensPerTheme(
-      [themes[0], themes[1]],
-      {},
-      themes,
-      CONTEXT,
-    );
+    const result = await fetchServerResolvedTokensPerTheme([themes[0], themes[1]], CONTEXT);
 
-    expect(result).toEqual({ 'light-id': { 'color.bg': '#ffffff' } });
+    expect(result).toBeNull();
   });
 
   it('returns null when every fetch fails', async () => {
     fetchSpy.mockResolvedValue(null);
 
-    const result = await fetchServerResolvedTokensPerTheme(
-      [themes[0], themes[1]],
-      {},
-      themes,
-      CONTEXT,
-    );
+    const result = await fetchServerResolvedTokensPerTheme([themes[0], themes[1]], CONTEXT);
 
     expect(result).toBeNull();
   });
@@ -145,7 +110,7 @@ describe('fetchServerResolvedTokensPerTheme', () => {
   it('forwards apiBaseUrl / projectId / changeSetId / authToken to the underlying fetch', async () => {
     fetchSpy.mockResolvedValue({});
 
-    await fetchServerResolvedTokensPerTheme([themes[0]], {}, themes, CONTEXT);
+    await fetchServerResolvedTokensPerTheme([themes[0]], CONTEXT);
 
     expect(fetchSpy).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchServerResolvedTokensPerTheme.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchServerResolvedTokensPerTheme.test.ts
@@ -1,0 +1,159 @@
+import { ThemeObject } from '@/types';
+import { TokenSetStatus } from '@/constants/TokenSetStatus';
+import { fetchServerResolvedTokensPerTheme } from './fetchServerResolvedTokensPerTheme';
+import * as fetchModule from './fetchServerResolvedTokens';
+
+const CONTEXT = {
+  apiBaseUrl: 'https://api.tokens.studio',
+  projectId: 'proj-1',
+  changeSetId: 'cs-1',
+  authToken: 'token',
+};
+
+const themes: ThemeObject[] = [
+  {
+    id: 'light-id',
+    name: 'Light',
+    group: 'Mode',
+    selectedTokenSets: { core: TokenSetStatus.ENABLED, dark: TokenSetStatus.DISABLED },
+  },
+  {
+    id: 'dark-id',
+    name: 'Dark',
+    group: 'Mode',
+    selectedTokenSets: { core: TokenSetStatus.ENABLED, dark: TokenSetStatus.ENABLED },
+  },
+  {
+    id: 'base-id',
+    name: 'Base',
+    group: 'Foundation',
+    selectedTokenSets: { foundation: TokenSetStatus.ENABLED },
+  },
+];
+
+describe('fetchServerResolvedTokensPerTheme', () => {
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    fetchSpy = jest.spyOn(fetchModule, 'fetchServerResolvedTokens');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns null when no themes are selected', async () => {
+    const result = await fetchServerResolvedTokensPerTheme([], { 'Mode': 'light-id' }, themes, CONTEXT);
+    expect(result).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('fetches once per selected theme and keys results by theme.id', async () => {
+    fetchSpy.mockImplementation(async ({ themeSelections }) => (
+      themeSelections.Mode === 'Light'
+        ? { 'color.bg': '#ffffff' }
+        : { 'color.bg': '#000000' }
+    ));
+
+    const result = await fetchServerResolvedTokensPerTheme(
+      [themes[0], themes[1]],
+      { Mode: 'light-id' },
+      themes,
+      CONTEXT,
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({
+      'light-id': { 'color.bg': '#ffffff' },
+      'dark-id': { 'color.bg': '#000000' },
+    });
+  });
+
+  it('forces the target theme option for that theme, even when activeTheme picks another option in the same group', async () => {
+    fetchSpy.mockResolvedValue({});
+
+    await fetchServerResolvedTokensPerTheme(
+      [themes[0], themes[1]],
+      { Mode: 'light-id' }, // active theme picks Light for Mode
+      themes,
+      CONTEXT,
+    );
+
+    const selections = fetchSpy.mock.calls.map((c) => c[0].themeSelections);
+    expect(selections[0]).toEqual({ Mode: 'Light' });
+    expect(selections[1]).toEqual({ Mode: 'Dark' });
+  });
+
+  it('layers active-theme selections for OTHER groups so the server has full context', async () => {
+    fetchSpy.mockResolvedValue({});
+
+    await fetchServerResolvedTokensPerTheme(
+      [themes[1]], // export only Dark from group "Mode"
+      { Mode: 'light-id', Foundation: 'base-id' },
+      themes,
+      CONTEXT,
+    );
+
+    expect(fetchSpy.mock.calls[0][0].themeSelections).toEqual({
+      Mode: 'Dark', // target theme's group overridden
+      Foundation: 'Base', // other group carried over from activeTheme
+    });
+  });
+
+  it('passes only ENABLED sets from each theme (excludes DISABLED)', async () => {
+    fetchSpy.mockResolvedValue({});
+
+    await fetchServerResolvedTokensPerTheme(
+      [themes[0], themes[1]],
+      {},
+      themes,
+      CONTEXT,
+    );
+
+    expect(fetchSpy.mock.calls[0][0].activeSets).toEqual(['core']);
+    expect(fetchSpy.mock.calls[1][0].activeSets).toEqual(['core', 'dark']);
+  });
+
+  it('skips null results from failed fetches and keeps the rest', async () => {
+    fetchSpy
+      .mockResolvedValueOnce({ 'color.bg': '#ffffff' })
+      .mockResolvedValueOnce(null);
+
+    const result = await fetchServerResolvedTokensPerTheme(
+      [themes[0], themes[1]],
+      {},
+      themes,
+      CONTEXT,
+    );
+
+    expect(result).toEqual({ 'light-id': { 'color.bg': '#ffffff' } });
+  });
+
+  it('returns null when every fetch fails', async () => {
+    fetchSpy.mockResolvedValue(null);
+
+    const result = await fetchServerResolvedTokensPerTheme(
+      [themes[0], themes[1]],
+      {},
+      themes,
+      CONTEXT,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('forwards apiBaseUrl / projectId / changeSetId / authToken to the underlying fetch', async () => {
+    fetchSpy.mockResolvedValue({});
+
+    await fetchServerResolvedTokensPerTheme([themes[0]], {}, themes, CONTEXT);
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiBaseUrl: 'https://api.tokens.studio',
+        projectId: 'proj-1',
+        changeSetId: 'cs-1',
+        authToken: 'token',
+      }),
+    );
+  });
+});

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchServerResolvedTokensPerTheme.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchServerResolvedTokensPerTheme.ts
@@ -10,45 +10,37 @@ export interface PerThemeServerResolveContext {
 }
 
 /**
- * Build { [themeGroupName]: themeOptionName } for a single target theme, using
- * the current active theme selections as the baseline for OTHER groups and
- * forcing the target theme's own group to its option name. This guarantees the
- * server resolves values for THIS mode, not the currently active mode.
+ * Build { [themeGroupName]: themeOptionName } for a single target theme.
+ *
+ * Only the target theme's own group is included. Other groups are
+ * intentionally omitted so the result of an export depends solely on the
+ * export selection, not on transient UI state (which theme happens to be
+ * active in the plugin at the moment of export). Any cross-group aliases the
+ * server can't resolve without those dimensions fall through to local
+ * resolution, which is deterministic against the theme's own selectedTokenSets.
  */
-function buildSelectionsForTheme(
-  theme: ThemeObject,
-  activeTheme: Record<string, string>,
-  themes: ThemeObject[],
-): Record<string, string> {
-  const selections: Record<string, string> = {};
-  Object.entries(activeTheme).forEach(([groupId, optionId]) => {
-    const match = themes.find((t) => t.id === optionId);
-    if (match) {
-      selections[match.group || groupId] = match.name;
-    }
-  });
-  selections[theme.group || theme.id] = theme.name;
-  return selections;
+function buildSelectionsForTheme(theme: ThemeObject): Record<string, string> {
+  return { [theme.group || theme.name]: theme.name };
 }
 
 /**
  * Fetches server-resolved token deltas independently for each selected theme,
  * so that a multi-mode variable export writes the correct values per mode.
  *
- * Returns a map keyed by theme.id → flat { tokenName: value } delta, or null
- * when nothing resolved (callers then fall back to local resolution).
+ * Returns a map keyed by theme.id → flat { tokenName: value } delta. If ANY
+ * theme's fetch fails, the entire result is null and the caller falls back
+ * to local resolution for every theme — mixing server-resolved and locally-
+ * resolved modes in a single export would be worse than either extreme.
  */
 export async function fetchServerResolvedTokensPerTheme(
   selectedThemes: ThemeObject[],
-  activeTheme: Record<string, string>,
-  themes: ThemeObject[],
   context: PerThemeServerResolveContext,
 ): Promise<Record<string, Record<string, string>> | null> {
   if (!selectedThemes.length) return null;
 
   const entries = await Promise.all(
     selectedThemes.map(async (theme) => {
-      const themeSelections = buildSelectionsForTheme(theme, activeTheme, themes);
+      const themeSelections = buildSelectionsForTheme(theme);
       const activeSets = Object.entries(theme.selectedTokenSets)
         .filter(([, status]) => status === TokenSetStatus.ENABLED)
         .map(([name]) => name);
@@ -61,13 +53,13 @@ export async function fetchServerResolvedTokensPerTheme(
     }),
   );
 
+  // All-or-nothing: a partial map would silently mix server-resolved and
+  // local resolution across modes within one export.
+  if (entries.some(([, resolved]) => resolved === null)) return null;
+
   const result: Record<string, Record<string, string>> = {};
-  let anyResolved = false;
   for (const [id, resolved] of entries) {
-    if (resolved) {
-      result[id] = resolved;
-      anyResolved = true;
-    }
+    result[id] = resolved!;
   }
-  return anyResolved ? result : null;
+  return result;
 }

--- a/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchServerResolvedTokensPerTheme.ts
+++ b/packages/tokens-studio-for-figma/src/utils/tokensStudio/fetchServerResolvedTokensPerTheme.ts
@@ -1,0 +1,73 @@
+import { ThemeObject } from '@/types';
+import { TokenSetStatus } from '@/constants/TokenSetStatus';
+import { fetchServerResolvedTokens } from './fetchServerResolvedTokens';
+
+export interface PerThemeServerResolveContext {
+  apiBaseUrl: string;
+  projectId: string;
+  changeSetId: string;
+  authToken: string;
+}
+
+/**
+ * Build { [themeGroupName]: themeOptionName } for a single target theme, using
+ * the current active theme selections as the baseline for OTHER groups and
+ * forcing the target theme's own group to its option name. This guarantees the
+ * server resolves values for THIS mode, not the currently active mode.
+ */
+function buildSelectionsForTheme(
+  theme: ThemeObject,
+  activeTheme: Record<string, string>,
+  themes: ThemeObject[],
+): Record<string, string> {
+  const selections: Record<string, string> = {};
+  Object.entries(activeTheme).forEach(([groupId, optionId]) => {
+    const match = themes.find((t) => t.id === optionId);
+    if (match) {
+      selections[match.group || groupId] = match.name;
+    }
+  });
+  selections[theme.group || theme.id] = theme.name;
+  return selections;
+}
+
+/**
+ * Fetches server-resolved token deltas independently for each selected theme,
+ * so that a multi-mode variable export writes the correct values per mode.
+ *
+ * Returns a map keyed by theme.id → flat { tokenName: value } delta, or null
+ * when nothing resolved (callers then fall back to local resolution).
+ */
+export async function fetchServerResolvedTokensPerTheme(
+  selectedThemes: ThemeObject[],
+  activeTheme: Record<string, string>,
+  themes: ThemeObject[],
+  context: PerThemeServerResolveContext,
+): Promise<Record<string, Record<string, string>> | null> {
+  if (!selectedThemes.length) return null;
+
+  const entries = await Promise.all(
+    selectedThemes.map(async (theme) => {
+      const themeSelections = buildSelectionsForTheme(theme, activeTheme, themes);
+      const activeSets = Object.entries(theme.selectedTokenSets)
+        .filter(([, status]) => status === TokenSetStatus.ENABLED)
+        .map(([name]) => name);
+      const resolved = await fetchServerResolvedTokens({
+        ...context,
+        themeSelections,
+        activeSets,
+      });
+      return [theme.id, resolved] as const;
+    }),
+  );
+
+  const result: Record<string, Record<string, string>> = {};
+  let anyResolved = false;
+  for (const [id, resolved] of entries) {
+    if (resolved) {
+      result[id] = resolved;
+      anyResolved = true;
+    }
+  }
+  return anyResolved ? result : null;
+}


### PR DESCRIPTION
… OAuth

### Why does this PR exist?

Closes #0000 <!-- link the related issue -->

When exporting tokens to Figma Variables from a theme group that has multiple options (modes), every mode ended up with the same values instead of resolving distinctly per mode. Only Tokens Studio OAuth projects were affected — the server-resolved delta used to override local resolution was fetched once for the currently active theme and then applied to every mode in the export loop, clobbering per-mode values.

### What does this pull request do?

**Core fix — per-theme resolution in the variable export path**

- `serverResolvedTokens` on `CREATE_LOCAL_VARIABLES` is now a per-theme map (`Record<themeId, Record<tokenName, value>>`) instead of a single flat delta.
- New `fetchServerResolvedTokensPerTheme` utility issues one server request per selected theme in parallel and returns the map keyed by `theme.id`.
- `createVariablesFromThemes` in `useTokens` builds the per-theme map before dispatch (OAuth projects only). Non-OAuth providers still pass `null` and are unaffected.
- The plugin loop (`createLocalVariablesInPlugin`) slices `serverResolvedTokens?.[theme.id]` at each iteration via a `deltaFor()` helper — every mode gets its own delta or falls back to local resolution.

**Same-class bug in the WITHOUT_MODES path**

- `createVariablesFromSets` also used the flat active-theme delta for every exported set. That would leak active-theme values into unrelated sets under OAuth. Fixed by passing `null` for the WITHOUT_MODES path — per-set exports have no theme dimension, so local resolution is authoritative there.

**Determinism and robustness (review round 2)**

- Per-theme selections only include the target theme's own group. Exports no longer depend on transient UI state (`activeTheme` is not layered in).
- Fetch is all-or-nothing: if any theme's fetch fails, the whole map is `null` and every mode falls back to local resolution. Prevents silent mixing of server-resolved and local values across modes.
- `try/finally` around fetch + dispatch so a throw can't strand the infinite `UI_CREATEVARIABLES` spinner.
- Snapshot the resolver context up front and bail on `projectId` mismatch after the fetch resolves — an in-flight project switch can no longer write A's deltas against B's Redux state.

**Tests**

- New `fetchServerResolvedTokensPerTheme.test.ts`: target-group selections, ungrouped-theme fallback, ENABLED-set filter, all-or-nothing failure semantics.
- New `createLocalVariablesInPlugin.perThemeDelta.test.ts`: real regression at the plugin-loop layer — asserts each per-theme call receives its own slice, `null` for absent themes, and `null` for a `null` map.
- Existing `generateTokensToCreate` test kept but re-scoped honestly (leaf-level pass-through).

### Testing this change

Requires a Tokens Studio OAuth project with a theme group containing 2+ modes.

1. Connect to a Tokens Studio OAuth project.
2. Open **Manage Styles & Variables → Export by themes**.
3. Select all themes in a multi-mode group and create variables.
4. In Figma, open the generated variable collection and confirm each mode has the correct per-mode value (before this fix, every mode shared the currently active theme's values).
5. Repeat for the **Export by sets** path — sets not included in the currently active theme should now produce their own values, not active-theme values.
6. Non-OAuth providers (GitHub, GitLab, local): behavior unchanged.

Automated coverage:
