### PR TITLE
fix: prevent stuck blue dot and empty commits on git sync

### DIFF
--- a/.changeset/beige-falcons-roll.md
+++ b/.changeset/beige-falcons-roll.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fixed GitHub/GitLab/ADO/Bitbucket sync so successful pushes clear the "unsynced changes" indicator and no longer produce empty commits.

--- a/.changeset/beige-falcons-roll.md
+++ b/.changeset/beige-falcons-roll.md
@@ -1,5 +1,0 @@
----
-"@tokens-studio/figma-plugin": patch
----
-
-Fixed GitHub/GitLab/ADO/Bitbucket sync so successful pushes clear the "unsynced changes" indicator and no longer produce empty commits.

--- a/.changeset/git-sync-empty-token-sets.md
+++ b/.changeset/git-sync-empty-token-sets.md
@@ -3,3 +3,5 @@
 ---
 
 Fixed GitHub multi-file sync losing newly created empty token sets: pushing now writes the set's file to the repository (and deletes it when an empty set is removed), so the set no longer silently disappears after reopening the plugin.
+
+Fixed GitHub/GitLab/ADO/Bitbucket sync so successful pushes clear the "unsynced changes" indicator and no longer produce empty commits.

--- a/.changeset/git-sync-empty-token-sets.md
+++ b/.changeset/git-sync-empty-token-sets.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fixed GitHub multi-file sync losing newly created empty token sets: pushing now writes the set's file to the repository (and deletes it when an empty set is removed), so the set no longer silently disappears after reopening the plugin.

--- a/packages/tokens-studio-for-figma/src/app/store/providers/ado/ado.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/ado/ado.tsx
@@ -21,6 +21,7 @@ import { PushOverrides } from '../../remoteTokens';
 import { useIsProUser } from '@/app/hooks/useIsProUser';
 import { TokenFormat } from '@/plugin/TokenFormatStoreClass';
 import { categorizeError } from '@/utils/error/categorizeError';
+import removeIdPropertyFromTokens from '@/utils/removeIdPropertyFromTokens';
 
 type AdoCredentials = Extract<StorageTypeCredentials, { provider: StorageProviderType.ADO; }>;
 type AdoFormValues = Extract<StorageTypeFormValues<false>, { provider: StorageProviderType.ADO; }>;
@@ -93,7 +94,7 @@ export const useADO = () => {
         });
         const branches = await storage.fetchBranches();
         dispatch.branchState.setBranches(branches);
-        const stringifiedRemoteTokens = JSON.stringify(compact([tokens, themes, TokenFormat.format]), null, 2);
+        const stringifiedRemoteTokens = JSON.stringify(compact([removeIdPropertyFromTokens(tokens), themes, TokenFormat.format]), null, 2);
         dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
         pushDialog({ state: 'success' });
 

--- a/packages/tokens-studio-for-figma/src/app/store/providers/bitbucket/bitbucket.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/bitbucket/bitbucket.tsx
@@ -21,6 +21,7 @@ import { PushOverrides } from '../../remoteTokens';
 import { useIsProUser } from '@/app/hooks/useIsProUser';
 import { TokenFormat } from '@/plugin/TokenFormatStoreClass';
 import { categorizeError } from '@/utils/error/categorizeError';
+import removeIdPropertyFromTokens from '@/utils/removeIdPropertyFromTokens';
 
 type BitbucketCredentials = Extract<StorageTypeCredentials, { provider: StorageProviderType.BITBUCKET }>;
 type BitbucketFormValues = Extract<StorageTypeFormValues<false>, { provider: StorageProviderType.BITBUCKET }>;
@@ -99,7 +100,7 @@ export function useBitbucket() {
           themes,
           metadata,
         });
-        const stringifiedRemoteTokens = JSON.stringify(compact([tokens, themes, TokenFormat.format]), null, 2);
+        const stringifiedRemoteTokens = JSON.stringify(compact([removeIdPropertyFromTokens(tokens), themes, TokenFormat.format]), null, 2);
         dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
         pushDialog({ state: 'success' });
         return {

--- a/packages/tokens-studio-for-figma/src/app/store/providers/github/github.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/github/github.tsx
@@ -24,6 +24,7 @@ import { PushOverrides } from '../../remoteTokens';
 import { useIsProUser } from '@/app/hooks/useIsProUser';
 import { categorizeError } from '@/utils/error/categorizeError';
 import { TokenFormat } from '@/plugin/TokenFormatStoreClass';
+import removeIdPropertyFromTokens from '@/utils/removeIdPropertyFromTokens';
 
 type GithubCredentials = Extract<StorageTypeCredentials, { provider: StorageProviderType.GITHUB; }>;
 type GithubFormValues = Extract<StorageTypeFormValues<false>, { provider: StorageProviderType.GITHUB }>;
@@ -115,7 +116,7 @@ export function useGitHub() {
           themes,
           metadata,
         });
