### PR TITLE
fix: preserve resolved change set id on branch switch

### DIFF
--- a/.changeset/eighty-spiders-crash.md
+++ b/.changeset/eighty-spiders-crash.md
@@ -1,0 +1,5 @@
+---
+"@tokens-studio/figma-plugin": patch
+---
+
+Fixed a bug where switching branches in the Studio provider could apply token edits to the previously selected branch instead of the one shown in the plugin.

--- a/packages/tokens-studio-for-figma/src/app/components/BranchSelector.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/BranchSelector.tsx
@@ -138,6 +138,13 @@ export default function BranchSelector() {
           // one. The stale `apiData` closure still holds the old branch's changeSetId,
           // so we must not spread it back over the freshly resolved value.
           const changeSetId = remoteData?.status === 'success' ? remoteData.metadata?.changeSetId : undefined;
+          if (isTokensStudioProvider && !changeSetId) {
+            // We couldn't resolve the new branch's change set (e.g. the pull failed).
+            // Don't switch the branch context: doing so would leave writes scoped to the
+            // previous branch's changeSetId (or, if cleared, to the server default) — either
+            // way silently targeting the wrong branch. pullTokens has already surfaced the error.
+            return;
+          }
           const nextApiData = { ...apiData, branch, ...(changeSetId ? { changeSetId } : {}) } as StorageTypeCredentials;
           // Now update UI state to show the new branch with already-loaded tokens
           setCurrentBranch(branch);

--- a/packages/tokens-studio-for-figma/src/app/components/BranchSelector.tsx
+++ b/packages/tokens-studio-for-figma/src/app/components/BranchSelector.tsx
@@ -129,18 +129,25 @@ export default function BranchSelector() {
           // Clear local token state BEFORE pulling to prevent bleed
           dispatch.tokenState.setEmptyTokens();
           // Pull tokens from new branch BEFORE switching UI state
-          await pullTokens({
+          const remoteData = await pullTokens({
             context: { ...apiData, branch }, usedTokenSet, activeTheme, updateLocalTokens: true, skipConfirmation: true,
           });
+          // For Tokens Studio, the branch is identified by its changeSetId, which
+          // pullTokens resolves for the newly selected branch. Carry it forward so
+          // subsequent edits (e.g. deletes) target this branch and not the previous
+          // one. The stale `apiData` closure still holds the old branch's changeSetId,
+          // so we must not spread it back over the freshly resolved value.
+          const changeSetId = remoteData?.status === 'success' ? remoteData.metadata?.changeSetId : undefined;
+          const nextApiData = { ...apiData, branch, ...(changeSetId ? { changeSetId } : {}) } as StorageTypeCredentials;
           // Now update UI state to show the new branch with already-loaded tokens
           setCurrentBranch(branch);
-          dispatch.uiState.setApiData({ ...apiData, branch });
+          dispatch.uiState.setApiData(nextApiData);
           dispatch.uiState.setLocalApiState({ ...localApiState, branch });
           AsyncMessageChannel.ReactInstance.message({
             type: AsyncMessageTypes.CREDENTIALS,
-            credential: { ...apiData, branch },
+            credential: nextApiData,
           });
-          setStorageType({ provider: { ...apiData, branch } as StorageTypeCredentials, shouldSetInDocument: true });
+          setStorageType({ provider: nextApiData, shouldSetInDocument: true });
         } finally {
           setIsSwitchingBranch(false);
         }


### PR DESCRIPTION
<!--
  Notes for authors:
  - Provide context with minimal words, keep it concise
  - Mark as a draft for work in progress PRs
  - Once ready for review, notify others in #code-reviews
  - Remember, the review process is a learning opportunity for both reviewers and authors, it's a way for us to share knowledge and avoid silos.
-->

### Why does this PR exist?

Closes #0000 <!-- link the related issue -->

On the Studio (Tokens Studio platform) provider, switching to another branch and then editing a token applied the change to the **previously selected branch** instead of the one shown in the plugin. e.g. with `truncation-test` selected, deleting a token deleted it from `main`. Because Studio scopes every write by the branch's `changeSetId`, a destructive edit silently landed on the wrong branch.

### What does this pull request do?

Fixes the branch context that gets persisted after a branch switch.

In `BranchSelector.changeAndPull`, `pullTokens` correctly resolves and stores the new branch's `changeSetId` on `uiState.api`. But the next line overwrote `uiState.api` with `{ ...apiData, branch }`, where `apiData` is the stale pre-switch snapshot still holding the old branch's `changeSetId` — and `setApiData` replaces the object wholesale, so the freshly resolved id was clobbered. Studio's REST delete scopes only by `change_set_id`, so edits went to the old branch.

The fix captures the `pullTokens` result, reads the freshly resolved `changeSetId`, and carries it into the `setApiData` call as well as the persisted credential writes (so a reload does not reintroduce the stale id). It's a no-op for git providers, whose `metadata.changeSetId` is undefined.

### Testing this change

1. Connect the Studio (Tokens Studio) platform provider to a project with at least two branches (e.g. `main` and `truncation-test`).
2. In the plugin, switch to `truncation-test` (confirm the branch indicator at the bottom shows it).
3. Delete a token.
4. In Studio web, verify the token is deleted from `truncation-test` only and `main` is untouched.

Before this change the delete landed on `main`; after it, it lands on the selected branch.

### Additional Notes (if any)

- The sibling path `onCreateBranchModalSuccess` has the same shape but is currently unreachable for the Studio provider — `CreateBranchModal`'s submit is git-gated and never calls `onSuccess` for Studio (Studio branches are created web-side), so no change was needed there.
- `deleteTokenRest` (and its siblings) accept a `branch` string param that is never applied to the request; only `change_set_id` scopes the call. Left as-is to keep this fix focused, but worth a follow-up cleanup.