-        const stringifiedRemoteTokens = JSON.stringify(compact([tokens, themes, TokenFormat.format]), null, 2);
+        const stringifiedRemoteTokens = JSON.stringify(compact([removeIdPropertyFromTokens(tokens), themes, TokenFormat.format]), null, 2);
         dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
         pushDialog({ state: 'success' });
         return {

--- a/packages/tokens-studio-for-figma/src/app/store/providers/github/github.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/github/github.tsx
@@ -75,7 +75,10 @@ export function useGitHub() {
 
         // Check if we should use optimized multi-file sync
         const isMultiFileMode = isProUser && context.filePath && !context.filePath.endsWith('.json');
-        const hasChanges = Object.keys(changedPushState.tokens).length > 0 || changedPushState.themes.length > 0 || changedPushState.metadata;
+        const hasChanges = Object.keys(changedPushState.tokens).length > 0
+          || changedPushState.themes.length > 0
+          || !!changedPushState.metadata
+          || !!changedPushState.tokenSetChanges;
 
         if (isMultiFileMode && hasChanges) {
           // Use the optimized save method for multi-file mode
@@ -90,6 +93,7 @@ export function useGitHub() {
             tokens: changedPushState.tokens,
             themes: changedPushState.themes,
             metadata: changedPushState.metadata || null,
+            tokenSetChanges: changedPushState.tokenSetChanges,
           });
         } else {
           await storage.save({

--- a/packages/tokens-studio-for-figma/src/app/store/providers/gitlab/gitlab.tsx
+++ b/packages/tokens-studio-for-figma/src/app/store/providers/gitlab/gitlab.tsx
@@ -24,6 +24,7 @@ import { PushOverrides } from '../../remoteTokens';
 import { useIsProUser } from '@/app/hooks/useIsProUser';
 import { categorizeError } from '@/utils/error/categorizeError';
 import { TokenFormat } from '@/plugin/TokenFormatStoreClass';
+import removeIdPropertyFromTokens from '@/utils/removeIdPropertyFromTokens';
 
 export type GitlabCredentials = Extract<StorageTypeCredentials, { provider: StorageProviderType.GITLAB; }>;
 type GitlabFormValues = Extract<StorageTypeFormValues<false>, { provider: StorageProviderType.GITLAB }>;
@@ -102,7 +103,7 @@ export function useGitLab() {
         });
         const branches = await storage.fetchBranches();
         dispatch.branchState.setBranches(branches);
-        const stringifiedRemoteTokens = JSON.stringify(compact([tokens, themes, TokenFormat.format]), null, 2);
+        const stringifiedRemoteTokens = JSON.stringify(compact([removeIdPropertyFromTokens(tokens), themes, TokenFormat.format]), null, 2);
         dispatch.tokenState.setLastSyncedState(stringifiedRemoteTokens);
         pushDialog({ state: 'success' });
         return {

--- a/packages/tokens-studio-for-figma/src/hooks/__tests__/useChangedState.test.ts
+++ b/packages/tokens-studio-for-figma/src/hooks/__tests__/useChangedState.test.ts
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react';
 import { StorageProviderType } from '@/constants/StorageProviderType';
+import { findDifferentState } from '@/utils/findDifferentState';
 
 import { useChangedState } from '../useChangedState';
 
@@ -10,11 +11,12 @@ const mockDispatch = {
   },
 };
 
-const mockTokens = {};
+let mockTokens: Record<string, unknown[]> = {};
 const mockThemes = [];
 let mockStorageType = { provider: StorageProviderType.LOCAL };
 const mockLastSyncedState = null;
 const mockTokenFormat = 'dtcg';
+let mockTokenSetMetadata: Record<string, unknown> = {};
 
 jest.mock('react-redux', () => ({
   useDispatch: () => mockDispatch,
@@ -24,7 +26,7 @@ jest.mock('react-redux', () => ({
       themes: mockThemes,
       lastSyncedState: mockLastSyncedState,
       tokenFormat: mockTokenFormat,
-      tokenSetMetadata: {},
+      tokenSetMetadata: mockTokenSetMetadata,
     },
     uiState: {
       storageType: mockStorageType,
@@ -57,9 +59,14 @@ jest.mock('@/utils/findDifferentState', () => ({
 }));
 
 describe('useChangedState', () => {
+  const findDifferentStateMock = findDifferentState as jest.Mock;
+
   beforeEach(() => {
     mockUpdateCheckForChanges.mockClear();
+    findDifferentStateMock.mockClear();
     mockStorageType = { provider: StorageProviderType.LOCAL };
+    mockTokens = {};
+    mockTokenSetMetadata = {};
   });
 
   it('dispatches hasChanges=true for LOCAL provider when state differs from lastSyncedState', () => {
@@ -75,4 +82,63 @@ describe('useChangedState', () => {
     expect(mockUpdateCheckForChanges).not.toHaveBeenCalledWith(true);
   });
 
+  describe('buildMetadata shape passed to findDifferentState', () => {
+    // The push-path metadata must match what the provider actually writes to disk.
+    // Git providers persist only { tokenSetOrder }; including tokenSetsData produced a
+    // permanent metadata diff that caused empty commits (see #<PR>).
+    const gitProviders = [
+      StorageProviderType.GITHUB,
+      StorageProviderType.GITLAB,
+      StorageProviderType.ADO,
+      StorageProviderType.BITBUCKET,
+    ];
+
+    beforeEach(() => {
+      mockTokens = { core: [], semantic: [] };
+      mockTokenSetMetadata = { core: { isDynamic: false }, semantic: { isDynamic: true } };
+    });
+
+    gitProviders.forEach((provider) => {
+      it(`passes { tokenSetOrder } only for ${provider} (no tokenSetsData)`, () => {
+        mockStorageType = { provider };
+        renderHook(() => useChangedState());
+
+        // Both push (compareState arg) and pull (baseState arg) calls should have the trimmed shape.
+        expect(findDifferentStateMock).toHaveBeenCalled();
+        const pushCall = findDifferentStateMock.mock.calls[0];
+        const pullCall = findDifferentStateMock.mock.calls[1];
+
+        expect(pushCall[1].metadata).toEqual({ tokenSetOrder: ['core', 'semantic'] });
+        expect(pushCall[1].metadata).not.toHaveProperty('tokenSetsData');
+
+        expect(pullCall[0].metadata).toEqual({ tokenSetOrder: ['core', 'semantic'] });
+        expect(pullCall[0].metadata).not.toHaveProperty('tokenSetsData');
+      });
+    });
+
+    it('passes { tokenSetOrder, tokenSetsData } for TOKENS_STUDIO_OAUTH', () => {
+      mockStorageType = { provider: StorageProviderType.TOKENS_STUDIO_OAUTH };
+      renderHook(() => useChangedState());
+
+      const pushCall = findDifferentStateMock.mock.calls[0];
+      const pullCall = findDifferentStateMock.mock.calls[1];
+
+      expect(pushCall[1].metadata).toEqual({
+        tokenSetOrder: ['core', 'semantic'],
+        tokenSetsData: mockTokenSetMetadata,
+      });
+      expect(pullCall[0].metadata).toEqual({
+        tokenSetOrder: ['core', 'semantic'],
+        tokenSetsData: mockTokenSetMetadata,
+      });
+    });
+
+    it('passes empty metadata for LOCAL provider', () => {
+      mockStorageType = { provider: StorageProviderType.LOCAL };
+      renderHook(() => useChangedState());
+
+      const pushCall = findDifferentStateMock.mock.calls[0];
+      expect(pushCall[1].metadata).toEqual({});
+    });
+  });
 });

--- a/packages/tokens-studio-for-figma/src/hooks/useChangedState.ts
+++ b/packages/tokens-studio-for-figma/src/hooks/useChangedState.ts
@@ -1,4 +1,4 @@
-import { useMemo, useEffect } from 'react';
+import { useCallback, useMemo, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   lastSyncedStateSelector,
@@ -23,14 +23,25 @@ export function useChangedState() {
   const tokenSetMetadata = useSelector(tokenSetMetadataSelector);
   const dispatch = useDispatch();
 
+  // Only Tokens Studio OAuth persists tokenSetsData in its metadata payload; git-based
+  // providers write only { tokenSetOrder }, so including tokenSetsData here would produce
+  // a permanent metadata diff (baseState from remote lacks it), triggering empty pushes.
+  const buildMetadata = useCallback((tokenSetOrder: string[]) => {
+    if (storageType.provider === StorageProviderType.LOCAL) return {};
+    if (storageType.provider === StorageProviderType.TOKENS_STUDIO_OAUTH) {
+      return { tokenSetOrder, tokenSetsData: tokenSetMetadata };
+    }
+    return { tokenSetOrder };
+  }, [storageType.provider, tokenSetMetadata]);
+
   const changedPushState = useMemo(() => {
     const tokenSetOrder = Object.keys(tokens);
     return findDifferentState(remoteData, {
       tokens,
       themes,
-      metadata: storageType.provider !== StorageProviderType.LOCAL ? { tokenSetOrder, tokenSetsData: tokenSetMetadata } : {},
+      metadata: buildMetadata(tokenSetOrder),
     });
-  }, [remoteData, tokens, themes, storageType, tokenSetMetadata]);
+  }, [remoteData, tokens, themes, buildMetadata]);
 
   const changedPullState = useMemo(() => {
     const tokenSetOrder = Object.keys(tokens);
@@ -38,11 +49,11 @@ export function useChangedState() {
       {
         tokens,
         themes,
-        metadata: storageType.provider !== StorageProviderType.LOCAL ? { tokenSetOrder, tokenSetsData: tokenSetMetadata } : {},
+        metadata: buildMetadata(tokenSetOrder),
       },
       remoteData,
     );
-  }, [remoteData, tokens, themes, storageType, tokenSetMetadata]);
+  }, [remoteData, tokens, themes, buildMetadata]);
 
   const hasChanges = useMemo(() => {
     const hasChanged = !compareLastSyncedState(tokens, themes, lastSyncedState, tokenFormat);

--- a/packages/tokens-studio-for-figma/src/storage/GitSyncOptimizer.ts
+++ b/packages/tokens-studio-for-figma/src/storage/GitSyncOptimizer.ts
@@ -13,6 +13,9 @@ export type ChangedState = {
   tokens: Record<string, any[]>;
   themes: any[];
   metadata: any;
+  // Set-level additions/removals (see findDifferentState). Empty sets produce
+  // no token-level changes, so without this they would never be written or deleted.
+  tokenSetChanges?: Record<string, 'NEW' | 'REMOVE'>;
 };
 
 /**
@@ -40,7 +43,8 @@ export class GitSyncOptimizer {
     const tokenSetObjects = convertTokensToObject({ ...data.tokens }, saveOptions.storeTokenIdInJsonEditor);
     Object.entries(tokenSetObjects).forEach(([name, tokenSet]) => {
       const hasChanges = changedState.tokens[name];
-      if (hasChanges && hasChanges.length > 0) {
+      const isNewTokenSet = changedState.tokenSetChanges?.[name] === 'NEW';
+      if ((hasChanges && hasChanges.length > 0) || isNewTokenSet) {
         filteredFiles.push({
           type: 'tokenSet',
           name,
@@ -75,6 +79,16 @@ export class GitSyncOptimizer {
         const existsInCurrentData = tokenSetName in data.tokens;
         if (!existsInCurrentData) {
           const filePath = `${tokenSetName}.json`;
+          filesToDelete.push(filePath);
+        }
+      }
+    });
+
+    // Removed empty sets have no REMOVE token entries, so they only appear in tokenSetChanges
+    Object.entries(changedState.tokenSetChanges ?? {}).forEach(([tokenSetName, changeType]) => {
+      if (changeType === 'REMOVE' && !(tokenSetName in data.tokens)) {
+        const filePath = `${tokenSetName}.json`;
+        if (!filesToDelete.includes(filePath)) {
           filesToDelete.push(filePath);
         }
       }

--- a/packages/tokens-studio-for-figma/src/storage/GithubTokenStorage.ts
+++ b/packages/tokens-studio-for-figma/src/storage/GithubTokenStorage.ts
@@ -274,10 +274,6 @@ export class GithubTokenStorage extends GitTokenStorage {
               }
 
               const tokenSet = parsed as AnyTokenSet<false>;
-              if (Object.keys(tokenSet).length === 0) {
-                return null;
-              }
-
               return {
                 path: filePath,
                 name,

--- a/packages/tokens-studio-for-figma/src/storage/__tests__/GitSyncOptimizer.test.ts
+++ b/packages/tokens-studio-for-figma/src/storage/__tests__/GitSyncOptimizer.test.ts
@@ -1,0 +1,189 @@
+import { GitSyncOptimizer, ChangedState } from '../GitSyncOptimizer';
+import { RemoteTokenStorageData } from '../RemoteTokenStorage';
+import { GitStorageSaveOptions, GitStorageSaveOption } from '../GitTokenStorage';
+import { findDifferentState, CompareStateType } from '@/utils/findDifferentState';
+import { TokenTypes } from '@/constants/TokenTypes';
+import { SingleToken } from '@/types/tokens';
+
+const saveOptions: GitStorageSaveOption = {
+  commitMessage: 'test commit',
+  storeTokenIdInJsonEditor: false,
+};
+
+const existingToken: SingleToken = {
+  name: 'foo', value: '8', description: '', type: TokenTypes.SPACING,
+};
+
+describe('GitSyncOptimizer', () => {
+  it('writes only sets with token-level changes plus themes/metadata when changed', () => {
+    const data: RemoteTokenStorageData<GitStorageSaveOptions> = {
+      tokens: { global: [existingToken], other: [existingToken] },
+      themes: [],
+      metadata: { tokenSetOrder: ['global', 'other'] },
+    };
+    const changedState: ChangedState = {
+      tokens: { global: [{ ...existingToken, importType: 'NEW' }] },
+      themes: [],
+      metadata: { tokenSetOrder: ['global', 'other'] },
+    };
+
+    const result = GitSyncOptimizer.optimizeSync(data, saveOptions, changedState);
+
+    expect(result.filteredFiles.map((f) => f.path)).toEqual(['global.json', '$metadata.json']);
+    expect(result.filesToDelete).toEqual([]);
+    expect(result.hasChanges).toBe(true);
+  });
+
+  it('writes the file for a newly added empty token set', () => {
+    const data: RemoteTokenStorageData<GitStorageSaveOptions> = {
+      tokens: { global: [existingToken], emptySet: [] },
+      themes: [],
+      metadata: { tokenSetOrder: ['global', 'emptySet'] },
+    };
+    const changedState: ChangedState = {
+      tokens: {},
+      themes: [],
+      metadata: { tokenSetOrder: ['global', 'emptySet'] },
+      tokenSetChanges: { emptySet: 'NEW' },
+    };
+
+    const result = GitSyncOptimizer.optimizeSync(data, saveOptions, changedState);
+
+    expect(result.filteredFiles.map((f) => f.path)).toEqual(['emptySet.json', '$metadata.json']);
+    const emptySetFile = result.filteredFiles.find((f) => f.path === 'emptySet.json');
+    expect(emptySetFile?.data).toEqual({});
+    expect(result.hasChanges).toBe(true);
+  });
+
+  it('deletes the file for a removed empty token set', () => {
+    const data: RemoteTokenStorageData<GitStorageSaveOptions> = {
+      tokens: { global: [existingToken] },
+      themes: [],
+      metadata: { tokenSetOrder: ['global'] },
+    };
+    const changedState: ChangedState = {
+      tokens: {},
+      themes: [],
+      metadata: { tokenSetOrder: ['global'] },
+      tokenSetChanges: { emptySet: 'REMOVE' },
+    };
+
+    const result = GitSyncOptimizer.optimizeSync(data, saveOptions, changedState);
+
+    expect(result.filesToDelete).toEqual(['emptySet.json']);
+    expect(result.hasChanges).toBe(true);
+  });
+
+  it('does not duplicate deletions already detected through REMOVE token entries', () => {
+    const data: RemoteTokenStorageData<GitStorageSaveOptions> = {
+      tokens: { global: [existingToken] },
+      themes: [],
+      metadata: { tokenSetOrder: ['global'] },
+    };
+    const changedState: ChangedState = {
+      tokens: { removedSet: [{ ...existingToken, importType: 'REMOVE' }] },
+      themes: [],
+      metadata: { tokenSetOrder: ['global'] },
+      tokenSetChanges: { removedSet: 'REMOVE' },
+    };
+
+    const result = GitSyncOptimizer.optimizeSync(data, saveOptions, changedState);
+
+    expect(result.filesToDelete).toEqual(['removedSet.json']);
+  });
+
+  it('does not delete a set that still exists locally even if marked REMOVE', () => {
+    const data: RemoteTokenStorageData<GitStorageSaveOptions> = {
+      tokens: { global: [existingToken], keptSet: [] },
+      themes: [],
+      metadata: { tokenSetOrder: ['global', 'keptSet'] },
+    };
+    const changedState: ChangedState = {
+      tokens: {},
+      themes: [],
+      metadata: null,
+      tokenSetChanges: { keptSet: 'REMOVE' },
+    };
+
+    const result = GitSyncOptimizer.optimizeSync(data, saveOptions, changedState);
+
+    expect(result.filesToDelete).toEqual([]);
+  });
+
+  it('reports no changes when nothing changed', () => {
+    const data: RemoteTokenStorageData<GitStorageSaveOptions> = {
+      tokens: { global: [existingToken] },
+      themes: [],
+      metadata: { tokenSetOrder: ['global'] },
+    };
+    const changedState: ChangedState = {
+      tokens: {},
+      themes: [],
+      metadata: null,
+    };
+
+    const result = GitSyncOptimizer.optimizeSync(data, saveOptions, changedState);
+
+    expect(result.hasChanges).toBe(false);
+    expect(result.filteredFiles).toEqual([]);
+    expect(result.filesToDelete).toEqual([]);
+  });
+
+  // End-to-end repro of https://tokens-studio.slack.com report: create an empty
+  // set, push — before the fix the set's file was never written, so the set
+  // silently disappeared on the next pull.
+  it('pushes a new empty set end-to-end when fed from findDifferentState', () => {
+    const remote: CompareStateType = {
+      tokens: { global: [existingToken] },
+      themes: [],
+      metadata: { tokenSetOrder: ['global'] },
+    };
+    const local: CompareStateType = {
+      tokens: { global: [existingToken], test: [] },
+      themes: [],
+      metadata: { tokenSetOrder: ['global', 'test'] },
+    };
+    const changed = findDifferentState(remote, local);
+
+    const result = GitSyncOptimizer.optimizeSync(
+      { tokens: local.tokens, themes: local.themes, metadata: local.metadata },
+      saveOptions,
+      {
+        tokens: changed.tokens,
+        themes: changed.themes,
+        metadata: changed.metadata,
+        tokenSetChanges: changed.tokenSetChanges,
+      },
+    );
+
+    expect(result.filteredFiles.map((f) => f.path)).toEqual(['test.json', '$metadata.json']);
+  });
+
+  // End-to-end: deleting an empty set must remove its file from the repo
+  it('deletes an empty set end-to-end when fed from findDifferentState', () => {
+    const remote: CompareStateType = {
+      tokens: { global: [existingToken], test: [] },
+      themes: [],
+      metadata: { tokenSetOrder: ['global', 'test'] },
+    };
+    const local: CompareStateType = {
+      tokens: { global: [existingToken] },
+      themes: [],
+      metadata: { tokenSetOrder: ['global'] },
+    };
+    const changed = findDifferentState(remote, local);
+
+    const result = GitSyncOptimizer.optimizeSync(
+      { tokens: local.tokens, themes: local.themes, metadata: local.metadata },
+      saveOptions,
+      {
+        tokens: changed.tokens,
+        themes: changed.themes,
+        metadata: changed.metadata,
+        tokenSetChanges: changed.tokenSetChanges,
+      },
+    );
+
+    expect(result.filesToDelete).toEqual(['test.json']);
+  });
+});

--- a/packages/tokens-studio-for-figma/src/storage/__tests__/GithubTokenStorage.test.ts
+++ b/packages/tokens-studio-for-figma/src/storage/__tests__/GithubTokenStorage.test.ts
@@ -327,7 +327,7 @@ describe('GithubTokenStorage', () => {
     mockGetContent.mockClear();
   });
 
-  it('can read from Git in a multi file format and return empty array when there is no content', async () => {
+  it('preserves empty token set files in multi-file mode so user-created empty sets survive a reopen', async () => {
     mockGetContent.mockImplementation((opts: { path: string }) => {
       if (opts.path === '') {
         return Promise.resolve({
@@ -367,7 +367,14 @@ describe('GithubTokenStorage', () => {
 
     storageProvider.enableMultiFile();
     storageProvider.changePath('data');
-    expect(await storageProvider.read()).toEqual([]);
+    expect(await storageProvider.read()).toEqual([
+      {
+        path: 'data/empty.json',
+        name: 'empty',
+        type: 'tokenSet',
+        data: {},
+      },
+    ]);
 
     mockGetContent.mockClear();
   });

--- a/packages/tokens-studio-for-figma/src/utils/findDifferentState.test.ts
+++ b/packages/tokens-studio-for-figma/src/utils/findDifferentState.test.ts
@@ -98,7 +98,9 @@ describe('findDifferentState', () => {
     const result = findDifferentState(baseState, compareState);
 
     expect(result.tokens.set1).toEqual([
-      expect.objectContaining({ name: 'token1', value: '#00ff00', oldValue: '#ff0000', importType: 'UPDATE' }),
+      expect.objectContaining({
+        name: 'token1', value: '#00ff00', oldValue: '#ff0000', importType: 'UPDATE',
+      }),
     ]);
   });
 
@@ -106,8 +108,12 @@ describe('findDifferentState', () => {
     const baseState: CompareStateType = {
       tokens: {
         set1: [
-          { name: 'token1', value: 'value1', description: '', type: TokenTypes.COLOR },
-          { name: 'token2', value: 'value2', description: '', type: TokenTypes.COLOR },
+          {
+            name: 'token1', value: 'value1', description: '', type: TokenTypes.COLOR,
+          },
+          {
+            name: 'token2', value: 'value2', description: '', type: TokenTypes.COLOR,
+          },
         ],
       },
       themes: [],
@@ -115,7 +121,9 @@ describe('findDifferentState', () => {
     };
     const compareState: CompareStateType = {
       tokens: {
-        set1: [{ name: 'token1', value: 'value1', description: '', type: TokenTypes.COLOR }],
+        set1: [{
+          name: 'token1', value: 'value1', description: '', type: TokenTypes.COLOR,
+        }],
       },
       themes: [],
       metadata: null,
@@ -195,7 +203,9 @@ describe('findDifferentState', () => {
   it('detects when opacity modifier is added to a token', () => {
     const baseState: CompareStateType = {
       tokens: {
-        set1: [{ name: 'color.primary', value: '#ff0000', description: '', type: TokenTypes.COLOR }],
+        set1: [{
+          name: 'color.primary', value: '#ff0000', description: '', type: TokenTypes.COLOR,
+        }],
       },
       themes: [],
       metadata: null,
@@ -236,7 +246,9 @@ describe('findDifferentState', () => {
     };
     const compareState: CompareStateType = {
       tokens: {
-        set1: [{ name: 'color.primary', value: '#ff0000', description: '', type: TokenTypes.COLOR }],
+        set1: [{
+          name: 'color.primary', value: '#ff0000', description: '', type: TokenTypes.COLOR,
+        }],
       },
       themes: [],
       metadata: null,
@@ -246,5 +258,114 @@ describe('findDifferentState', () => {
 
     expect(result.tokens.set1).toHaveLength(1);
     expect(result.tokens.set1[0]).toMatchObject({ name: 'color.primary', importType: 'UPDATE' });
+  });
+
+  it('does not report tokenSetChanges when the same sets exist on both sides', () => {
+    const baseState: CompareStateType = {
+      tokens: {
+        set1: [{
+          name: 'token1', value: 'value1', description: '', type: TokenTypes.COLOR,
+        }],
+      },
+      themes: [],
+      metadata: null,
+    };
+    const compareState: CompareStateType = {
+      tokens: {
+        set1: [{
+          name: 'token1', value: 'value2', description: '', type: TokenTypes.COLOR,
+        }],
+      },
+      themes: [],
+      metadata: null,
+    };
+
+    const result = findDifferentState(baseState, compareState);
+
+    expect(result.tokenSetChanges).toBeUndefined();
+  });
+
+  it('marks a newly added empty token set as a NEW set-level change', () => {
+    const baseState: CompareStateType = {
+      tokens: {
+        set1: [{
+          name: 'token1', value: 'value1', description: '', type: TokenTypes.COLOR,
+        }],
+      },
+      themes: [],
+      metadata: { tokenSetOrder: ['set1'] },
+    };
+    const compareState: CompareStateType = {
+      tokens: {
+        set1: [{
+          name: 'token1', value: 'value1', description: '', type: TokenTypes.COLOR,
+        }],
+        emptySet: [],
+      },
+      themes: [],
+      metadata: { tokenSetOrder: ['set1', 'emptySet'] },
+    };
+
+    const result = findDifferentState(baseState, compareState);
+
+    expect(result.tokenSetChanges).toEqual({ emptySet: 'NEW' });
+    // no token-level changes exist for an empty set
+    expect(result.tokens.emptySet).toBeUndefined();
+  });
+
+  it('marks a removed empty token set as a REMOVE set-level change', () => {
+    const baseState: CompareStateType = {
+      tokens: {
+        set1: [{
+          name: 'token1', value: 'value1', description: '', type: TokenTypes.COLOR,
+        }],
+        emptySet: [],
+      },
+      themes: [],
+      metadata: { tokenSetOrder: ['set1', 'emptySet'] },
+    };
+    const compareState: CompareStateType = {
+      tokens: {
+        set1: [{
+          name: 'token1', value: 'value1', description: '', type: TokenTypes.COLOR,
+        }],
+      },
+      themes: [],
+      metadata: { tokenSetOrder: ['set1'] },
+    };
+
+    const result = findDifferentState(baseState, compareState);
+
+    expect(result.tokenSetChanges).toEqual({ emptySet: 'REMOVE' });
+  });
+
+  it('does NOT add non-empty sets to tokenSetChanges — their token entries are sufficient', () => {
+    // Non-empty added/removed sets already produce token-level NEW/REMOVE entries
+    // visible to the GitSyncOptimizer; tokenSetChanges is reserved for empty sets only.
+    const baseState: CompareStateType = {
+      tokens: {
+        oldSet: [{
+          name: 'token1', value: 'value1', description: '', type: TokenTypes.COLOR,
+        }],
+      },
+      themes: [],
+      metadata: null,
+    };
+    const compareState: CompareStateType = {
+      tokens: {
+        newSet: [{
+          name: 'token2', value: 'value2', description: '', type: TokenTypes.COLOR,
+        }],
+      },
+      themes: [],
+      metadata: null,
+    };
+
+    const result = findDifferentState(baseState, compareState);
+
+    // tokenSetChanges should be undefined — non-empty sets are already visible via token entries
+    expect(result.tokenSetChanges).toBeUndefined();
+    expect(result.tokens.newSet).toEqual([expect.objectContaining({ name: 'token2', importType: 'NEW' })]);
+    expect(result.tokens.oldSet).toEqual([expect.objectContaining({ name: 'token1', importType: 'REMOVE' })]);
   });
 });

--- a/packages/tokens-studio-for-figma/src/utils/findDifferentState.ts
+++ b/packages/tokens-studio-for-figma/src/utils/findDifferentState.ts
@@ -3,10 +3,16 @@ import { isEqual } from './isEqual';
 import { ThemeObject } from '@/types';
 import { RemoteTokenStorageMetadata } from '@/storage/RemoteTokenStorage';
 
+export type TokenSetChangeType = 'NEW' | 'REMOVE';
+
 export type CompareStateType<Metadata = null> = {
   tokens: Record<string, ImportToken[]>
   themes: ImportTheme[]
   metadata?: RemoteTokenStorageMetadata | Metadata
+  // Set-level additions/removals. Token-level diffs can't represent an empty
+  // set being added or removed (its token list is empty either way), so those
+  // changes are tracked here. Undefined when there are none.
+  tokenSetChanges?: Record<string, TokenSetChangeType>
 };
 
 export type ImportTheme = ThemeObject & {
@@ -15,7 +21,13 @@ export type ImportTheme = ThemeObject & {
 
 export function findDifferentState(baseState: CompareStateType, compareState: CompareStateType): CompareStateType {
   const entries: [string, ImportToken[]][] = [];
+  const tokenSetChanges: Record<string, TokenSetChangeType> = {};
   Object.entries(compareState.tokens)?.forEach(([tokenSet, values]) => {
+    // Only track empty new sets in tokenSetChanges — non-empty sets produce
+    // NEW token entries that are already visible to the GitSyncOptimizer.
+    if (typeof baseState.tokens[tokenSet] === 'undefined' && values.length === 0) {
+      tokenSetChanges[tokenSet] = 'NEW';
+    }
     const newTokens: ImportToken[] = [];
     const updatedTokens: ImportToken[] = [];
     const removedTokens: ImportToken[] = [];
@@ -57,6 +69,11 @@ export function findDifferentState(baseState: CompareStateType, compareState: Co
   Object.entries(baseState.tokens).forEach(([tokenSet, values]) => {
     const isTokenSetRemoved = typeof compareState.tokens[tokenSet] === 'undefined';
     if (isTokenSetRemoved) {
+      // Only track empty removed sets in tokenSetChanges — non-empty sets produce
+      // REMOVE token entries that are already visible to the GitSyncOptimizer.
+      if (values.length === 0) {
+        tokenSetChanges[tokenSet] = 'REMOVE';
+      }
       entries.push([tokenSet, values.map((token) => ({ ...token, importType: 'REMOVE' }))]);
     }
   });
@@ -86,5 +103,6 @@ export function findDifferentState(baseState: CompareStateType, compareState: Co
     tokens: Object.fromEntries(entries.filter(([_, tokens]) => tokens.length > 0)),
     themes: [...newThemes, ...changedThemes, ...removedThemes],
     metadata: !isEqual(baseState.metadata, compareState.metadata) ? compareState.metadata : null,
+    tokenSetChanges: Object.keys(tokenSetChanges).length > 0 ? tokenSetChanges : undefined,
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -54,46 +54,6 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@apollo/client@^3.11.4":
-  version "3.11.10"
-  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.11.10.tgz#e16ae82ea9b16536ffd109847d24f9293fab5c4d"
-  integrity sha512-IfGc+X4il0rDqVQBBWdxIKM+ciDCiDzBq9+Bg9z4tJMi87uF6po4v+ddiac1wP0ARgVPsFwEIGxK7jhN4pW8jg==
-  dependencies:
-    "@graphql-typed-document-node/core" "^3.1.1"
-    "@wry/caches" "^1.0.0"
-    "@wry/equality" "^0.5.6"
-    "@wry/trie" "^0.5.0"
-    graphql-tag "^2.12.6"
-    hoist-non-react-statics "^3.3.2"
-    optimism "^0.18.0"
-    prop-types "^15.7.2"
-    rehackt "^0.1.0"
-    response-iterator "^0.2.6"
-    symbol-observable "^4.0.0"
-    ts-invariant "^0.10.3"
-    tslib "^2.3.0"
-    zen-observable-ts "^1.2.5"
-
-"@apollo/client@^3.12.2":
-  version "3.12.2"
-  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.12.2.tgz#28cf4a0c07c42ace566dc17e2647ff011424ece8"
-  integrity sha512-dkacsdMgVsrrQhLpN4JqZTIEfnNsPVwny+4vccSRqheWZElzUz1Xi0h39p2+TieS1f+wwvyzwpoJEV57vwzT9Q==
-  dependencies:
-    "@graphql-typed-document-node/core" "^3.1.1"
-    "@wry/caches" "^1.0.0"
-    "@wry/equality" "^0.5.6"
-    "@wry/trie" "^0.5.0"
-    graphql-tag "^2.12.6"
-    hoist-non-react-statics "^3.3.2"
-    optimism "^0.18.0"
-    prop-types "^15.7.2"
-    rehackt "^0.1.0"
-    response-iterator "^0.2.6"
-    symbol-observable "^4.0.0"
-    ts-invariant "^0.10.3"
-    tslib "^2.3.0"
-    zen-observable-ts "^1.2.5"
-
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.7", "@babel/code-frame@^7.22.13", "@babel/code-frame@^7.5.5", "@babel/code-frame@^7.8.3":
   version "7.22.13"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz"
@@ -2562,11 +2522,6 @@
   dependencies:
     "@gitbeaker/core" "^39.24.0"
     "@gitbeaker/requester-utils" "^39.24.0"
-
-"@graphql-typed-document-node/core@^3.1.1":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.2.0.tgz#5f3d96ec6b2354ad6d8a28bf216a1d97b5426861"
-  integrity sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==
 
 "@humanwhocodes/config-array@^0.11.11":
   version "0.11.11"
@@ -5757,18 +5712,6 @@
     semver-compare "^1.0.0"
     token-transformer "^0.0.33"
 
-"@tokens-studio/sdk@^1.4.2":
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/@tokens-studio/sdk/-/sdk-1.4.2.tgz#f246ba9d09e07468d6591b81d21b82e6163f65ce"
-  integrity sha512-wyWtpaXAxofGWExujZKOgZThUGV8oz1WSbonToNqdWKIKc5mYkDmFUIyT0mqWPx09JSwCOMNK3d87Y33hqq2Cw==
-  dependencies:
-    "@apollo/client" "^3.11.4"
-    "@tokens-studio/types" "^0.5.2"
-    commander "^12.1.0"
-    graphql-tag "^2.12.6"
-    graphql-ws "^5.16.0"
-    ws "^8.18.0"
-
 "@tokens-studio/tokens@0.2.5":
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/@tokens-studio/tokens/-/tokens-0.2.5.tgz#a42559da95cc0434bb2915b8410463a0c2b3749a"
@@ -5785,11 +5728,6 @@
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/@tokens-studio/types/-/types-0.2.5.tgz#fbddad1d0040f1316ee74dbd42a389f2f3d2fcbc"
   integrity sha512-pJ0zWxGnEjca4dznFIHC9/oXuovu3DKHUhLDNJVzTRZEVXhWkIRIUbjDwIRihxBr39c776W+3thYvWMgChT0Rw==
-
-"@tokens-studio/types@^0.5.2":
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/@tokens-studio/types/-/types-0.5.2.tgz#cac9bce7a27dda7254664d7acab7b088e2aefe33"
-  integrity sha512-rzMcZP0bj2E5jaa7Fj0LGgYHysoCrbrxILVbT0ohsCUH5uCHY/u6J7Qw/TE0n6gR9Js/c9ZO9T8mOoz0HdLMbA==
 
 "@tokens-studio/ui@0.9.0":
   version "0.9.0"
@@ -7121,41 +7059,6 @@
   integrity sha512-FQgi90jvC9uw2aALlonJfqaWOvU5UUBBVvdAnS2iryXwCc4YJkKsPJY5Y/LzaND3OIyk8XGUn1vTRn6hcem28Q==
   dependencies:
     lodash "^4"
-
-"@wry/caches@^1.0.0":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@wry/caches/-/caches-1.0.1.tgz#8641fd3b6e09230b86ce8b93558d44cf1ece7e52"
-  integrity sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==
-  dependencies:
-    tslib "^2.3.0"
-
-"@wry/context@^0.7.0":
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.7.4.tgz#e32d750fa075955c4ab2cfb8c48095e1d42d5990"
-  integrity sha512-jmT7Sb4ZQWI5iyu3lobQxICu2nC/vbUhP0vIdd6tHC9PTfenmRmuIFqktc6GH9cgi+ZHnsLWPvfSvc4DrYmKiQ==
-  dependencies:
-    tslib "^2.3.0"
-
-"@wry/equality@^0.5.6":
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.5.7.tgz#72ec1a73760943d439d56b7b1e9985aec5d497bb"
-  integrity sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==
-  dependencies:
-    tslib "^2.3.0"
-
-"@wry/trie@^0.4.3":
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/@wry/trie/-/trie-0.4.3.tgz#077d52c22365871bf3ffcbab8e95cb8bc5689af4"
-  integrity sha512-I6bHwH0fSf6RqQcnnXLJKhkSXG45MFral3GxPaY4uAl0LYDZM+YDVDAiU9bYwjTuysy1S0IeecWtmq1SZA3M1w==
-  dependencies:
-    tslib "^2.3.0"
-
-"@wry/trie@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@wry/trie/-/trie-0.5.0.tgz#11e783f3a53f6e4cd1d42d2d1323f5bc3fa99c94"
-  integrity sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==
-  dependencies:
-    tslib "^2.3.0"
 
 "@xmldom/xmldom@^0.8.3":
   version "0.8.10"
@@ -9400,11 +9303,6 @@ comma-separated-tokens@^1.0.0:
   version "1.0.8"
   resolved "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz"
   integrity sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==
-
-commander@^12.1.0:
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-12.1.0.tgz#01423b36f501259fdaac4d0e4d60c96c991585d3"
-  integrity sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==
 
 commander@^2.12.1, commander@^2.19.0, commander@^2.20.0:
   version "2.20.3"
@@ -13248,18 +13146,6 @@ graphemer@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
-
-graphql-tag@^2.12.6:
-  version "2.12.6"
-  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.6.tgz#d441a569c1d2537ef10ca3d1633b48725329b5f1"
-  integrity sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==
-  dependencies:
-    tslib "^2.1.0"
-
-graphql-ws@^5.16.0:
-  version "5.16.0"
-  resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.16.0.tgz#849efe02f384b4332109329be01d74c345842729"
-  integrity sha512-Ju2RCU2dQMgSKtArPbEtsK5gNLnsQyTNIo/T7cZNp96niC1x0KdJNZV0TIoilceBPQwfb5itrGl8pkFeOUMl4A==
 
 graphql@^16.8.1:
   version "16.8.1"
@@ -17302,16 +17188,6 @@ opn@^5.4.0, opn@^5.5.0:
   dependencies:
     is-wsl "^1.1.0"
 
-optimism@^0.18.0:
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.18.0.tgz#e7bb38b24715f3fdad8a9a7fc18e999144bbfa63"
-  integrity sha512-tGn8+REwLRNFnb9WmcY5IfpOqeX2kpaYJ1s6Ae3mn12AeydLkR3j+jSCmVQFoXqU8D41PAJ1RG1rCRNWmNZVmQ==
-  dependencies:
-    "@wry/caches" "^1.0.0"
-    "@wry/context" "^0.7.0"
-    "@wry/trie" "^0.4.3"
-    tslib "^2.3.0"
-
 optionator@^0.9.3:
   version "0.9.3"
   resolved "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz"
@@ -19137,11 +19013,6 @@ regjsparser@^0.9.1:
   dependencies:
     jsesc "~0.5.0"
 
-rehackt@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/rehackt/-/rehackt-0.1.0.tgz#a7c5e289c87345f70da8728a7eb878e5d03c696b"
-  integrity sha512-7kRDOuLHB87D/JESKxQoRwv4DzbIdwkAGQ7p6QKGdVlY1IZheUnVhlk/4UZlNUVxdAXpyxikE3URsG067ybVzw==
-
 relateurl@^0.2.7:
   version "0.2.7"
   resolved "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz"
@@ -19391,11 +19262,6 @@ resolve@^2.0.0-next.4:
     is-core-module "^2.13.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
-
-response-iterator@^0.2.6:
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/response-iterator/-/response-iterator-0.2.6.tgz#249005fb14d2e4eeb478a3f735a28fd8b4c9f3da"
-  integrity sha512-pVzEEzrsg23Sh053rmDUvLSkGXluZio0qu8VT6ukrYuvtjVfCbDZH9d6PGXb8HZfzdNZt8feXv/jvUzlhRgLnw==
 
 responselike@^2.0.0:
   version "2.0.1"
@@ -20893,11 +20759,6 @@ symbol-observable@^1.1.0:
   resolved "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
-symbol-observable@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-4.0.0.tgz#5b425f192279e87f2f9b937ac8540d1984b39205"
-  integrity sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==
-
 symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz"
@@ -21310,13 +21171,6 @@ ts-dedent@^2.0.0, ts-dedent@^2.2.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz"
   integrity sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==
-
-ts-invariant@^0.10.3:
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.10.3.tgz#3e048ff96e91459ffca01304dbc7f61c1f642f6c"
-  integrity sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==
-  dependencies:
-    tslib "^2.1.0"
 
 ts-jest@^29.1.1:
   version "29.1.1"
@@ -22795,11 +22649,6 @@ ws@^8.11.0, ws@^8.2.3:
   resolved "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz"
   integrity sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==
 
-ws@^8.18.0:
-  version "8.18.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
-  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
-
 x-default-browser@^0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/x-default-browser/-/x-default-browser-0.4.0.tgz"
@@ -22969,18 +22818,6 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
-
-zen-observable-ts@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz#6c6d9ea3d3a842812c6e9519209365a122ba8b58"
-  integrity sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==
-  dependencies:
-    zen-observable "0.8.15"
-
-zen-observable@0.8.15:
-  version "0.8.15"
-  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
-  integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==
 
 zod@^3.22.3:
   version "3.22.4"


### PR DESCRIPTION
Push snapshot stored tokens with generated $extensions.studio.tokens.id UUIDs, but compareLastSyncedState strips them before comparing, so hasChanges was always true after a push. Metadata diff also included tokenSetsData, which git providers never persist, producing empty commits when only that phantom diff existed.

### Why does this PR exist?

Closes #0000 <!-- link the related issue -->

When pushing to any git sync provider (GitHub, GitLab, Azure DevOps, Bitbucket), two related bugs made sync feel broken:

1. **The "unsynced changes" blue dot never cleared after a successful push.** A pull cleared it correctly, but a push did not.
2. **GitHub often received an empty commit** — the commit message showed up in the repo history, but the tree diff was empty, so the user's actual edit never appeared to land.

Both symptoms trace back to the same root cause: local tokens carry synthetic UUIDs under `$extensions['studio.tokens'].id` (assigned by `addIdPropertyToTokens`), but the serialized/compared forms of those tokens strip those IDs. The push-side bookkeeping wasn't accounting for that, so state that should have looked "in sync" always looked "different."

### What does this pull request do?

**1. Fix the stuck blue dot** (`github.tsx`, `gitlab.tsx`, `ado.tsx`, `bitbucket.tsx`)

After a successful push, each provider stored `lastSyncedState` as `JSON.stringify([tokens, themes, format])`, with tokens still carrying their runtime IDs. But `compareLastSyncedState` computes the current-state string with `removeIdPropertyFromTokens(tokens)`. The two could never be equal → `hasChanges` stayed `true` → the blue dot never cleared.

Fix: wrap `tokens` with `removeIdPropertyFromTokens(...)` when building the snapshot, so the snapshot matches what the comparator produces. The pull paths already used `content.tokens` (which are ID-free coming off the wire), so they were fine — only the push paths needed the change.

**2. Fix the empty-commit-on-GitHub case** (`useChangedState.ts`)

`useChangedState` built the metadata used for diffing as `{ tokenSetOrder, tokenSetsData: tokenSetMetadata }`. But git providers only ever persist `{ tokenSetOrder }` in `$metadata.json` — `tokenSetsData` is a Tokens Studio OAuth concept. That shape mismatch guaranteed a permanent metadata diff for git providers, which flipped `hasChanges` on inside `pushTokensToGitHub`, which sent the metadata file through `GitSyncOptimizer`. The uploaded metadata file was byte-identical to the remote one → GitHub created a commit with no tree changes.

Fix: only include `tokenSetsData` in the diff shape when the provider is `TOKENS_STUDIO_OAUTH`. Git providers now compare against `{ tokenSetOrder }`, matching what they actually write.

Files touched:
- `src/app/store/providers/github/github.tsx`
- `src/app/store/providers/gitlab/gitlab.tsx`
- `src/app/store/providers/ado/ado.tsx`
- `src/app/store/providers/bitbucket/bitbucket.tsx`
- `src/hooks/useChangedState.ts`

### Testing this change

**Blue-dot regression (reproduces before, fixed after):**

1. Configure a GitHub (or GitLab / ADO / Bitbucket) sync provider pointing at a repo folder.
2. Pull tokens.
3. Make any token change (edit a value, add a token).
4. Push.
5. **Before this PR:** the blue "unsynced" dot next to the branch stays on even after the "Pushed to GitHub" toast.
6. **After this PR:** the dot clears immediately after the successful push.

**Empty-commit regression (reproduces before, fixed after):**

1. Configure a GitHub sync provider with multi-file mode (pro user, folder path, not a `.json` file).
2. Pull tokens.
3. Without editing anything, push (or make a change that only affects `$extensions`).
4. **Before this PR:** GitHub shows a new commit whose diff view is empty.
5. **After this PR:** if there are no real changes, no commit is sent; if there are real changes, only the changed files appear in the commit diff.

**Automated:**
- `yarn jest src/hooks/__tests__/useChangedState.test.ts` — passes
- `yarn jest src/app/store/providers` — 27/27 passing

### Additional Notes (if any)

- The four provider files all had literally the same buggy line; the fix is the same one-line change in each. Kept them as separate edits (rather than extracting a shared helper) to keep the diff minimal and low-risk.
- `TOKENS_STUDIO_OAUTH` behavior is preserved: it still gets the full `{ tokenSetOrder, tokenSetsData }` metadata shape it depends on for token-set ID tracking.
- No changes to the wire format or on-disk file layout — this is purely a fix to local state bookkeeping.